### PR TITLE
DOC-001: AVIF ICC非対応の警告強化

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,16 +458,27 @@ const result = await ImageEngine.fromPath('huge-image.tiff')
 
 ### Color Management
 
-ICC color profiles are automatically:
-- **Extracted** from input images (JPEG, PNG, WebP)
-- **Preserved** through the processing pipeline
-- **Embedded** in output images
+ICC color profiles are automatically extracted and embedded during processing.
 
-This ensures photos from iPhones (P3 color space) or professional cameras (Adobe RGB) maintain their intended colors.
+| Format | ICC Profile Support | Notes |
+|--------|---------------------|-------|
+| JPEG   | ✅ Full support | Extracted and embedded |
+| PNG    | ✅ Full support | Via iCCP chunk |
+| WebP   | ✅ Full support | Via ICCP chunk |
+| AVIF   | ⚠️ **Not supported** | **See warning below** |
 
-
-> **Note**: AVIF format does not currently preserve ICC profiles (ravif limitation).
-> AVIF output assumes sRGB color space. Use JPEG or PNG for color-critical workflows.
+> ⚠️ **Important: AVIF Color Space Limitation**
+> 
+> **AVIF format does NOT preserve ICC color profiles** due to a limitation in the ravif encoder.
+> 
+> **Impact:**
+> - Images with Display P3, Adobe RGB, or other wide-gamut profiles will be converted to sRGB
+> - Color accuracy may be affected for professional photography workflows
+> 
+> **Recommendation:**
+> - Use **JPEG or WebP** for color-critical applications
+> - AVIF is safe for images already in sRGB color space
+> - For maximum compatibility, convert to sRGB before AVIF encoding
 ### Supported Platforms
 
 | Platform | Architecture | Status |


### PR DESCRIPTION
## 概要

READMEにAVIF ICC制限を目立つ形で記載しました。

## 変更内容

- Color Managementセクションにフォーマット比較表を追加
- AVIF ICC制限を目立つ警告として記載
- 色管理重視ユーザーへの影響と推奨事項を明記

## 課題

現在のREADMEでは「Note」として小さく記載されているのみで、色管理重視ユーザーがAVIFを使って色がおかしくなる可能性がありました。

## 達成条件

- ✅ READMEの目立つ位置にAVIF ICC制限が記載されている
- ✅ フォーマット比較表にICC対応状況が追加されている

## 関連タスク

DOC-001