### PR TITLE
chore: Remove unnecessary num_cpus dependency (#110)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -93,7 +93,11 @@ jobs:
 
   test-rust:
     name: Rust Tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.host }}
+    strategy:
+      fail-fast: false
+      matrix:
+        host: [ubuntu-latest, macos-14]
 
     steps:
       - uses: actions/checkout@v4
@@ -101,8 +105,13 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install NASM
+      - name: Install NASM (Linux)
+        if: matrix.host == 'ubuntu-latest'
         run: sudo apt-get update && sudo apt-get install -y nasm
+
+      - name: Install NASM (macOS)
+        if: matrix.host == 'macos-14'
+        run: brew install nasm
 
       - name: Run Rust tests (without NAPI features)
         run: cargo test --no-default-features --no-fail-fast

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,7 +603,6 @@ dependencies = [
  "mozjpeg",
  "napi",
  "napi-derive",
- "num_cpus",
  "once_cell",
  "rayon",
  "tempfile",
@@ -876,16 +875,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,6 @@ tempfile = "3.10"
 
 # Parallel processing for batch operations
 rayon = "1.8"
-num_cpus = "1.16"
 
 # Error handling
 thiserror = "1.0"

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -183,7 +183,6 @@ use mozjpeg::{ColorSpace, Compress, Decompress, ScanMode};
 use napi::bindgen_prelude::*;
 #[cfg(feature = "napi")]
 use napi::{Env, JsBuffer, JsFunction, JsObject, Task};
-use num_cpus;
 #[cfg(feature = "napi")]
 use rayon::prelude::*;
 #[cfg(feature = "napi")]
@@ -1781,7 +1780,9 @@ impl EncodeTask {
             (*encoder).qualityAlpha = quality as i32;
             (*encoder).speed = settings.avif_speed();
             // libavif requires maxThreads >= 2 for multi-threading; cap at 8 to avoid runaway thread counts
-            let cpu_threads = num_cpus::get();
+            let cpu_threads = std::thread::available_parallelism()
+                .map(|n| n.get())
+                .unwrap_or(2);
             let capped = cmp::min(8, cpu_threads);
             let encoder_threads = cmp::max(2, capped) as i32;
             (*encoder).maxThreads = encoder_threads;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,9 @@ pub struct InspectMetadata {
 }
 
 #[cfg(any(feature = "napi", feature = "fuzzing"))]
-fn read_inspect_metadata<R: BufRead + Seek>(reader: R) -> std::result::Result<InspectMetadata, LazyImageError> {
+fn read_inspect_metadata<R: BufRead + Seek>(
+    reader: R,
+) -> std::result::Result<InspectMetadata, LazyImageError> {
     let reader = ImageReader::new(reader)
         .with_guessed_format()
         .map_err(|e| LazyImageError::decode_failed(format!("failed to read image header: {e}")))?;
@@ -57,12 +59,16 @@ fn read_inspect_metadata<R: BufRead + Seek>(reader: R) -> std::result::Result<In
 }
 
 #[cfg(any(feature = "napi", feature = "fuzzing"))]
-pub fn inspect_header_from_bytes(data: &[u8]) -> std::result::Result<InspectMetadata, LazyImageError> {
+pub fn inspect_header_from_bytes(
+    data: &[u8],
+) -> std::result::Result<InspectMetadata, LazyImageError> {
     read_inspect_metadata(Cursor::new(data))
 }
 
 #[cfg(any(feature = "napi", feature = "fuzzing"))]
-pub fn inspect_header_from_path(path: &str) -> std::result::Result<InspectMetadata, LazyImageError> {
+pub fn inspect_header_from_path(
+    path: &str,
+) -> std::result::Result<InspectMetadata, LazyImageError> {
     use std::fs::File;
 
     let file = File::open(path).map_err(|e| LazyImageError::file_read_failed(path, e))?;


### PR DESCRIPTION
This PR removes the unnecessary num_cpus dependency and replaces it with the standard library's std::thread::available_parallelism() function.

Changes:
- Removed num_cpus dependency from Cargo.toml
- Replaced num_cpus::get() with std::thread::available_parallelism() in src/engine.rs
- Added macOS matrix to Rust tests in CI
- Formatted src/lib.rs for consistency

Benefits:
- Reduced dependencies and build time
- Smaller binary size
- Better maintainability using standard library
- Improved cross-platform test coverage

Closes #110