### PR TITLE
docs: Update CHANGELOG and README for v0.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.8.5] - 2026-01-12
+
+### Fixed
+- Fixed CI compilation errors when building with `--no-default-features`
+- Made imports conditional for NAPI-dependent types to support compilation without default features
+- Fixed missing export of `run_stress_iteration` from engine module for stress testing
+
+### Changed
+- Updated conditional compilation attributes to properly handle `--no-default-features` builds
+- Improved test module imports in `engine.rs` for better feature flag compatibility
+
+---
+
 ## [0.8.4] - 2026-01-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -892,6 +892,7 @@ Built on the shoulders of giants:
 
 | Version | Features |
 |---------|----------|
+| v0.8.5 | Fixed CI compilation errors and improved --no-default-features build support |
 | v0.8.4 | Zero-copy memory mapping implementation: fromPath() and processBatch() use mmap for zero-copy file access |
 | v0.8.3 | Documentation: Updated README.md to document zero-copy memory mapping for processBatch() |
 | v0.8.1 | WebP encoding optimization: ~4x speed improvement (method 4, single pass) to match sharp performance |


### PR DESCRIPTION
## Summary
Update documentation for v0.8.5 release.

## Changes
- Added v0.8.5 entry to CHANGELOG.md
- Added v0.8.5 entry to README.md version history

## Related
- Release: v0.8.5
- Fixes CI compilation errors and improves --no-default-features build support