### PR TITLE
docs: add Limitations section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,24 @@ AVIF vs sharp AVIF: -46.2% smaller (and 1.08x faster!)
 
 ---
 
+## ⚠️ Limitations
+
+Before choosing lazy-image, please understand these limitations:
+
+| Limitation | Details |
+|------------|---------|
+| **16-bit images** | Converted to 8-bit during processing (by design for web optimization) |
+| **AVIF ICC profiles** | Not preserved (ravif encoder limitation) - use JPEG/WebP for color-critical work |
+| **Rotation angles** | Only 90°, 180°, 270° supported (no arbitrary angles) |
+| **No filters** | No blur, sharpen, or artistic effects (out of scope) |
+| **No animation** | GIF/APNG animation not supported |
+| **Processing speed** | Slower than sharp for JPEG/WebP (prioritizes compression over speed) |
+
+> **Note**: These limitations are intentional - lazy-image focuses on **file size optimization**, not feature completeness.
+> See [docs/ROADMAP.md](./docs/ROADMAP.md) for the full project scope.
+
+---
+
 ## 📦 Installation
 
 ```bash


### PR DESCRIPTION
- Document 16-bit image conversion to 8-bit
- Note AVIF ICC profile limitation
- Clarify rotation angle restrictions
- List out-of-scope features (filters, animation)
- Mention speed vs compression trade-off
- Link to ROADMAP for full project scope

Users can now make informed decisions before adopting lazy-image.