### PR TITLE
chore: prepare release v0.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.8.4] - 2026-01-12
+
+### Added
+- Zero-copy memory mapping implementation (#128)
+  - `fromPath()` now uses memory mapping (mmap) for zero-copy file access
+  - `processBatch()` uses memory mapping for efficient batch processing
+  - Bypasses Node.js heap entirely, ideal for processing large images in memory-constrained environments
+  - Added `MmapFailed` error type for accurate error reporting
+
+### Changed
+- Improved zero-copy implementation: eliminated unnecessary buffer copies for memory-mapped sources
+- Updated `BatchTask` to use memory mapping instead of `fs::read` for zero-copy access
+- Enhanced documentation in README.md with detailed zero-copy memory mapping information
+- Added Windows file locking notes in README.md (memory-mapped files cannot be deleted while mapped on Windows)
+
+### Fixed
+- Fixed issue where `Source::load()` was converting Mapped→Vec, defeating zero-copy purpose
+- Removed dead code: `Source::Path` variant and `source_bytes` field
+
+---
+
 ## [0.8.3] - 2026-01-12
 
 ### Documentation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lazy-image"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2021"
 description = "Next-gen image processing engine - faster, smaller, better than sharp"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -892,6 +892,7 @@ Built on the shoulders of giants:
 
 | Version | Features |
 |---------|----------|
+| v0.8.4 | Zero-copy memory mapping implementation: fromPath() and processBatch() use mmap for zero-copy file access |
 | v0.8.3 | Documentation: Updated README.md to document zero-copy memory mapping for processBatch() |
 | v0.8.1 | WebP encoding optimization: ~4x speed improvement (method 4, single pass) to match sharp performance |
 | v0.8.0 | Updated benchmark results, improved test suite |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alberteinshutoin/lazy-image",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@alberteinshutoin/lazy-image",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.0",
@@ -18,16 +18,16 @@
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "@alberteinshutoin/lazy-image-darwin-arm64": "0.8.3",
-        "@alberteinshutoin/lazy-image-darwin-x64": "0.8.3",
-        "@alberteinshutoin/lazy-image-linux-x64-gnu": "0.8.3",
-        "@alberteinshutoin/lazy-image-linux-x64-musl": "0.8.3",
-        "@alberteinshutoin/lazy-image-win32-x64-msvc": "0.8.3"
+        "@alberteinshutoin/lazy-image-darwin-arm64": "0.8.4",
+        "@alberteinshutoin/lazy-image-darwin-x64": "0.8.4",
+        "@alberteinshutoin/lazy-image-linux-x64-gnu": "0.8.4",
+        "@alberteinshutoin/lazy-image-linux-x64-musl": "0.8.4",
+        "@alberteinshutoin/lazy-image-win32-x64-msvc": "0.8.4"
       }
     },
     "node_modules/@alberteinshutoin/lazy-image-darwin-arm64": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-darwin-arm64/-/lazy-image-darwin-arm64-0.8.3.tgz",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-darwin-arm64/-/lazy-image-darwin-arm64-0.8.4.tgz",
       "integrity": "sha512-wserB2Yor5n9DSycWar4WU8X84eWbjXGZ2JgdupzoSfI56c8ipN2JCaI+i0V/kAa/0Ul4jvPga8hgTxWOdRo6Q==",
       "cpu": [
         "arm64"
@@ -42,8 +42,8 @@
       }
     },
     "node_modules/@alberteinshutoin/lazy-image-darwin-x64": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-darwin-x64/-/lazy-image-darwin-x64-0.8.3.tgz",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-darwin-x64/-/lazy-image-darwin-x64-0.8.4.tgz",
       "integrity": "sha512-A6VcIuf1iWIOjiVVY/JwsXbLU3wskhNXRcC8bo4mvNtvpvkH/QWKKVXAkbYrBsvjiNTEX01LdDupYNZoRKyiJw==",
       "cpu": [
         "x64"
@@ -58,8 +58,8 @@
       }
     },
     "node_modules/@alberteinshutoin/lazy-image-linux-x64-gnu": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-linux-x64-gnu/-/lazy-image-linux-x64-gnu-0.8.3.tgz",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-linux-x64-gnu/-/lazy-image-linux-x64-gnu-0.8.4.tgz",
       "integrity": "sha512-jH4JY79rwWPGWY24bK/xLHzdMu6xXZrzfkammtIUskl+hYkTWa3fkzRM7GTc0hh6dn7c/akxsVqLrgsl3bCAaQ==",
       "cpu": [
         "x64"
@@ -74,8 +74,8 @@
       }
     },
     "node_modules/@alberteinshutoin/lazy-image-linux-x64-musl": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-linux-x64-musl/-/lazy-image-linux-x64-musl-0.8.3.tgz",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-linux-x64-musl/-/lazy-image-linux-x64-musl-0.8.4.tgz",
       "integrity": "sha512-lTtdJaKQHLsUmDXd88mInvI32/QSd41sJZgQ21EH5tWUPwQnDY0z7hXzCcI8NLGsPDwF4qCyDleIhys+qmGGMg==",
       "cpu": [
         "x64"
@@ -90,8 +90,8 @@
       }
     },
     "node_modules/@alberteinshutoin/lazy-image-win32-x64-msvc": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-win32-x64-msvc/-/lazy-image-win32-x64-msvc-0.8.3.tgz",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-win32-x64-msvc/-/lazy-image-win32-x64-msvc-0.8.4.tgz",
       "integrity": "sha512-YoEPcu9hcSjUFu/itZrZpSX5YFaeFNOdH0h29e+5sm6dIsjkkjAA8asMjYwzyRLDl8UhD8rdpQvo9UTKNk8GSg==",
       "cpu": [
         "x64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alberteinshutoin/lazy-image",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Next-generation image processing engine - smaller files than sharp, powered by Rust + mozjpeg",
   "main": "index.js",
   "repository": {
@@ -63,11 +63,11 @@
     }
   },
   "optionalDependencies": {
-    "@alberteinshutoin/lazy-image-darwin-arm64": "0.8.3",
-    "@alberteinshutoin/lazy-image-darwin-x64": "0.8.3",
-    "@alberteinshutoin/lazy-image-linux-x64-gnu": "0.8.3",
-    "@alberteinshutoin/lazy-image-linux-x64-musl": "0.8.3",
-    "@alberteinshutoin/lazy-image-win32-x64-msvc": "0.8.3"
+    "@alberteinshutoin/lazy-image-darwin-arm64": "0.8.4",
+    "@alberteinshutoin/lazy-image-darwin-x64": "0.8.4",
+    "@alberteinshutoin/lazy-image-linux-x64-gnu": "0.8.4",
+    "@alberteinshutoin/lazy-image-linux-x64-musl": "0.8.4",
+    "@alberteinshutoin/lazy-image-win32-x64-msvc": "0.8.4"
   },
   "engines": {
     "node": ">= 18"


### PR DESCRIPTION
## v0.8.4 Release

### Changes
- Zero-copy memory mapping implementation (#128)
  - `fromPath()` and `processBatch()` use memory mapping for zero-copy file access
  - Bypasses Node.js heap entirely
  - Added `MmapFailed` error type

### Files Changed
- package.json: 0.8.3 → 0.8.4
- Cargo.toml: 0.8.3 → 0.8.4
- CHANGELOG.md: Added v0.8.4 entry
- README.md: Updated version history

After merge, create tag `v0.8.4` to trigger npm publish.