### PR TITLE
docs: add GitHub Issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,49 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+title: '[Bug] '
+labels: bug
+assignees: ''
+---
+
+## Bug Description
+A clear and concise description of the bug.
+
+## Steps to Reproduce
+1. 
+2. 
+3. 
+
+## Expected Behavior
+What you expected to happen.
+
+## Actual Behavior
+What actually happened.
+
+## Environment
+- **OS**: (e.g., macOS 14.0, Ubuntu 22.04, Windows 11)
+- **Node.js version**: (e.g., 18.17.0)
+- **lazy-image version**: (e.g., 0.7.8)
+
+## Code Example
+```javascript
+// Minimal code to reproduce the issue
+const { ImageEngine } = require('@alberteinshutoin/lazy-image');
+// ...
+```
+
+## Error Message
+```
+Paste any error messages here
+```
+
+## Additional Context
+- Input image format:
+- Output format:
+- Any other relevant information
+
+## Checklist
+- [ ] I have searched existing issues to ensure this is not a duplicate
+- [ ] I have tested with the latest version
+- [ ] I have included a minimal reproducible example
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,45 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+title: '[Feature] '
+labels: enhancement
+assignees: ''
+---
+
+## Feature Description
+A clear and concise description of the feature you'd like to see.
+
+## Problem Statement
+Describe the problem this feature would solve.
+
+**Example**: I'm always frustrated when [...]
+
+## Proposed Solution
+Describe the solution you'd like.
+
+## API Design (if applicable)
+```javascript
+// How you envision the API would look
+const engine = ImageEngine.fromPath('input.jpg')
+  .newMethod()
+  .toFile('output.webp');
+```
+
+## Alternatives Considered
+Describe any alternative solutions or features you've considered.
+
+## Use Cases
+1. 
+2. 
+3. 
+
+## Additional Context
+- Reference to similar features in other libraries (e.g., sharp, jimp)
+- Links to relevant documentation or specifications
+- Mockups or examples
+
+## Checklist
+- [ ] I have searched existing issues/PRs to ensure this is not a duplicate
+- [ ] I have considered the impact on existing functionality
+- [ ] I am willing to contribute to implementing this feature
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,51 @@
+## Description
+Brief description of what this PR does.
+
+## Related Issue
+Fixes #(issue number)
+
+## Type of Change
+- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
+- [ ] ✨ New feature (non-breaking change that adds functionality)
+- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] 📝 Documentation update
+- [ ] 🔧 Refactoring (no functional changes)
+- [ ] 🧪 Tests (adding or updating tests)
+- [ ] 🔨 Build/CI (changes to build process or CI/CD)
+
+## Changes Made
+- 
+- 
+- 
+
+## Testing
+Describe the tests that you ran to verify your changes.
+
+```bash
+# Commands used to test
+npm test
+cargo test
+```
+
+## Screenshots (if applicable)
+<!-- Add screenshots for UI changes or visual comparisons -->
+
+## Checklist
+- [ ] My code follows the project's style guidelines
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published
+
+## Performance Impact
+<!-- If applicable, describe any performance implications -->
+- [ ] No performance impact
+- [ ] Performance improved
+- [ ] Performance may be affected (explain below)
+
+## Additional Notes
+<!-- Any additional information that reviewers should know -->
+


### PR DESCRIPTION
## Description
GitHub Issue/PR テンプレートを追加しました。

## Related Issue
Closes #39

## Type of Change
- [x] 📝 Documentation update

## Changes Made
- bug_report.md テンプレート追加（構造化されたセクション付き）
- feature_request.md テンプレート追加（API設計セクション付き）
- PULL_REQUEST_TEMPLATE.md 追加（チェックリスト付き）

## Testing
ドキュメントのみの変更のため、テストは不要です。

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings