### PR TITLE
docs: add email contact to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -125,6 +125,7 @@ We monitor security advisories for all dependencies and update promptly when vul
 ## Contact
 
 For security-related inquiries:
-- GitHub Security Advisories: [Report a vulnerability](https://github.com/albert-einshutoin/lazy-image/security/advisories/new)
+- **Email**: einstein.4s.1110@gmail.com (preferred for sensitive reports)
+- **GitHub Security Advisories**: [Report a vulnerability](https://github.com/albert-einshutoin/lazy-image/security/advisories/new)
 
 Thank you for helping keep lazy-image secure! 🔒


### PR DESCRIPTION
## Description
SECURITY.md にセキュリティ報告用のメールアドレスを追加しました。

## Related Issue
Closes #44

## Type of Change
- [x] 📝 Documentation update

## Changes Made
- メンテナーのメールアドレス (einstein.4s.1110@gmail.com) を追加
- 機密性の高いセキュリティ報告にはメールを推奨

## Before
```markdown
## Contact

For security-related inquiries:
- GitHub Security Advisories: [Report a vulnerability](...)
```

## After
```markdown
## Contact

For security-related inquiries:
- **Email**: einstein.4s.1110@gmail.com (preferred for sensitive reports)
- **GitHub Security Advisories**: [Report a vulnerability](...)
```

## Testing
ドキュメントのみの変更のため、テストは不要です。

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings