### PR TITLE
chore: add author and bugs to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,11 @@
     "napi",
     "optimization"
   ],
-  "author": "",
+  "author": "albert-einshutoin",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/albert-einshutoin/lazy-image/issues"
+  },
   "scripts": {
     "build": "napi build --platform --release",
     "test": "node test/basic.test.js && node test/edge-cases.test.js",


### PR DESCRIPTION
## Summary

Add missing npm package metadata for better OSS visibility.

## Changes

- Set `author` field to `albert-einshutoin`
- Add `bugs` URL pointing to GitHub issues

## Why

npm best practices recommend including:
- Author information for attribution
- Bugs URL so users can easily report issues

This improves the package's discoverability and professionalism on npm.

## Related

Part of OSS best practices preparation for v1.0 release.