### PR TITLE
Add property-based tests for resize, crop, and rotate operations (#177)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,6 +435,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,7 +521,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
 dependencies = [
  "byteorder-lite",
- "quick-error",
+ "quick-error 2.0.1",
 ]
 
 [[package]]
@@ -605,6 +626,7 @@ dependencies = [
  "mozjpeg",
  "napi",
  "napi-derive",
+ "proptest",
  "rayon",
  "tempfile",
  "thiserror 1.0.69",
@@ -997,6 +1019,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1004,6 +1045,12 @@ checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-error"
@@ -1033,8 +1080,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1044,7 +1101,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1054,6 +1121,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1084,8 +1169,8 @@ dependencies = [
  "once_cell",
  "paste",
  "profiling",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "scan_fmt",
  "simd_helpers",
  "system-deps",
@@ -1169,6 +1254,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -1433,6 +1530,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1460,6 +1563,15 @@ name = "version-compare"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ tikv-jemallocator = { version = "0.6", optional = true, features = ["disable_ini
 
 [dev-dependencies]
 criterion = "0.5"
+proptest = "1.4"
 
 [[bench]]
 name = "benchmark"

--- a/tests/property_based.rs
+++ b/tests/property_based.rs
@@ -1,0 +1,252 @@
+use image::{DynamicImage, GenericImageView, RgbImage};
+use lazy_image::engine::{apply_ops, calc_resize_dimensions};
+use lazy_image::ops::{Operation, ResizeFit};
+use proptest::prelude::*;
+use std::borrow::Cow;
+
+fn create_test_image(width: u32, height: u32) -> DynamicImage {
+    DynamicImage::ImageRgb8(RgbImage::from_fn(width, height, |x, y| {
+        image::Rgb([(x % 256) as u8, (y % 256) as u8, 128])
+    }))
+}
+
+fn valid_crop_strategy() -> impl Strategy<Value = (u32, u32, u32, u32, u32, u32)> {
+    (1u32..=64, 1u32..=64)
+        .prop_flat_map(|(img_w, img_h)| {
+            let crop_w = 1u32..=img_w;
+            let crop_h = 1u32..=img_h;
+            (Just(img_w), Just(img_h), crop_w, crop_h)
+        })
+        .prop_flat_map(|(img_w, img_h, crop_w, crop_h)| {
+            let max_x = img_w - crop_w;
+            let max_y = img_h - crop_h;
+            (
+                Just(img_w),
+                Just(img_h),
+                Just(crop_w),
+                Just(crop_h),
+                0u32..=max_x,
+                0u32..=max_y,
+            )
+        })
+}
+
+fn invalid_crop_strategy() -> impl Strategy<Value = (u32, u32, u32, u32, u32, u32)> {
+    (1u32..=64, 1u32..=64)
+        .prop_flat_map(|(img_w, img_h)| {
+            let crop_w = 1u32..=img_w;
+            let crop_h = 1u32..=img_h;
+            (Just(img_w), Just(img_h), crop_w, crop_h)
+        })
+        .prop_flat_map(|(img_w, img_h, crop_w, crop_h)| {
+            let min_x = img_w - crop_w + 1;
+            let min_y = img_h - crop_h + 1;
+            prop_oneof![
+                (
+                    Just(img_w),
+                    Just(img_h),
+                    Just(crop_w),
+                    Just(crop_h),
+                    min_x..=img_w,
+                    Just(0u32),
+                ),
+                (
+                    Just(img_w),
+                    Just(img_h),
+                    Just(crop_w),
+                    Just(crop_h),
+                    Just(0u32),
+                    min_y..=img_h,
+                ),
+            ]
+        })
+}
+
+fn rotate_angle_strategy() -> impl Strategy<Value = i32> {
+    prop_oneof![
+        Just(0),
+        Just(90),
+        Just(180),
+        Just(270),
+        Just(-90),
+        Just(-180),
+        Just(-270),
+    ]
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 64,
+        .. ProptestConfig::default()
+    })]
+
+    #[test]
+    fn prop_resize_inside_matches_calc(
+        orig_w in 1u32..=64,
+        orig_h in 1u32..=64,
+        target_w in 0u32..=64,
+        target_h in 0u32..=64,
+    ) {
+        let img = create_test_image(orig_w, orig_h);
+        let (calc_w, calc_h) = calc_resize_dimensions(orig_w, orig_h, Some(target_w), Some(target_h));
+        let ops = vec![Operation::Resize {
+            width: Some(target_w),
+            height: Some(target_h),
+            fit: ResizeFit::Inside,
+        }];
+        let result = apply_ops(Cow::Owned(img), &ops);
+
+        if calc_w == 0 || calc_h == 0 {
+            prop_assert!(result.is_err());
+        } else {
+            let resized = result.unwrap();
+            prop_assert_eq!(resized.dimensions(), (calc_w, calc_h));
+            prop_assert!(calc_w <= target_w);
+            prop_assert!(calc_h <= target_h);
+        }
+    }
+
+    #[test]
+    fn prop_resize_width_only_matches_calc(
+        orig_w in 1u32..=64,
+        orig_h in 1u32..=64,
+        target_w in 0u32..=64,
+    ) {
+        let img = create_test_image(orig_w, orig_h);
+        let (calc_w, calc_h) = calc_resize_dimensions(orig_w, orig_h, Some(target_w), None);
+        let ops = vec![Operation::Resize {
+            width: Some(target_w),
+            height: None,
+            fit: ResizeFit::Inside,
+        }];
+        let result = apply_ops(Cow::Owned(img), &ops);
+
+        if calc_w == 0 || calc_h == 0 {
+            prop_assert!(result.is_err());
+        } else {
+            let resized = result.unwrap();
+            prop_assert_eq!(resized.dimensions(), (calc_w, calc_h));
+            prop_assert_eq!(resized.dimensions().0, target_w);
+        }
+    }
+
+    #[test]
+    fn prop_resize_height_only_matches_calc(
+        orig_w in 1u32..=64,
+        orig_h in 1u32..=64,
+        target_h in 0u32..=64,
+    ) {
+        let img = create_test_image(orig_w, orig_h);
+        let (calc_w, calc_h) = calc_resize_dimensions(orig_w, orig_h, None, Some(target_h));
+        let ops = vec![Operation::Resize {
+            width: None,
+            height: Some(target_h),
+            fit: ResizeFit::Inside,
+        }];
+        let result = apply_ops(Cow::Owned(img), &ops);
+
+        if calc_w == 0 || calc_h == 0 {
+            prop_assert!(result.is_err());
+        } else {
+            let resized = result.unwrap();
+            prop_assert_eq!(resized.dimensions(), (calc_w, calc_h));
+            prop_assert_eq!(resized.dimensions().1, target_h);
+        }
+    }
+
+    #[test]
+    fn prop_crop_within_bounds_succeeds(
+        params in valid_crop_strategy(),
+    ) {
+        let (img_w, img_h, crop_w, crop_h, x, y) = params;
+        let img = create_test_image(img_w, img_h);
+        let ops = vec![Operation::Crop {
+            x,
+            y,
+            width: crop_w,
+            height: crop_h,
+        }];
+        let result = apply_ops(Cow::Owned(img), &ops).unwrap();
+        prop_assert_eq!(result.dimensions(), (crop_w, crop_h));
+    }
+
+    #[test]
+    fn prop_crop_out_of_bounds_errors(
+        params in invalid_crop_strategy(),
+    ) {
+        let (img_w, img_h, crop_w, crop_h, x, y) = params;
+        let img = create_test_image(img_w, img_h);
+        let ops = vec![Operation::Crop {
+            x,
+            y,
+            width: crop_w,
+            height: crop_h,
+        }];
+        let result = apply_ops(Cow::Owned(img), &ops);
+        prop_assert!(result.is_err());
+    }
+
+    #[test]
+    fn prop_rotate_valid_angles_preserve_dimensions(
+        orig_w in 1u32..=64,
+        orig_h in 1u32..=64,
+        degrees in rotate_angle_strategy(),
+    ) {
+        let img = create_test_image(orig_w, orig_h);
+        let ops = vec![Operation::Rotate { degrees }];
+        let result = apply_ops(Cow::Owned(img), &ops).unwrap();
+
+        let swaps = matches!(degrees, 90 | -90 | 270 | -270);
+        let expected = if swaps {
+            (orig_h, orig_w)
+        } else {
+            (orig_w, orig_h)
+        };
+        prop_assert_eq!(result.dimensions(), expected);
+    }
+
+    #[test]
+    fn prop_rotate_invalid_angles_error(
+        orig_w in 1u32..=64,
+        orig_h in 1u32..=64,
+        degrees in (-360i32..=360).prop_filter("invalid rotation", |d| {
+            !matches!(*d, 0 | 90 | 180 | 270 | -90 | -180 | -270)
+        }),
+    ) {
+        let img = create_test_image(orig_w, orig_h);
+        let ops = vec![Operation::Rotate { degrees }];
+        let result = apply_ops(Cow::Owned(img), &ops);
+        prop_assert!(result.is_err());
+    }
+
+    #[test]
+    fn prop_rotate_180_commutes_with_fill_resize(
+        orig_w in 1u32..=32,
+        orig_h in 1u32..=32,
+        target_w in 1u32..=32,
+        target_h in 1u32..=32,
+    ) {
+        let ops_a = vec![
+            Operation::Rotate { degrees: 180 },
+            Operation::Resize {
+                width: Some(target_w),
+                height: Some(target_h),
+                fit: ResizeFit::Fill,
+            },
+        ];
+        let ops_b = vec![
+            Operation::Resize {
+                width: Some(target_w),
+                height: Some(target_h),
+                fit: ResizeFit::Fill,
+            },
+            Operation::Rotate { degrees: 180 },
+        ];
+
+        let out_a = apply_ops(Cow::Owned(create_test_image(orig_w, orig_h)), &ops_a).unwrap().into_owned();
+        let out_b = apply_ops(Cow::Owned(create_test_image(orig_w, orig_h)), &ops_b).unwrap().into_owned();
+
+        prop_assert_eq!(out_a.dimensions(), out_b.dimensions());
+        prop_assert_eq!(out_a.to_rgba8().into_raw(), out_b.to_rgba8().into_raw());
+    }
+}


### PR DESCRIPTION
## 概要
プロパティベーステストを追加しました。

## 変更内容
- クレートをdev-dependenciesに追加
- に以下のプロパティテストを追加:
  - リサイズ操作のテスト（inside fit、width only、height only）
  - クロップ操作のテスト（有効/無効な範囲）
  - 回転操作のテスト（有効/無効な角度、可換性）

## テスト結果
すべてのプロパティテスト（8件）が正常に通過しました。

## 関連Issue
#177