### PR TITLE
chore: toColorspace() deprecation 警告を強化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Deprecated
+- `toColorspace()` method: Strengthened deprecation warning. **Will be removed in v1.0**. This method only ensures RGB/RGBA format, not true color space conversion.
+
 ### Added
 - This CHANGELOG file to track project changes
 

--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ const buffer = await engine.toBuffer(preset.format, preset.quality);
 | `.grayscale()` | Convert to grayscale |
 | `.brightness(value)` | Adjust brightness (-100 to 100) |
 | `.contrast(value)` | Adjust contrast (-100 to 100) |
-| `.toColorspace(space)` | Convert to color space (`'srgb'`) |
+| `.toColorspace(space)` | ⚠️ **DEPRECATED** - Will be removed in v1.0. Only ensures RGB/RGBA format. |
 | `.preset(name)` | Apply preset (`'thumbnail'`, `'avatar'`, `'hero'`, `'social'`) |
 
 ### Output

--- a/index.js
+++ b/index.js
@@ -313,13 +313,15 @@ if (!nativeBinding) {
 const { ImageEngine, ErrorCode, inspect, inspectFile, version, supportedInputFormats, supportedOutputFormats } = nativeBinding
 
 // Add deprecation warning for toColorspace method
+// DEPRECATED: toColorspace() will be removed in v1.0
 const originalToColorspace = ImageEngine.prototype.toColorspace;
 if (originalToColorspace) {
   ImageEngine.prototype.toColorspace = function(colorSpace) {
     console.warn(
-      '[lazy-image] toColorspace() is deprecated and will be removed in v1.0. ' +
-      'Use ensureRgb() instead. Note: This method does NOT perform true color space ' +
-      'conversion with ICC profiles - it only ensures RGB/RGBA pixel format.'
+      '[lazy-image] ⚠️ DEPRECATION WARNING: toColorspace() is deprecated and will be REMOVED in v1.0. ' +
+      'This method does NOT perform true color space conversion with ICC profiles - ' +
+      'it only ensures RGB/RGBA pixel format. ' +
+      'Please update your code before upgrading to v1.0.'
     );
     return originalToColorspace.call(this, colorSpace);
   };


### PR DESCRIPTION
## 概要
toColorspace() の deprecation 警告を強化し、v1.0での削除を明記。

## 変更内容
- index.js: 警告メッセージをより明確に（v1.0削除予定を強調）
- README.md: API テーブルに DEPRECATED 表記を追加
- CHANGELOG.md: Deprecated セクションに記載

Closes #46