### PR TITLE
feat: 統一panic policy実装 (#166)

### DIFF
--- a/src/engine/api.rs
+++ b/src/engine/api.rs
@@ -623,11 +623,8 @@ impl ImageEngine {
 
             crate::engine::decoder::ensure_dimensions_safe(bytes)?;
 
-            let img = image::load_from_memory(bytes).map_err(|e| {
-                napi::Error::from(LazyImageError::decode_failed(format!(
-                    "failed to decode: {e}"
-                )))
-            })?;
+            let img = crate::engine::decoder::decode_with_image_crate(bytes)
+                .map_err(napi::Error::from)?;
 
             // Security check: reject decompression bombs
             let (w, h) = img.dimensions();
@@ -673,8 +670,7 @@ impl ImageEngine {
 
             crate::engine::decoder::ensure_dimensions_safe(bytes)?;
 
-            let img = image::load_from_memory(bytes)
-                .map_err(|e| LazyImageError::decode_failed(format!("failed to decode: {e}")))?;
+            let img = crate::engine::decoder::decode_with_image_crate(bytes)?;
 
             // Security check: reject decompression bombs
             let (w, h) = img.dimensions();

--- a/src/engine/encoder.rs
+++ b/src/engine/encoder.rs
@@ -3,6 +3,7 @@
 // Encoder operations: JPEG (mozjpeg), PNG, WebP, AVIF with quality settings
 
 use crate::codecs::avif_safe::{create_rgb_image, SafeAvifEncoder, SafeAvifImage, SafeAvifRwData};
+use crate::engine::common::run_with_panic_policy;
 use crate::error::LazyImageError;
 use image::{DynamicImage, GenericImageView, ImageFormat};
 use img_parts::{jpeg::Jpeg, png::Png, ImageICC};
@@ -129,268 +130,232 @@ pub fn encode_jpeg_with_settings(
     icc: Option<&[u8]>,
     fast_mode: bool,
 ) -> EncoderResult<Vec<u8>> {
-    use std::borrow::Cow;
+    run_with_panic_policy("encode:jpeg", || {
+        use std::borrow::Cow;
 
-    // Zero-copy optimization: avoid conversion if already RGB8
-    let rgb: Cow<'_, image::RgbImage> = match img {
-        DynamicImage::ImageRgb8(rgb_img) => Cow::Borrowed(rgb_img),
-        _ => Cow::Owned(img.to_rgb8()),
-    };
-    let (w, h) = rgb.dimensions();
-    let pixels: &[u8] = rgb.as_raw();
+        // Zero-copy optimization: avoid conversion if already RGB8
+        let rgb: Cow<'_, image::RgbImage> = match img {
+            DynamicImage::ImageRgb8(rgb_img) => Cow::Borrowed(rgb_img),
+            _ => Cow::Owned(img.to_rgb8()),
+        };
+        let (w, h) = rgb.dimensions();
+        let pixels: &[u8] = rgb.as_raw();
 
-    // 1. 事前検証 (パニック要因の排除)
-    // 画像サイズの妥当性チェック
-    if w == 0 || h == 0 {
-        return Err(LazyImageError::internal_panic(
-            "Invalid image dimensions: width or height is zero",
-        ));
-    }
-
-    // MAX_DIMENSIONチェック（プロジェクト全体の一貫性のため）
-    if w > MAX_DIMENSION || h > MAX_DIMENSION {
-        return Err(LazyImageError::dimension_exceeds_limit(
-            w.max(h),
-            MAX_DIMENSION,
-        ));
-    }
-
-    // バッファサイズの整合性チェック（非常に重要）
-    let expected_len = (w as usize) * (h as usize) * 3;
-    if pixels.len() != expected_len {
-        return Err(LazyImageError::corrupted_image());
-    }
-
-    // 2. エンコード (catch_unwind は削除)
-    // ここでパニックが起きるなら、それはライブラリのバグなのでクラッシュさせるべき（Fail Fast）
-    let mut comp = Compress::new(ColorSpace::JCS_RGB);
-
-    comp.set_size(w as usize, h as usize);
-
-    // Output color space: YCbCr (standard for JPEG)
-    comp.set_color_space(ColorSpace::JCS_YCbCr);
-
-    // Quality setting with fine-grained control
-    // Convert 0-100 to mozjpeg's quality scale (0.0-100.0)
-    let quality_f32 = quality as f32;
-    comp.set_quality(quality_f32);
-
-    // =========================================================
-    // RUTHLESS WEB OPTIMIZATION SETTINGS (Enhanced)
-    // =========================================================
-
-    // 1. Chroma Subsampling: Force 4:2:0 (same as sharp default)
-    //    (2,2) means 2x2 pixel blocks for Cb and Cr channels
-    //    This halves chroma resolution - imperceptible for photos
-    comp.set_chroma_sampling_pixel_sizes((2, 2), (2, 2));
-
-    // 2. Progressive mode: Better compression + progressive loading
-    comp.set_progressive_mode();
-
-    // 3. & 4. Optimize Huffman tables and scan order
-    // Fast mode: Sharp (libjpeg-turbo defaults) に近い設定
-    if fast_mode {
-        // Disable expensive optimizations for faster encoding
-        comp.set_optimize_coding(false);
-        comp.set_optimize_scans(false);
-    } else {
-        // 既存の高品質設定 (mozjpeg defaults)
-        // Optimize Huffman tables: Custom tables per image
-        comp.set_optimize_coding(true);
-
-        // Optimize scan order: Better progressive compression
-        comp.set_optimize_scans(true);
-        comp.set_scan_optimization_mode(ScanMode::AllComponentsTogether);
-    }
-
-    // 5. Enhanced Trellis quantization: Better rate-distortion optimization
-    //    This is mozjpeg's secret sauce - it tries multiple quantization
-    //    strategies and picks the best one for file size vs quality
-    //    Trellis quantization is automatically enabled when optimize_coding is true (set above)
-    //    This ensures consistent behavior and optimal compression
-    //    Note: set_trellis_quantization() method is not available in mozjpeg 0.10 API,
-    //    but Trellis quantization is guaranteed to be enabled via set_optimize_coding(true)
-
-    // 6. Adaptive smoothing: Reduces high-frequency noise for better compression
-    //    Higher quality = less smoothing, lower quality = more smoothing
-    //    Enhanced smoothing for low quality (60 and below) to reduce block noise
-    //    while maintaining compression ratio (good trade-off for web use)
-    let smoothing = if quality_f32 >= 90.0 {
-        0 // No smoothing for high quality
-    } else if quality_f32 >= 70.0 {
-        5 // Minimal smoothing
-    } else if quality_f32 >= 60.0 {
-        10 // Moderate smoothing
-    } else {
-        18 // Enhanced smoothing for lower quality (was 15, now 18 for better block noise reduction)
-    };
-    comp.set_smoothing_factor(smoothing);
-
-    // 7. Quantization table optimization
-    //    mozjpeg automatically optimizes quantization tables when optimize_coding is true
-
-    // Estimate output size: ~10% of raw size for typical JPEG compression
-    let estimated_size = (w as usize * h as usize * 3 / 10).max(4096);
-    let mut output = Vec::with_capacity(estimated_size);
-
-    let encoded = {
-        let mut writer = comp.start_compress(&mut output).map_err(|e| {
-            LazyImageError::encode_failed(
-                "jpeg",
-                format!("mozjpeg: failed to start compress: {e:?}"),
-            )
-        })?;
-
-        let stride = w as usize * 3;
-        for row in pixels.chunks(stride) {
-            writer.write_scanlines(row).map_err(|e| {
-                LazyImageError::encode_failed(
-                    "jpeg",
-                    format!("mozjpeg: failed to write scanlines: {e:?}"),
-                )
-            })?;
+        // 1. 事前検証 (パニック要因の排除)
+        if w == 0 || h == 0 {
+            return Err(LazyImageError::internal_panic(
+                "Invalid image dimensions: width or height is zero",
+            ));
         }
 
-        writer.finish().map_err(|e| {
-            LazyImageError::encode_failed("jpeg", format!("mozjpeg: failed to finish: {e:?}"))
-        })?;
+        if w > MAX_DIMENSION || h > MAX_DIMENSION {
+            return Err(LazyImageError::dimension_exceeds_limit(
+                w.max(h),
+                MAX_DIMENSION,
+            ));
+        }
 
-        output
-    };
+        let expected_len = (w as usize) * (h as usize) * 3;
+        if pixels.len() != expected_len {
+            return Err(LazyImageError::corrupted_image());
+        }
 
-    // Embed ICC profile using img-parts if present
-    if let Some(icc_data) = icc {
-        embed_icc_jpeg(encoded, icc_data)
-    } else {
-        Ok(encoded)
-    }
+        let mut comp = Compress::new(ColorSpace::JCS_RGB);
+        comp.set_size(w as usize, h as usize);
+        comp.set_color_space(ColorSpace::JCS_YCbCr);
+
+        let quality_f32 = quality as f32;
+        comp.set_quality(quality_f32);
+
+        // =========================================================
+        // RUTHLESS WEB OPTIMIZATION SETTINGS (Enhanced)
+        // =========================================================
+
+        comp.set_chroma_sampling_pixel_sizes((2, 2), (2, 2));
+        comp.set_progressive_mode();
+
+        if fast_mode {
+            comp.set_optimize_coding(false);
+            comp.set_optimize_scans(false);
+        } else {
+            comp.set_optimize_coding(true);
+            comp.set_optimize_scans(true);
+            comp.set_scan_optimization_mode(ScanMode::AllComponentsTogether);
+        }
+
+        let smoothing = if quality_f32 >= 90.0 {
+            0
+        } else if quality_f32 >= 70.0 {
+            5
+        } else if quality_f32 >= 60.0 {
+            10
+        } else {
+            18
+        };
+        comp.set_smoothing_factor(smoothing);
+
+        // 7. Quantization table optimization is implied by optimize_coding(true)
+
+        let estimated_size = (w as usize * h as usize * 3 / 10).max(4096);
+        let mut output = Vec::with_capacity(estimated_size);
+
+        let encoded = {
+            let mut writer = comp.start_compress(&mut output).map_err(|e| {
+                LazyImageError::encode_failed(
+                    "jpeg",
+                    format!("mozjpeg: failed to start compress: {e:?}"),
+                )
+            })?;
+
+            let stride = w as usize * 3;
+            for row in pixels.chunks(stride) {
+                writer.write_scanlines(row).map_err(|e| {
+                    LazyImageError::encode_failed(
+                        "jpeg",
+                        format!("mozjpeg: failed to write scanlines: {e:?}"),
+                    )
+                })?;
+            }
+
+            writer.finish().map_err(|e| {
+                LazyImageError::encode_failed("jpeg", format!("mozjpeg: failed to finish: {e:?}"))
+            })?;
+
+            output
+        };
+
+        if let Some(icc_data) = icc {
+            embed_icc_jpeg(encoded, icc_data)
+        } else {
+            Ok(encoded)
+        }
+    })
 }
 
 /// Embed ICC profile into JPEG using img-parts
 pub fn embed_icc_jpeg(jpeg_data: Vec<u8>, icc: &[u8]) -> EncoderResult<Vec<u8>> {
-    use img_parts::jpeg::{markers::APP2, JpegSegment};
-    use img_parts::Bytes;
+    run_with_panic_policy("encode:jpeg:embed_icc", || {
+        use img_parts::jpeg::{markers::APP2, JpegSegment};
+        use img_parts::Bytes;
 
-    let mut jpeg = Jpeg::from_bytes(Bytes::from(jpeg_data))
-        .map_err(|e| LazyImageError::decode_failed(format!("failed to parse JPEG for ICC: {e}")))?;
+        let mut jpeg = Jpeg::from_bytes(Bytes::from(jpeg_data)).map_err(|e| {
+            LazyImageError::decode_failed(format!("failed to parse JPEG for ICC: {e}"))
+        })?;
 
-    // Build ICC marker: "ICC_PROFILE\0" + chunk_num + total_chunks + data
-    // For simplicity, we embed as a single chunk (works for profiles < 64KB)
-    let mut marker_data = Vec::with_capacity(14 + icc.len());
-    marker_data.extend_from_slice(b"ICC_PROFILE\0");
-    marker_data.push(1); // Chunk number
-    marker_data.push(1); // Total chunks
-    marker_data.extend_from_slice(icc);
+        let mut marker_data = Vec::with_capacity(14 + icc.len());
+        marker_data.extend_from_slice(b"ICC_PROFILE\0");
+        marker_data.push(1);
+        marker_data.push(1);
+        marker_data.extend_from_slice(icc);
 
-    // Create APP2 segment
-    let segment = JpegSegment::new_with_contents(APP2, Bytes::from(marker_data));
+        let segment = JpegSegment::new_with_contents(APP2, Bytes::from(marker_data));
 
-    // Insert after SOI (before other segments)
-    let segments = jpeg.segments_mut();
-    segments.insert(0, segment);
+        let segments = jpeg.segments_mut();
+        segments.insert(0, segment);
 
-    // Encode back
-    let mut output = Vec::new();
-    jpeg.encoder().write_to(&mut output).map_err(|e| {
-        LazyImageError::encode_failed("jpeg", format!("failed to write JPEG with ICC: {e}"))
-    })?;
+        let mut output = Vec::new();
+        jpeg.encoder().write_to(&mut output).map_err(|e| {
+            LazyImageError::encode_failed("jpeg", format!("failed to write JPEG with ICC: {e}"))
+        })?;
 
-    Ok(output)
+        Ok(output)
+    })
 }
 
 /// Encode to PNG using image crate
 pub fn encode_png(img: &DynamicImage, icc: Option<&[u8]>) -> EncoderResult<Vec<u8>> {
-    let mut buf = Vec::new();
-    img.write_to(&mut Cursor::new(&mut buf), ImageFormat::Png)
-        .map_err(|e| LazyImageError::encode_failed("png", format!("PNG encode failed: {e}")))?;
+    run_with_panic_policy("encode:png", || {
+        let mut buf = Vec::new();
+        img.write_to(&mut Cursor::new(&mut buf), ImageFormat::Png)
+            .map_err(|e| LazyImageError::encode_failed("png", format!("PNG encode failed: {e}")))?;
 
-    // Embed ICC profile if present
-    if let Some(icc_data) = icc {
-        embed_icc_png(buf, icc_data)
-    } else {
-        Ok(buf)
-    }
+        if let Some(icc_data) = icc {
+            embed_icc_png(buf, icc_data)
+        } else {
+            Ok(buf)
+        }
+    })
 }
 
 /// Embed ICC profile into PNG using img-parts
 pub fn embed_icc_png(png_data: Vec<u8>, icc: &[u8]) -> EncoderResult<Vec<u8>> {
-    use img_parts::Bytes;
+    run_with_panic_policy("encode:png:embed_icc", || {
+        use img_parts::Bytes;
 
-    let mut png = Png::from_bytes(Bytes::from(png_data))
-        .map_err(|e| LazyImageError::decode_failed(format!("failed to parse PNG for ICC: {e}")))?;
+        let mut png = Png::from_bytes(Bytes::from(png_data)).map_err(|e| {
+            LazyImageError::decode_failed(format!("failed to parse PNG for ICC: {e}"))
+        })?;
 
-    // img-parts' set_icc_profile expects raw ICC profile data
-    // It will handle iCCP chunk formatting (profile_name + compression_method + compressed_data) internally
-    png.set_icc_profile(Some(Bytes::from(icc.to_vec())));
+        png.set_icc_profile(Some(Bytes::from(icc.to_vec())));
 
-    // Encode back
-    let mut output = Vec::new();
-    png.encoder().write_to(&mut output).map_err(|e| {
-        LazyImageError::encode_failed("png", format!("failed to write PNG with ICC: {e}"))
-    })?;
+        let mut output = Vec::new();
+        png.encoder().write_to(&mut output).map_err(|e| {
+            LazyImageError::encode_failed("png", format!("failed to write PNG with ICC: {e}"))
+        })?;
 
-    Ok(output)
+        Ok(output)
+    })
 }
 
 /// Encode to WebP with optimized settings
 /// Avoids unnecessary alpha channel to reduce file size
 pub fn encode_webp(img: &DynamicImage, quality: u8, icc: Option<&[u8]>) -> EncoderResult<Vec<u8>> {
-    use std::borrow::Cow;
+    run_with_panic_policy("encode:webp", || {
+        use std::borrow::Cow;
 
-    // Zero-copy optimization: avoid conversion if already RGB8
-    let rgb: Cow<'_, image::RgbImage> = match img {
-        DynamicImage::ImageRgb8(rgb_img) => Cow::Borrowed(rgb_img),
-        _ => Cow::Owned(img.to_rgb8()),
-    };
-    let (w, h) = rgb.dimensions();
-    let encoder = webp::Encoder::from_rgb(&rgb, w, h);
+        let rgb: Cow<'_, image::RgbImage> = match img {
+            DynamicImage::ImageRgb8(rgb_img) => Cow::Borrowed(rgb_img),
+            _ => Cow::Owned(img.to_rgb8()),
+        };
+        let (w, h) = rgb.dimensions();
+        let encoder = webp::Encoder::from_rgb(&rgb, w, h);
 
-    // Create WebPConfig with enhanced preprocessing for better compression
-    let mut config = webp::WebPConfig::new()
-        .map_err(|_| LazyImageError::internal_panic("failed to create WebPConfig"))?;
+        let mut config = webp::WebPConfig::new()
+            .map_err(|_| LazyImageError::internal_panic("failed to create WebPConfig"))?;
 
-    let settings = QualitySettings::new(quality);
-    config.quality = settings.quality;
-    config.method = settings.webp_method();
-    config.pass = settings.webp_pass();
-    config.preprocessing = settings.webp_preprocessing();
-    config.sns_strength = settings.webp_sns_strength();
-    config.autofilter = 1;
-    config.filter_strength = settings.webp_filter_strength();
-    config.filter_sharpness = settings.webp_filter_sharpness();
+        let settings = QualitySettings::new(quality);
+        config.quality = settings.quality;
+        config.method = settings.webp_method();
+        config.pass = settings.webp_pass();
+        config.preprocessing = settings.webp_preprocessing();
+        config.sns_strength = settings.webp_sns_strength();
+        config.autofilter = 1;
+        config.filter_strength = settings.webp_filter_strength();
+        config.filter_sharpness = settings.webp_filter_sharpness();
 
-    let mem = encoder
-        .encode_advanced(&config)
-        .map_err(|e| LazyImageError::encode_failed("webp", format!("WebP encode failed: {e:?}")))?;
+        let mem = encoder.encode_advanced(&config).map_err(|e| {
+            LazyImageError::encode_failed("webp", format!("WebP encode failed: {e:?}"))
+        })?;
 
-    let encoded = mem.to_vec();
+        let encoded = mem.to_vec();
 
-    // Embed ICC profile if present
-    if let Some(icc_data) = icc {
-        embed_icc_webp(encoded, icc_data)
-    } else {
-        Ok(encoded)
-    }
+        if let Some(icc_data) = icc {
+            embed_icc_webp(encoded, icc_data)
+        } else {
+            Ok(encoded)
+        }
+    })
 }
 
 /// Embed ICC profile into WebP using img-parts
 pub fn embed_icc_webp(webp_data: Vec<u8>, icc: &[u8]) -> EncoderResult<Vec<u8>> {
-    use img_parts::webp::WebP;
-    use img_parts::Bytes;
+    run_with_panic_policy("encode:webp:embed_icc", || {
+        use img_parts::webp::WebP;
+        use img_parts::Bytes;
 
-    let mut webp = WebP::from_bytes(Bytes::from(webp_data))
-        .map_err(|e| LazyImageError::decode_failed(format!("failed to parse WebP for ICC: {e}")))?;
+        let mut webp = WebP::from_bytes(Bytes::from(webp_data)).map_err(|e| {
+            LazyImageError::decode_failed(format!("failed to parse WebP for ICC: {e}"))
+        })?;
 
-    // Set the ICCP chunk directly
-    webp.set_icc_profile(Some(Bytes::from(icc.to_vec())));
+        webp.set_icc_profile(Some(Bytes::from(icc.to_vec())));
 
-    // Encode back
-    let mut output = Vec::new();
-    webp.encoder().write_to(&mut output).map_err(|e| {
-        LazyImageError::encode_failed("webp", format!("failed to write WebP with ICC: {e}"))
-    })?;
+        let mut output = Vec::new();
+        webp.encoder().write_to(&mut output).map_err(|e| {
+            LazyImageError::encode_failed("webp", format!("failed to write WebP with ICC: {e}"))
+        })?;
 
-    Ok(output)
+        Ok(output)
+    })
 }
 
 /// Encode to AVIF format using libavif (AOMedia reference implementation).
@@ -403,113 +368,87 @@ pub fn embed_icc_webp(webp_data: Vec<u8>, icc: &[u8]) -> EncoderResult<Vec<u8>> 
 /// This function uses safe abstractions from `codecs::avif_safe` to minimize
 /// unsafe blocks and improve memory safety.
 pub fn encode_avif(img: &DynamicImage, quality: u8, icc: Option<&[u8]>) -> EncoderResult<Vec<u8>> {
-    use std::borrow::Cow;
+    run_with_panic_policy("encode:avif", || {
+        use std::borrow::Cow;
 
-    let settings = QualitySettings::new(quality);
-    let (width, height) = img.dimensions();
+        let settings = QualitySettings::new(quality);
+        let (width, height) = img.dimensions();
 
-    // Determine if image has alpha
-    let has_alpha = img.color().has_alpha();
+        let has_alpha = img.color().has_alpha();
 
-    // Zero-copy optimization: avoid conversion if already RGBA8
-    let rgba: Cow<'_, image::RgbaImage> = match img {
-        DynamicImage::ImageRgba8(rgba_img) => Cow::Borrowed(rgba_img),
-        _ => Cow::Owned(img.to_rgba8()),
-    };
-    let pixels = rgba.as_raw();
+        let rgba: Cow<'_, image::RgbaImage> = match img {
+            DynamicImage::ImageRgba8(rgba_img) => Cow::Borrowed(rgba_img),
+            _ => Cow::Owned(img.to_rgba8()),
+        };
+        let pixels = rgba.as_raw();
 
-    // Create AVIF image using safe wrapper
-    let mut avif_image = SafeAvifImage::new(
-        width,
-        height,
-        8, // 8-bit depth
-        AVIF_PIXEL_FORMAT_YUV420,
-    )
-    .map_err(|e| LazyImageError::encode_failed("avif".to_string(), e.to_string()))?;
-
-    // Set color properties
-    avif_image.set_color_properties(
-        AVIF_COLOR_PRIMARIES_BT709 as u16,
-        AVIF_TRANSFER_CHARACTERISTICS_SRGB as u16,
-        AVIF_MATRIX_COEFFICIENTS_BT709 as u16,
-        AVIF_RANGE_FULL,
-    );
-
-    // Set ICC profile if provided
-    if let Some(icc_data) = icc {
-        avif_image
-            .set_icc_profile(icc_data)
-            .map_err(|e| LazyImageError::encode_failed("avif".to_string(), e.to_string()))?;
-    }
-
-    // Create and configure RGB image structure
-    let rgb = create_rgb_image(&mut avif_image, pixels.as_ptr(), width, height);
-
-    // Allocate YUV planes in the image
-    avif_image
-        .allocate_planes(AVIF_PLANES_YUV)
-        .map_err(|e| LazyImageError::encode_failed("avif".to_string(), e.to_string()))?;
-
-    // Convert RGB to YUV using libavif's optimized conversion
-    avif_image
-        .rgb_to_yuv(&rgb)
-        .map_err(|e| LazyImageError::encode_failed("avif".to_string(), e.to_string()))?;
-
-    // Handle alpha channel if present
-    if has_alpha {
-        avif_image
-            .allocate_planes(AVIF_PLANES_A)
+        let mut avif_image = SafeAvifImage::new(width, height, 8, AVIF_PIXEL_FORMAT_YUV420)
             .map_err(|e| LazyImageError::encode_failed("avif".to_string(), e.to_string()))?;
 
-        // Copy alpha channel data
-        // This is the only place where we need unsafe access to the alpha plane
-        unsafe {
-            let alpha_plane = avif_image.alpha_plane_mut();
-            let alpha_row_bytes = avif_image.alpha_row_bytes();
-            for y in 0..height as usize {
-                for x in 0..width as usize {
-                    let src_idx = (y * width as usize + x) * 4 + 3; // Alpha is 4th component
-                    let dst_idx = y * alpha_row_bytes + x;
-                    *alpha_plane.add(dst_idx) = pixels[src_idx];
+        avif_image.set_color_properties(
+            AVIF_COLOR_PRIMARIES_BT709 as u16,
+            AVIF_TRANSFER_CHARACTERISTICS_SRGB as u16,
+            AVIF_MATRIX_COEFFICIENTS_BT709 as u16,
+            AVIF_RANGE_FULL,
+        );
+
+        if let Some(icc_data) = icc {
+            avif_image
+                .set_icc_profile(icc_data)
+                .map_err(|e| LazyImageError::encode_failed("avif".to_string(), e.to_string()))?;
+        }
+
+        let rgb = create_rgb_image(&mut avif_image, pixels.as_ptr(), width, height);
+
+        avif_image
+            .allocate_planes(AVIF_PLANES_YUV)
+            .map_err(|e| LazyImageError::encode_failed("avif".to_string(), e.to_string()))?;
+
+        avif_image
+            .rgb_to_yuv(&rgb)
+            .map_err(|e| LazyImageError::encode_failed("avif".to_string(), e.to_string()))?;
+
+        if has_alpha {
+            avif_image
+                .allocate_planes(AVIF_PLANES_A)
+                .map_err(|e| LazyImageError::encode_failed("avif".to_string(), e.to_string()))?;
+
+            unsafe {
+                let alpha_plane = avif_image.alpha_plane_mut();
+                let alpha_row_bytes = avif_image.alpha_row_bytes();
+                for y in 0..height as usize {
+                    for x in 0..width as usize {
+                        let src_idx = (y * width as usize + x) * 4 + 3;
+                        let dst_idx = y * alpha_row_bytes + x;
+                        *alpha_plane.add(dst_idx) = pixels[src_idx];
+                    }
                 }
             }
         }
-    }
 
-    // Create encoder using safe wrapper
-    let mut encoder = SafeAvifEncoder::new()
-        .map_err(|e| LazyImageError::encode_failed("avif".to_string(), e.to_string()))?;
+        let mut encoder = SafeAvifEncoder::new()
+            .map_err(|e| LazyImageError::encode_failed("avif".to_string(), e.to_string()))?;
 
-    // Configure encoder
-    // libavif quality: 0 (worst) to 100 (lossless),
-    // but internally uses quantizer where lower = better
-    // quality maps to: minQuantizer and maxQuantizer
-    // libavif requires maxThreads >= 2 for multi-threading; cap at 8 to avoid runaway thread counts
-    let cpu_threads = std::thread::available_parallelism()
-        .map(|n| n.get())
-        .unwrap_or(2);
-    let capped = cmp::min(8, cpu_threads);
-    let encoder_threads = cmp::max(2, capped) as i32;
+        let cpu_threads = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(2);
+        let capped = cmp::min(8, cpu_threads);
+        let encoder_threads = cmp::max(2, capped) as i32;
 
-    encoder.configure(quality, quality, settings.avif_speed(), encoder_threads);
+        encoder.configure(quality, quality, settings.avif_speed(), encoder_threads);
 
-    // Create output buffer using safe wrapper
-    let mut output = SafeAvifRwData::new();
+        let mut output = SafeAvifRwData::new();
 
-    // Add image to encoder
-    encoder
-        .add_image(&mut avif_image, 1, AVIF_ADD_IMAGE_FLAG_SINGLE)
-        .map_err(|e| LazyImageError::encode_failed("avif".to_string(), e.to_string()))?;
+        encoder
+            .add_image(&mut avif_image, 1, AVIF_ADD_IMAGE_FLAG_SINGLE)
+            .map_err(|e| LazyImageError::encode_failed("avif".to_string(), e.to_string()))?;
 
-    // Finish encoding
-    encoder
-        .finish(&mut output)
-        .map_err(|e| LazyImageError::encode_failed("avif".to_string(), e.to_string()))?;
+        encoder
+            .finish(&mut output)
+            .map_err(|e| LazyImageError::encode_failed("avif".to_string(), e.to_string()))?;
 
-    // Copy output data
-    let encoded_data = output.to_vec();
-
-    Ok(encoded_data)
+        Ok(output.to_vec())
+    })
 }
 
 #[cfg(test)]

--- a/src/engine/stress.rs
+++ b/src/engine/stress.rs
@@ -8,7 +8,9 @@ use crate::convert_result;
 #[cfg(feature = "stress")]
 use crate::engine::common::EngineResult;
 #[cfg(feature = "stress")]
-use crate::engine::decoder::{decode_jpeg_mozjpeg, ensure_dimensions_safe};
+use crate::engine::decoder::{
+    decode_jpeg_mozjpeg, decode_with_image_crate, ensure_dimensions_safe,
+};
 #[cfg(feature = "stress")]
 use crate::engine::encoder::{
     encode_avif, encode_jpeg, encode_jpeg_with_settings, encode_png, encode_webp,
@@ -61,10 +63,8 @@ pub fn run_stress_iteration(data: &[u8]) -> EngineResult<()> {
         // JPEG - use mozjpeg for speed
         convert_result!(decode_jpeg_mozjpeg(data))
     } else {
-        // Other formats - use image crate
-        image::load_from_memory(data).map_err(|e| {
-            crate::error::LazyImageError::decode_failed(format!("decode failed: {e}"))
-        })?
+        // Other formats - use image crate (guarded by panic policy)
+        convert_result!(decode_with_image_crate(data))
     };
 
     // Apply operations and encode in each format


### PR DESCRIPTION
## 概要
panic policyを統一し、すべてのcodecエントリーポイントをpanic guardで保護しました。

## 変更内容
- ✅ すべてのcodecエントリーポイントを`run_with_panic_policy`でラップ
- ✅ decode/encode/ICC埋め込み処理をpanic guardで保護
- ✅ ERROR_CODES.mdにPanic Policyセクションを追加
- ✅ サードパーティライブラリのpanicをInternalPanicエラーに変換

## 影響範囲
- `src/engine/decoder.rs`: decode処理をpanic guardで保護
- `src/engine/encoder.rs`: encode処理とICC埋め込み処理をpanic guardで保護
- `src/engine/common.rs`: `run_with_panic_policy`ヘルパー関数を追加
- `docs/ERROR_CODES.md`: Panic Policyセクションを追加

## テスト
- [x] リンターエラーなし
- [x] すべてのcodecエントリーポイントが適切にラップされていることを確認

## 関連Issue
#166