### PR TITLE
docs: Resolve AVIF ICC profile documentation contradiction #256

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Memory semaphore switched to `parking_lot` mutex/condvar for reduced contention under load; added contention benchmark (#241)
 - Added ColorState tracking for pipeline operations (color space / bit depth / transfer / ICC) to prepare for safer color-handling (#169)
+- Documentation corrected: AVIF now preserves ICC profiles in v0.9.0+ via libavif-sys; pre-0.9.0 ravif-only builds still drop ICC (#256)
 
 ---
 


### PR DESCRIPTION
## Summary

This PR resolves the documentation contradiction regarding AVIF ICC profile preservation.

## Changes

- Updated CHANGELOG.md to clarify that AVIF preserves ICC profiles in v0.9.0+ via libavif-sys
- Updated README.md to reflect AVIF ICC support (multiple sections)
- Unified all documentation to English (removed Japanese text)

## Details

- AVIF now preserves ICC profiles in v0.9.0+ (libavif-sys backend)
- Legacy builds (<0.9.0 or ravif-only) still drop ICC
- All documentation is now consistently in English

Closes #256