### PR TITLE
feat: unify metrics measurement (#182)

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,8 @@ console.log(metrics);
 // }
 ```
 
+詳しい計測境界と保証事項は `docs/METRICS_CONTRACT.md` を参照してください。
+
 ### Batch Processing (v0.6.0+)
 
 ```javascript

--- a/docs/METRICS_CONTRACT.md
+++ b/docs/METRICS_CONTRACT.md
@@ -1,0 +1,22 @@
+# Metrics Contract (decode / ops / encode)
+
+## 計測境界
+- **decode_time (ms)**: `decode_internal()` 開始からデコード完了まで。入力バイトを画像に起こす処理のみを計測。
+- **process_time (ms)**: デコード完了直後から `apply_ops` 完了まで。リサイズや回転などのオペレーションのみを計測。
+- **encode_time (ms)**: エンコード開始からバイト列生成完了まで。形式変換や圧縮を含む。
+- **processing_time (s)**: パイプライン開始から終了までのウォールクロック。`decode+process+encode` の合算を必ず包含する（同一 `Instant` 基準）。
+
+## リソース系
+- **cpu_time (s)**: `getrusage()` で取得した CPU 時間差分。取得できない環境では 0。
+- **memory_peak (bytes)**: `ru_maxrss` を優先。取得不可の場合は `width*height*4 + output_size` で概算し、`u32::MAX` にクランプ。
+
+## サイズ系
+- **input_size (bytes)**: 入力ソースのバイト長（u32 クランプ）。
+- **output_size (bytes)**: エンコード結果のバイト長（u32 クランプ）。
+- **compression_ratio**: `output_size / input_size`。入力サイズが 0 の場合は 0。
+
+## 保障事項
+1) すべての時間計測は単一の `Instant` 基準で測定し、`processing_time` は decode/process/encode 区間を必ず包含する。  
+2) 数値は非負。`decode_time + process_time + encode_time > 0` の場合、`processing_time*1000` はその合計以上になる。  
+3) メタデータ（input/output/compression_ratio/cpu_time/memory_peak）は、計測可能な範囲で常に埋められる。取得不可項目は 0 にフォールバック。  
+4) フォーマットやオプションにかかわらず測定の粒度・順序は一定。

--- a/test/integration/edge-cases.test.js
+++ b/test/integration/edge-cases.test.js
@@ -462,6 +462,16 @@ async function runTests() {
         assert(result.metrics.inputSize > 0, 'inputSize should be positive');
         assert(result.metrics.outputSize > 0, 'outputSize should be positive');
         assert(result.metrics.compressionRatio >= 0, 'compressionRatio should be non-negative');
+
+        // Contract: processingTime should encompass decode+process+encode (same Instant baseline)
+        const stageMs =
+            result.metrics.decodeTime + result.metrics.processTime + result.metrics.encodeTime;
+        const totalMs = result.metrics.processingTime * 1000;
+        assert(stageMs > 0, 'sum of decode/process/encode should be positive');
+        assert(
+            totalMs + 5 >= stageMs,
+            'processingTime must include decode+process+encode (allow slight scheduling drift)'
+        );
     });
 
     await asyncTest('toBufferWithMetrics handles input_size=0 gracefully', async () => {


### PR DESCRIPTION
## 概要
メトリクス測定を一元化し、計測境界と保証事項を明確化しました。

## 変更内容
- `MetricsRecorder` 構造体を追加してメトリクス測定を一元化
- `process_and_encode` メソッドをリファクタリングして `MetricsRecorder` を使用
- `docs/METRICS_CONTRACT.md` を追加して計測境界と保証事項を文書化
- `processingTime` が各ステージ（decode+process+encode）を包含することを検証するテストを追加
- README.md に `METRICS_CONTRACT.md` への参照を追加

## 技術的詳細
- すべての時間計測は単一の `Instant` 基準で測定
- `processing_time` は decode/process/encode 区間を必ず包含
- メトリクス測定ロジックを一箇所に集約することで保守性を向上

## テスト
- 既存のテストはすべて通過
- 新しいテストで `processingTime` の包含関係を検証