### PR TITLE
chore: Release v0.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.8.6] - 2026-01-XX
+
+### Changed
+- Version bump to 0.8.6
+
+---
+
+## [0.8.5] - 2026-01-12
+
+### Fixed
+- Fixed CI compilation errors when building with `--no-default-features`
+- Made imports conditional for NAPI-dependent types to support compilation without default features
+- Fixed missing export of `run_stress_iteration` from engine module for stress testing
+
+### Changed
+- Updated conditional compilation attributes to properly handle `--no-default-features` builds
+- Improved test module imports in `engine.rs` for better feature flag compatibility
+
+---
+
 ## [0.8.4] - 2026-01-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "lazy-image"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "criterion",
  "fast_image_resize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lazy-image"
-version = "0.8.5"
+version = "0.8.6"
 edition = "2021"
 description = "Next-gen image processing engine - faster, smaller, better than sharp"
 license = "MIT"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -335,12 +335,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "image"
 version = "0.25.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -419,16 +413,15 @@ dependencies = [
 
 [[package]]
 name = "lazy-image"
-version = "0.8.1"
+version = "0.8.6"
 dependencies = [
  "fast_image_resize",
  "flate2",
  "image",
  "img-parts",
  "libavif-sys",
+ "memmap2",
  "mozjpeg",
- "num_cpus",
- "once_cell",
  "rayon",
  "tempfile",
  "thiserror 1.0.69",
@@ -514,6 +507,15 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "memmap2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -648,16 +650,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alberteinshutoin/lazy-image",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@alberteinshutoin/lazy-image",
-      "version": "0.8.5",
+      "version": "0.8.6",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.0",
@@ -18,16 +18,16 @@
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "@alberteinshutoin/lazy-image-darwin-arm64": "0.8.4",
-        "@alberteinshutoin/lazy-image-darwin-x64": "0.8.4",
-        "@alberteinshutoin/lazy-image-linux-x64-gnu": "0.8.4",
-        "@alberteinshutoin/lazy-image-linux-x64-musl": "0.8.4",
-        "@alberteinshutoin/lazy-image-win32-x64-msvc": "0.8.4"
+        "@alberteinshutoin/lazy-image-darwin-arm64": "0.8.6",
+        "@alberteinshutoin/lazy-image-darwin-x64": "0.8.6",
+        "@alberteinshutoin/lazy-image-linux-x64-gnu": "0.8.6",
+        "@alberteinshutoin/lazy-image-linux-x64-musl": "0.8.6",
+        "@alberteinshutoin/lazy-image-win32-x64-msvc": "0.8.6"
       }
     },
     "node_modules/@alberteinshutoin/lazy-image-darwin-arm64": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-darwin-arm64/-/lazy-image-darwin-arm64-0.8.4.tgz",
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-darwin-arm64/-/lazy-image-darwin-arm64-0.8.6.tgz",
       "integrity": "sha512-wserB2Yor5n9DSycWar4WU8X84eWbjXGZ2JgdupzoSfI56c8ipN2JCaI+i0V/kAa/0Ul4jvPga8hgTxWOdRo6Q==",
       "cpu": [
         "arm64"
@@ -42,8 +42,8 @@
       }
     },
     "node_modules/@alberteinshutoin/lazy-image-darwin-x64": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-darwin-x64/-/lazy-image-darwin-x64-0.8.4.tgz",
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-darwin-x64/-/lazy-image-darwin-x64-0.8.6.tgz",
       "integrity": "sha512-A6VcIuf1iWIOjiVVY/JwsXbLU3wskhNXRcC8bo4mvNtvpvkH/QWKKVXAkbYrBsvjiNTEX01LdDupYNZoRKyiJw==",
       "cpu": [
         "x64"
@@ -58,8 +58,8 @@
       }
     },
     "node_modules/@alberteinshutoin/lazy-image-linux-x64-gnu": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-linux-x64-gnu/-/lazy-image-linux-x64-gnu-0.8.4.tgz",
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-linux-x64-gnu/-/lazy-image-linux-x64-gnu-0.8.6.tgz",
       "integrity": "sha512-jH4JY79rwWPGWY24bK/xLHzdMu6xXZrzfkammtIUskl+hYkTWa3fkzRM7GTc0hh6dn7c/akxsVqLrgsl3bCAaQ==",
       "cpu": [
         "x64"
@@ -74,8 +74,8 @@
       }
     },
     "node_modules/@alberteinshutoin/lazy-image-linux-x64-musl": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-linux-x64-musl/-/lazy-image-linux-x64-musl-0.8.4.tgz",
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-linux-x64-musl/-/lazy-image-linux-x64-musl-0.8.6.tgz",
       "integrity": "sha512-lTtdJaKQHLsUmDXd88mInvI32/QSd41sJZgQ21EH5tWUPwQnDY0z7hXzCcI8NLGsPDwF4qCyDleIhys+qmGGMg==",
       "cpu": [
         "x64"
@@ -90,8 +90,8 @@
       }
     },
     "node_modules/@alberteinshutoin/lazy-image-win32-x64-msvc": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-win32-x64-msvc/-/lazy-image-win32-x64-msvc-0.8.4.tgz",
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-win32-x64-msvc/-/lazy-image-win32-x64-msvc-0.8.6.tgz",
       "integrity": "sha512-YoEPcu9hcSjUFu/itZrZpSX5YFaeFNOdH0h29e+5sm6dIsjkkjAA8asMjYwzyRLDl8UhD8rdpQvo9UTKNk8GSg==",
       "cpu": [
         "x64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alberteinshutoin/lazy-image",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "Next-generation image processing engine - smaller files than sharp, powered by Rust + mozjpeg",
   "main": "index.js",
   "repository": {
@@ -63,11 +63,11 @@
     }
   },
   "optionalDependencies": {
-    "@alberteinshutoin/lazy-image-darwin-arm64": "0.8.4",
-    "@alberteinshutoin/lazy-image-darwin-x64": "0.8.4",
-    "@alberteinshutoin/lazy-image-linux-x64-gnu": "0.8.4",
-    "@alberteinshutoin/lazy-image-linux-x64-musl": "0.8.4",
-    "@alberteinshutoin/lazy-image-win32-x64-msvc": "0.8.4"
+    "@alberteinshutoin/lazy-image-darwin-arm64": "0.8.6",
+    "@alberteinshutoin/lazy-image-darwin-x64": "0.8.6",
+    "@alberteinshutoin/lazy-image-linux-x64-gnu": "0.8.6",
+    "@alberteinshutoin/lazy-image-linux-x64-musl": "0.8.6",
+    "@alberteinshutoin/lazy-image-win32-x64-msvc": "0.8.6"
   },
   "engines": {
     "node": ">= 18"


### PR DESCRIPTION
## 変更内容

- バージョンを0.8.5から0.8.6に更新
- 以下のファイルを更新:
  - Cargo.toml
  - Cargo.lock
  - package.json
  - package-lock.json
  - CHANGELOG.md
  - fuzz/Cargo.lock

## チェックリスト

- [x] バージョン番号を更新
- [x] CHANGELOG.mdを更新
- [x] すべてのバージョン参照を同期