### PR TITLE
refactor: Unify processing policies across formats (metadata/color/error handling) #176

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -34,6 +34,8 @@ export interface BatchResult {
   errorCode?: string
   errorCategory?: ErrorCategory
 }
+/** Helper to extract ErrorCategory from lazy-image errors (or null otherwise). */
+export declare function getErrorCategory(err: unknown): ErrorCategory | null
 /**
  * Error taxonomy for proper error handling in JavaScript
  *
@@ -53,10 +55,6 @@ export const enum ErrorCategory {
   /** Library bugs (should not happen) */
   InternalBug = 3
 }
-
-/** Extract ErrorCategory from a thrown error or returns null if unavailable */
-export declare function getErrorCategory(err: unknown): ErrorCategory | null
-
 /** Image metadata returned by inspect() */
 export interface ImageMetadata {
   /** Image width in pixels */

--- a/src/codecs/avif_safe.rs
+++ b/src/codecs/avif_safe.rs
@@ -275,10 +275,10 @@ impl SafeAvifRwData {
         }
     }
 
-    /// Copy the encoded data into a Vec<u8>.
+    /// Copy the encoded data into a `Vec<u8>`.
     ///
     /// # Returns
-    /// Returns a Vec<u8> containing a copy of the encoded AVIF data.
+    /// Returns a `Vec<u8>` containing a copy of the encoded AVIF data.
     pub fn to_vec(&self) -> Vec<u8> {
         self.as_slice().to_vec()
     }

--- a/src/engine/decoder.rs
+++ b/src/engine/decoder.rs
@@ -78,7 +78,7 @@ pub fn decode_with_image_crate(data: &[u8]) -> DecoderResult<DynamicImage> {
     })
 }
 
-/// Decode PNG using zune-png (SIMD最適化デコーダ)。16bit入力は8bitへダウンサンプル。
+/// Decode PNG using zune-png (SIMD-optimized decoder). 16-bit input is downsampled to 8-bit.
 /// Falls back to image crate if:
 /// - Image dimensions exceed zune-png's limit (16,384px)
 /// - Unsupported colorspace (e.g., YCbCr)
@@ -92,7 +92,7 @@ pub fn decode_png_zune(data: &[u8]) -> DecoderResult<DynamicImage> {
 
         // Try to read dimensions from PNG header without full decode
         if let Ok((width, height)) = read_png_dimensions(data) {
-            // Global safety check (DoS防止)
+            // Global safety check (avoid decompression bombs)
             check_dimensions(width, height)?;
 
             if width > ZUNE_PNG_MAX_DIM || height > ZUNE_PNG_MAX_DIM {
@@ -134,19 +134,21 @@ pub fn decode_png_zune(data: &[u8]) -> DecoderResult<DynamicImage> {
             ColorSpace::RGB => RgbImage::from_raw(width, height, buf)
                 .map(DynamicImage::ImageRgb8)
                 .ok_or_else(|| LazyImageError::decode_failed("png: failed to build RGB image"))?,
-            ColorSpace::RGBA | ColorSpace::BGRA | ColorSpace::ARGB => {
-                RgbaImage::from_raw(width, height, buf)
-                    .map(DynamicImage::ImageRgba8)
-                    .ok_or_else(|| {
-                        LazyImageError::decode_failed("png: failed to build RGBA image")
-                    })?
-            }
+            ColorSpace::RGBA => RgbaImage::from_raw(width, height, buf)
+                .map(DynamicImage::ImageRgba8)
+                .ok_or_else(|| LazyImageError::decode_failed("png: failed to build RGBA image"))?,
             ColorSpace::Luma => GrayImage::from_raw(width, height, buf)
                 .map(DynamicImage::ImageLuma8)
                 .ok_or_else(|| LazyImageError::decode_failed("png: failed to build Luma image"))?,
             ColorSpace::LumaA => GrayAlphaImage::from_raw(width, height, buf)
                 .map(DynamicImage::ImageLumaA8)
                 .ok_or_else(|| LazyImageError::decode_failed("png: failed to build LumaA image"))?,
+            // Fallback to image crate for unsupported ordering/space
+            ColorSpace::BGRA | ColorSpace::ARGB => {
+                return Err(LazyImageError::decode_failed(
+                    "png: BGRA/ARGB not supported by zune-png, fallback to image crate",
+                ));
+            }
             // YCbCr is 3-channel, not compatible with RGBA (4-channel)
             // Fallback to image crate for proper handling
             ColorSpace::YCbCr | ColorSpace::YCCK => {

--- a/src/engine/io.rs
+++ b/src/engine/io.rs
@@ -19,7 +19,7 @@ pub enum Source {
 
 impl Source {
     /// Load the actual bytes from the source
-    /// Note: For Mapped sources, this converts to Vec<u8> (defeats zero-copy).
+    /// Note: For Mapped sources, this converts to `Vec<u8>` (defeats zero-copy).
     /// Prefer using as_bytes() for zero-copy access when possible.
     #[deprecated(
         note = "Use as_bytes() for zero-copy access. This method defeats zero-copy by converting Mapped to Vec<u8>."


### PR DESCRIPTION
## 概要
フォーマット間で処理ポリシー（メタデータ/色/エラーハンドリング）を統一しました。

## 変更内容
- **次元バリデーションの統一**: `validate_encode_dimensions()` と `validate_buffer_len()` 関数を追加
- **エンコーダーの統一**: すべてのエンコーダー（JPEG、PNG、WebP、AVIF）で一貫したバリデーションを使用
- **デコーダーの統一**: 重複していた次元チェックを削除し、`check_dimensions()` に統一
- **WebPエンコーダーの改善**: アルファチャンネルを適切に処理するように改善
- **エラーハンドリングの統一**: すべてのフォーマットのエンコーダー/デコーダーで一貫したエラーハンドリング

## テスト
- すべてのユニットテストが成功
- リントエラーなし