### PR TITLE
feat: Add quality/effort/speed mapping documentation and refactor (#185)

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,8 @@ Each format has an optimal default quality based on its compression characterist
 | **WebP** | 80 | 70-90 | Balanced quality and file size |
 | **AVIF** | 60 | 50-80 | High compression efficiency means lower quality still looks great |
 
+See `docs/QUALITY_EFFORT_SPEED_MAPPING.md` for the exact quality/effort/speed mapping and cross-format equivalence tables.
+
 **Why different defaults?**
 - **JPEG (85)**: JPEG benefits from higher quality to avoid compression artifacts
 - **WebP (80)**: WebP's superior compression allows good quality at 80

--- a/docs/QUALITY_EFFORT_SPEED_MAPPING.md
+++ b/docs/QUALITY_EFFORT_SPEED_MAPPING.md
@@ -1,0 +1,40 @@
+# Quality / Effort / Speed Mapping
+
+This document freezes how `QualitySettings` converts a quality value (0-100) into encoder parameters. The quality bands are shared across formats so the same number yields the same banded behavior.
+
+## Shared Quality Bands
+
+| Band | Quality range | Goal | AVIF speed | Notes |
+| --- | --- | --- | --- | --- |
+| High | 85-100 | Visual fidelity first | 6 | Lowest noise, best detail |
+| Balanced | 70-84 | Quality/latency balance | 7 | Default “high quality” tier |
+| Fast | 50-69 | Size/throughput oriented | 8 | Keep quality reasonable while speeding up |
+| Fastest | 0-49 | Lowest latency | 9 | Prioritize speed over fidelity |
+
+## Format-specific mapping
+
+### JPEG (mozjpeg)
+- `fast_mode: false` (default) enables aggressive quality optimizations.
+- `fast_mode: true` matches sharp/libjpeg-turbo speed profile.
+- Smoothing: 90+ → 0, 70-89 → 5, 60-69 → 10, 0-59 → 18.
+
+### WebP
+- `method: 4`, `pass: 1`, `preprocessing: 0` are fixed (sharp-equivalent).
+- `sns_strength`: High=50 / Balanced=70 / Fast & Fastest=80.
+- `filter_strength`: >=80 -> 20, 60-79 -> 30, <=59 -> 40 (keeps sharp-style cutoffs).
+- `filter_sharpness`: High=2 / others=0.
+
+### AVIF (libavif speed)
+- Speed ranges 0 (slowest/best) to 10 (fastest/worst).
+- Mapping: High=6, Balanced=7, Fast=8, Fastest=9.
+
+## Cross-format quality equivalence (guidance)
+
+| Intent | JPEG | WebP | AVIF (speed) | Notes |
+| --- | --- | --- | --- | --- |
+| High detail | 90-95 | 85-90 | 70-80 (6-7) | Preserve fine details |
+| Default/general | 82-88 (default 85) | 78-82 (default 80) | 60-70 (8) | Matches README defaults |
+| Fast delivery | 70-80 | 68-75 | 50-60 (8-9) | Favors throughput and size |
+| Lowest latency | 50-65 | 50-65 | 35-55 (9) | Speed over fidelity |
+
+These ranges are based on current tests/benchmarks; using the same numeric quality keeps behavior stable per band.


### PR DESCRIPTION
## 概要
品質/エフォート/スピードマッピングのドキュメントを追加し、コードをリファクタリングしました。

## 変更内容
- `docs/QUALITY_EFFORT_SPEED_MAPPING.md` を追加
  - 品質帯域（High/Balanced/Fast/Fastest）の定義
  - フォーマット別（JPEG/WebP/AVIF）のマッピング
  - クロスフォーマット品質等価表
- `src/engine/encoder.rs` をリファクタリング
  - `QualityBand` enum を追加して品質帯域を明確化
  - `band()` メソッドで品質帯域を判定
  - `webp_sns_strength()`, `webp_filter_sharpness()`, `avif_speed()` を match 式でリファクタリング
  - 品質帯域の境界値テストと WebP マッピングの安定性テストを追加
- `README.md` を更新
  - Quality Settings セクションにドキュメントへのリンクを追加

## テスト
- 全てのテストがパス
- リンターエラーなし
