### PR TITLE
chore: update benchmark results and bump to v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [0.8.0] - 2025-12-28
+
+### Changed
+- Updated benchmark results with latest comparison against sharp v0.34.x
+- README.md benchmark section now reflects current performance characteristics
+- Improved benchmark test image (66MB PNG with complex patterns)
+
 ### Deprecated
 - `toColorspace()` method: Strengthened deprecation warning. **Will be removed in v1.0**. This method only ensures RGB/RGBA format, not true color space conversion.
-
-### Added
-- This CHANGELOG file to track project changes
 
 ---
 
@@ -143,7 +149,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[Unreleased]: https://github.com/albert-einshutoin/lazy-image/compare/v0.7.9...HEAD
+[Unreleased]: https://github.com/albert-einshutoin/lazy-image/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/albert-einshutoin/lazy-image/compare/v0.7.9...v0.8.0
 [0.7.9]: https://github.com/albert-einshutoin/lazy-image/compare/v0.7.8...v0.7.9
 [0.7.8]: https://github.com/albert-einshutoin/lazy-image/compare/v0.7.7...v0.7.8
 [0.7.7]: https://github.com/albert-einshutoin/lazy-image/compare/v0.7.6...v0.7.7

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lazy-image"
-version = "0.7.9"
+version = "0.8.0"
 edition = "2021"
 description = "Next-gen image processing engine - faster, smaller, better than sharp"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -21,21 +21,21 @@
 
 | Format | lazy-image | sharp | Difference |
 |--------|-----------|-------|------------|
-| **AVIF** | **77,800 bytes** | 144,700 bytes | **-46.2%** ✅ |
-| **JPEG** | 91,437 bytes | 103,566 bytes | **-11.7%** ✅ |
-| **WebP** | 115,782 bytes | 114,664 bytes | +1.0% ⚠️ |
-| **Complex Pipeline** | 73,956 bytes | 69,786 bytes | +6.0% ⚠️ |
+| **JPEG** | 15,790 bytes | 17,495 bytes | **-9.7%** ✅ |
+| **WebP** | 6,378 bytes | 6,362 bytes | +0.3% ⚠️ |
+| **AVIF** | 5,599 bytes | 3,683 bytes | +52.0% ⚠️ |
+| **Complex Pipeline** | 7,205 bytes | 8,297 bytes | **-13.2%** ✅ |
 
 ### Processing Speed Comparison
 
 | Format | lazy-image | sharp | Speed Ratio |
 |--------|-----------|-------|-------------|
-| **AVIF** | 346ms | 381ms | **1.10x faster** ⚡ |
-| **JPEG** | 325ms | 185ms | 0.57x slower 🐢 |
-| **WebP** | 429ms | 171ms | 0.40x slower 🐢 |
-| **Complex Pipeline** | 293ms | 176ms | 0.60x slower 🐢 |
+| **JPEG** | 242ms | 257ms | **1.06x faster** ⚡ |
+| **WebP** | 301ms | 233ms | 0.77x slower 🐢 |
+| **AVIF** | 267ms | 288ms | **1.08x faster** ⚡ |
+| **Complex Pipeline** | 193ms | 273ms | **1.41x faster** ⚡ |
 
-> *Tested with 23MB PNG input, resize to 800px, quality 60-80*
+> *Tested with 66MB PNG input (6000×4000), resize to 800px, quality 60-80*
 
 <details>
 <summary>📋 Benchmark Test Environment (Click to expand)</summary>
@@ -44,7 +44,7 @@
 |------|--------------|
 | **Node.js** | v22.x |
 | **sharp** | 0.34.x |
-| **Test Image** | 6000×4000 PNG (23MB) |
+| **Test Image** | 6000×4000 PNG (66MB) |
 | **Output Size** | 800px width (auto height) |
 | **Quality** | JPEG: 80, WebP: 80, AVIF: 60 |
 | **Platform** | macOS (Apple Silicon) |
@@ -58,15 +58,15 @@ npm run test:bench:compare
 
 </details>
 
-### AVIF: The Ultimate Compression
+### Key Advantages
 
 ```
-AVIF vs JPEG: -14.9% smaller
-AVIF vs WebP: -32.8% smaller
-AVIF vs sharp AVIF: -46.2% smaller (and 1.10x faster!)
+JPEG: -9.7% smaller files than sharp (with 1.06x faster processing)
+Complex Pipeline: -13.2% smaller + 1.41x faster
+AVIF/WebP: Comparable speed with format-optimized encoding
 ```
 
-**Translation**: If you serve 1 billion images/month and switch to AVIF, you save **~300GB of bandwidth per month** compared to WebP. lazy-image's AVIF encoder produces **46% smaller files** than sharp's AVIF implementation while being **10% faster**.
+**Translation**: lazy-image excels at JPEG compression (mozjpeg) and complex multi-operation pipelines. For single-format WebP/AVIF encoding, both libraries perform similarly.
 
 ---
 
@@ -697,6 +697,7 @@ Built on the shoulders of giants:
 
 | Version | Features |
 |---------|----------|
+| v0.8.0 | Updated benchmark results, improved test suite |
 | v0.7.7 | CI/CD improvements: skip napi prepublish auto-publish, use manual package generation |
 | v0.7.6 | Fixed napi prepublish: create skeleton package.json for each platform before running prepublish |
 | v0.7.5 | Fixed platform-specific package publishing (robust CI/CD workflow) |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alberteinshutoin/lazy-image",
-  "version": "0.7.9",
+  "version": "0.8.0",
   "description": "Next-generation image processing engine - smaller files than sharp, powered by Rust + mozjpeg",
   "main": "index.js",
   "repository": {
@@ -62,11 +62,11 @@
     }
   },
   "optionalDependencies": {
-    "@alberteinshutoin/lazy-image-darwin-arm64": "0.7.9",
-    "@alberteinshutoin/lazy-image-darwin-x64": "0.7.9",
-    "@alberteinshutoin/lazy-image-linux-x64-gnu": "0.7.9",
-    "@alberteinshutoin/lazy-image-linux-x64-musl": "0.7.9",
-    "@alberteinshutoin/lazy-image-win32-x64-msvc": "0.7.9"
+    "@alberteinshutoin/lazy-image-darwin-arm64": "0.8.0",
+    "@alberteinshutoin/lazy-image-darwin-x64": "0.8.0",
+    "@alberteinshutoin/lazy-image-linux-x64-gnu": "0.8.0",
+    "@alberteinshutoin/lazy-image-linux-x64-musl": "0.8.0",
+    "@alberteinshutoin/lazy-image-win32-x64-msvc": "0.8.0"
   },
   "engines": {
     "node": ">= 18"


### PR DESCRIPTION
## Summary
- Update README.md benchmark section with latest sharp v0.34.x comparison
- Bump version: 0.7.9 → 0.8.0

## Benchmark Results (66MB PNG, 6000×4000)

### File Size Comparison
| Format | lazy-image | sharp | Difference |
|--------|-----------|-------|------------|
| **JPEG** | 15,790 bytes | 17,495 bytes | **-9.7%** ✅ |
| **WebP** | 6,378 bytes | 6,362 bytes | +0.3% ⚠️ |
| **AVIF** | 5,599 bytes | 3,683 bytes | +52.0% ⚠️ |
| **Complex Pipeline** | 7,205 bytes | 8,297 bytes | **-13.2%** ✅ |

### Processing Speed Comparison
| Format | lazy-image | sharp | Speed Ratio |
|--------|-----------|-------|-------------|
| **JPEG** | 242ms | 257ms | **1.06x faster** ⚡ |
| **WebP** | 301ms | 233ms | 0.77x slower 🐢 |
| **AVIF** | 267ms | 288ms | **1.08x faster** ⚡ |
| **Complex Pipeline** | 193ms | 273ms | **1.41x faster** ⚡ |

## Changes
- README.md: Updated benchmark results
- package.json: 0.7.9 → 0.8.0
- Cargo.toml: 0.7.9 → 0.8.0
- CHANGELOG.md: Added v0.8.0 section