### PR TITLE
docs: Clarify disk-buffered streaming naming in API #260

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Memory semaphore switched to `parking_lot` mutex/condvar for reduced contention under load; added contention benchmark (#241)
 - Added ColorState tracking for pipeline operations (color space / bit depth / transfer / ICC) to prepare for safer color-handling (#169)
+- Docs: Clarified `createStreamingPipeline()` is disk-backed bounded-memory (not true chunk streaming); name retained for compatibility (#260)
 - Documentation corrected: AVIF now preserves ICC profiles in v0.9.0+ via libavif-sys; pre-0.9.0 ravif-only builds still drop ICC (#256)
 
 ---

--- a/README.md
+++ b/README.md
@@ -648,7 +648,7 @@ try {
 }
 ```
 
-#### Streaming (bounded-memory, disk-backed)
+#### Streaming (disk-backed, bounded-memory)
 
 ```javascript
 const { createStreamingPipeline } = require('@alberteinshutoin/lazy-image');
@@ -667,7 +667,9 @@ readable.on('finish', () => console.log('done'));
 readable.on('error', console.error);
 ```
 
-> Note: This pipeline uses disk-backed streaming to keep memory usage near O(1). The API will remain backward-compatible for future true streaming encoding support.
+> What this does: stages input to a temp file, processes via `ImageEngine.fromPath`, and streams the encoded result from another temp file.  
+> What this does **not** do: real-time chunked encoding; latency includes downloading to disk first.  
+> Naming: kept as `createStreamingPipeline()` for compatibility; a future true streaming encoder will be exposed as a separate API.
 
 #### Rust
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -302,4 +302,8 @@ export interface StreamingPipeline {
   readable: NodeJS.ReadableStream
 }
 
+/**
+ * Disk-backed, bounded-memory helper that stages input to temp files before encoding.
+ * Not a true chunk-by-chunk encoder; kept for backward compatibility.
+ */
 export function createStreamingPipeline(options?: StreamingPipelineOptions): StreamingPipeline

--- a/streaming/pipeline.js
+++ b/streaming/pipeline.js
@@ -4,9 +4,13 @@ const os = require('os');
 const { PassThrough } = require('stream');
 
 /**
- * Create a streaming processor that accepts a Writable input stream and exposes a Readable output stream.
- * Internally it stages input to a temp file (bounded memory), then processes via ImageEngine.fromPath,
- * writes to another temp file, and streams the result out.
+ * Create a disk-backed, bounded-memory pipeline that accepts a Writable input stream
+ * and exposes a Readable output stream.
+ *
+ * Notes:
+ * - This is NOT true chunk-by-chunk encoding; input is staged to a temp file first.
+ * - Memory stays ~O(1) while disk usage mirrors input/output sizes.
+ * - Name is kept for backward compatibility; future true streaming APIs will be additive.
  *
  * options:
  * - format: 'jpeg' | 'png' | 'webp' | 'avif'


### PR DESCRIPTION
Clarifies that `createStreamingPipeline()` is disk-backed bounded-memory (not true chunk streaming); name retained for compatibility.

## Changes
- Updated README.md to clarify streaming pipeline behavior
- Added JSDoc comments to `createStreamingPipeline()` in index.d.ts and pipeline.js
- Updated CHANGELOG.md with documentation clarification

## Summary
This PR clarifies that the streaming pipeline is not a true chunk-by-chunk encoder, but rather a disk-backed, bounded-memory helper that stages input to temp files before encoding. The naming is kept for backward compatibility, and future true streaming APIs will be additive.