### PR TITLE
ci: CI/CD不要ファイルの変更時にワークフローをスキップするように設定

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,27 @@ on:
       - main
     tags:
       - 'v*'
+    paths-ignore:
+      - '*.md'
+      - 'LICENSE'
+      - 'SECURITY.md'
+      - 'CHANGELOG.md'
+      - 'README.md'
+      - 'docs/**'
+      - 'OSS_*.md'
+      - 'TEST_*.md'
+      - 'SHARP_COMPARISON.md'
   pull_request:
+    paths-ignore:
+      - '*.md'
+      - 'LICENSE'
+      - 'SECURITY.md'
+      - 'CHANGELOG.md'
+      - 'README.md'
+      - 'docs/**'
+      - 'OSS_*.md'
+      - 'TEST_*.md'
+      - 'SHARP_COMPARISON.md'
   workflow_dispatch:  # Allow manual trigger
 
 jobs:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,7 +4,27 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '*.md'
+      - 'LICENSE'
+      - 'SECURITY.md'
+      - 'CHANGELOG.md'
+      - 'README.md'
+      - 'docs/**'
+      - 'OSS_*.md'
+      - 'TEST_*.md'
+      - 'SHARP_COMPARISON.md'
   pull_request:
+    paths-ignore:
+      - '*.md'
+      - 'LICENSE'
+      - 'SECURITY.md'
+      - 'CHANGELOG.md'
+      - 'README.md'
+      - 'docs/**'
+      - 'OSS_*.md'
+      - 'TEST_*.md'
+      - 'SHARP_COMPARISON.md'
   schedule:
     - cron: '0 0 * * 0'  # 毎週日曜0時
   workflow_dispatch:


### PR DESCRIPTION
## 概要
CI/CDに関連しないファイル（ドキュメント、LICENSEなど）の変更時にCI/CDワークフローが実行されないようにを追加しました。

## 変更内容
- `.github/workflows/CI.yml`に`paths-ignore`を追加
- `.github/workflows/security.yml`に`paths-ignore`を追加

## 除外されるファイル
- `*.md`（ドキュメントファイル）
- `LICENSE`
- `SECURITY.md`
- `CHANGELOG.md`
- `README.md`
- `docs/**`
- `OSS_*.md`
- `TEST_*.md`
- `SHARP_COMPARISON.md`

## 効果
- ドキュメントのみの変更時にCI/CDがスキップされ、MRからデプロイまでの時間を短縮
- CI/CDリソースの無駄を削減