### PR TITLE
docs: Document Windows mmap file deletion limitation and recommended usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -942,9 +942,9 @@ ICC color profiles are automatically extracted and embedded during processing.
 **Impact**: If you use `fromPath()` to process a file and then try to delete or replace that file while the `ImageEngine` instance is still in scope, the operation will fail on Windows.
 
 **Recommended usage (Windows)**:
-- 処理中は元ファイルを変更・削除しない。エンジンのスコープ終了（drop）を待ってから削除する。
-- 直後に削除したい場合は `fs.readFileSync` → `ImageEngine.from(buffer)` でヒープ経路を使うか、一時ディレクトリにコピーしてから処理・削除する。
-- `processBatch()` でも同様に、バッチ終了まで入力ファイルを残す。
+- Do not modify or delete the source file while processing. Wait for the engine to be dropped (out of scope) before deleting.
+- If you need to delete immediately after processing, use `fs.readFileSync` → `ImageEngine.from(buffer)` to use the heap path, or copy to a temporary directory before processing and deletion.
+- For `processBatch()`, similarly keep input files until batch completion.
 
 **Example**:
 ```javascript


### PR DESCRIPTION
## Summary

This PR documents the Windows-specific limitation where memory-mapped files cannot be deleted while they are mapped, and provides recommended usage patterns.

## Changes

- **README.md**: Added recommended usage patterns for Windows in the "Platform Notes" section
- **docs/ZERO_COPY.md**: Added Windows-specific safe usage pattern examples

## Details

On Windows, memory-mapped files cannot be deleted while they are mapped. This is a platform limitation of Windows' memory mapping implementation.

The documentation now includes:
- Clear explanation of the limitation
- Recommended usage patterns (wait for engine drop, use Buffer path, or copy to temp directory)
- Code examples showing safe patterns for immediate deletion, temp file processing, and batch processing

## Related

Closes #168