### PR TITLE
fix: sync package-lock.json version to 0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alberteinshutoin/lazy-image",
-  "version": "0.7.9",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@alberteinshutoin/lazy-image",
-      "version": "0.7.9",
+      "version": "0.8.0",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.0",
@@ -18,16 +18,16 @@
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "@alberteinshutoin/lazy-image-darwin-arm64": "0.7.9",
-        "@alberteinshutoin/lazy-image-darwin-x64": "0.7.9",
-        "@alberteinshutoin/lazy-image-linux-x64-gnu": "0.7.9",
-        "@alberteinshutoin/lazy-image-linux-x64-musl": "0.7.9",
-        "@alberteinshutoin/lazy-image-win32-x64-msvc": "0.7.9"
+        "@alberteinshutoin/lazy-image-darwin-arm64": "0.8.0",
+        "@alberteinshutoin/lazy-image-darwin-x64": "0.8.0",
+        "@alberteinshutoin/lazy-image-linux-x64-gnu": "0.8.0",
+        "@alberteinshutoin/lazy-image-linux-x64-musl": "0.8.0",
+        "@alberteinshutoin/lazy-image-win32-x64-msvc": "0.8.0"
       }
     },
     "node_modules/@alberteinshutoin/lazy-image-darwin-arm64": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-darwin-arm64/-/lazy-image-darwin-arm64-0.7.9.tgz",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-darwin-arm64/-/lazy-image-darwin-arm64-0.8.0.tgz",
       "integrity": "sha512-f2VN459x7To4UlH9GTAZQKNcyeY1WqdYn5mLyt+UP49mVumTUYVL0Li9Wrf+PV944tvzs+JkPTiS8DDxTES6KQ==",
       "cpu": [
         "arm64"
@@ -42,8 +42,8 @@
       }
     },
     "node_modules/@alberteinshutoin/lazy-image-darwin-x64": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-darwin-x64/-/lazy-image-darwin-x64-0.7.9.tgz",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-darwin-x64/-/lazy-image-darwin-x64-0.8.0.tgz",
       "integrity": "sha512-nW0A76RtaASq78av1p4+5EchXFViBXodlkvqDfjuICJP2qaZfDOdDuDSL9oSqz/sBGnJfgWVDTSmt6YCLL1pTg==",
       "cpu": [
         "x64"
@@ -58,8 +58,8 @@
       }
     },
     "node_modules/@alberteinshutoin/lazy-image-linux-x64-gnu": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-linux-x64-gnu/-/lazy-image-linux-x64-gnu-0.7.9.tgz",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-linux-x64-gnu/-/lazy-image-linux-x64-gnu-0.8.0.tgz",
       "integrity": "sha512-/QrPI+9i5l0PyRsIzb4QZeYeM/1pxlPTB39vqkzsrX+8cLyQwljbxexmRKqrRiffbm01Wq+RItiGOSrlDSHvXw==",
       "cpu": [
         "x64"
@@ -74,8 +74,8 @@
       }
     },
     "node_modules/@alberteinshutoin/lazy-image-linux-x64-musl": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-linux-x64-musl/-/lazy-image-linux-x64-musl-0.7.9.tgz",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-linux-x64-musl/-/lazy-image-linux-x64-musl-0.8.0.tgz",
       "integrity": "sha512-HQ8l+wOxM5JCxA72iRZakogvn7zTm3jpI0UHKUKEQ+elLg/VnCXqiO+so0xbn51qac5auUnmpgAP9eIRMG01xQ==",
       "cpu": [
         "x64"
@@ -90,8 +90,8 @@
       }
     },
     "node_modules/@alberteinshutoin/lazy-image-win32-x64-msvc": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-win32-x64-msvc/-/lazy-image-win32-x64-msvc-0.7.9.tgz",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-win32-x64-msvc/-/lazy-image-win32-x64-msvc-0.8.0.tgz",
       "integrity": "sha512-6xKdzBWgOis/xWavBj+hIPiqiI3eKwy9fET7Pk1YF0IEbDabChFuXCrQb0eUgbyIRwa74NQQqXY1LfadO3ejEg==",
       "cpu": [
         "x64"


### PR DESCRIPTION
## 問題

CIが失敗している原因を調査したところ、`package.json`と`package-lock.json`のバージョン不一致が判明しました。

- `package.json`: バージョン `0.8.0`
- `package-lock.json`: バージョン `0.7.9`（未同期）

v0.7.9からv0.8.0への変更で、`package-lock.json`が更新されていませんでした。

## 修正内容

- `scripts/sync-version.js`を実行して`package-lock.json`のバージョンを0.8.0に同期
- `optionalDependencies`のバージョンも0.8.0に更新
- プラットフォームパッケージの`resolved` URLも更新

## 期待される効果

- CIの`npm ci`が正常に実行されるようになる
- `package.json`と`package-lock.json`のバージョンが一致する

## 関連

- v0.7.9からv0.8.0への変更で発生した問題