### PR TITLE
chore: add coverage files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,13 @@ Thumbs.db
 npm/
 artifacts/
 
+# Coverage reports (generated files)
+coverage/
+*.lcov
+rust-coverage.lcov
+
 # Internal documentation (not for public)
+COVERAGE_REPORT.md
 OSS_REVIEW.md
 OSS_CHECKLIST.md
 TEST_QUALITY_REVIEW.md


### PR DESCRIPTION
## Summary
Add coverage-related generated files to .gitignore to prevent them from being committed.

## Changes
- Added `coverage/` directory to .gitignore
- Added `*.lcov` and `rust-coverage.lcov` to .gitignore
- Added `COVERAGE_REPORT.md` to internal documentation section

## Rationale
These files are generated artifacts from coverage analysis tools and should not be tracked in git. The coverage report can be regenerated when needed.

Related to #99

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds coverage artifacts to version control ignore list.
> 
> - Ignore generated coverage outputs: `coverage/`, `*.lcov`, `rust-coverage.lcov`
> - Ignore internal coverage report doc: `COVERAGE_REPORT.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58f1b1c4f9f89c3cead8b8e68556efb897188072. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->