### PR TITLE
docs: Unify README.md language (remove mixed Japanese/English) #255

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Docs: Clarified `createStreamingPipeline()` is disk-backed bounded-memory (not true chunk streaming); name retained for compatibility (#260)
 - Documentation corrected: AVIF now preserves ICC profiles in v0.9.0+ via libavif-sys; pre-0.9.0 ravif-only builds still drop ICC (#256)
 - Docs: README positioning strengthened with security defaults, zero-copy definition, and measurable RSS/heap targets (#195)
+- Docs: README fully English; added `README.ja.md` for Japanese summary (#255)
 
 ---
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,35 @@
+# lazy-image 🦀 (日本語サマリー)
+
+英語版 README が正です。このファイルは主要ポイントの日本語サマリーです。詳細・最新情報は必ず [README.md](./README.md) を参照してください。
+
+## 位置付け
+- Web 向け画像最適化に特化した意図的なエンジン
+- まだ sharp のドロップイン代替ではありません（互換 API が必要なら sharp を使用）
+- セキュリティ優先: EXIF/XMP などのメタデータはデフォルトで削除、ICC は色精度のため保持
+- ゼロコピー入力パス: `fromPath()/processBatch()` → `toFile()` で入力ファイルを JS ヒープへコピーしない
+- AVIF の ICC は v0.9.x（libavif-sys）で保持。<0.9.0 や ravif のみ構成では破棄
+
+## 計測可能な指標
+- JS ヒープ増加: `fromPath → toBufferWithMetrics` で **2MB 以下**（`node --expose-gc docs/scripts/measure-zero-copy.js` で検証）
+- RSS 目安: `peak_rss ≤ decoded_bytes + 24MB`（decoded_bytes = width × height × bpp; JPEG bpp=3, PNG/WebP/AVIF bpp=4）。例: 6000×4000 PNG (≈96MB) → 目標 RSS ≤ 120MB
+- 品質ゲート: SSIM ≥ 0.995 / PSNR ≥ 40dB （sharp 出力と比較するベンチで検証）
+
+## 主な特徴
+- AVIF/WebP/JPEG/PNG エンコード（AVIFは高速かつ小サイズ）
+- ICC プロファイル保持（AVIFは v0.9.x 以降）
+- EXIF 自動回転（`autoOrient(false)` で無効化）
+- ディスクバッファ型ストリーミングでメモリを O(1) 近傍に抑制
+- Rust コアによるメモリ安全 & Node.js バインディング (napi-rs)
+
+## 推奨シナリオ
+- CDN/モバイル向けの帯域削減
+- バッチ処理・静的サイト生成
+- メモリ制約環境（512MB コンテナなど）
+- AVIF 生成・色精度重視ワークフロー
+
+## セキュリティと互換性
+- 安全策の詳細とサポートバージョン: [SECURITY.md](./SECURITY.md)
+- 互換性のマトリクスと移行ノート: [docs/COMPATIBILITY.md](./docs/COMPATIBILITY.md)
+
+---
+英語版で更新が先行します。疑問点や翻訳改善の提案は Issue/PR で歓迎します。

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 > - **Security-first defaults**: EXIF/XMP and other metadata are stripped by default; ICC is preserved for color accuracy
 > - **Zero-copy input path**: `fromPath()/processBatch()` → `toFile()` avoids copying source data into the JS heap
 > - **AVIF ICC**: preserved in v0.9.x (libavif-sys); older <0.9.0 or ravif-only builds drop ICC
+>
+> Looking for Japanese? See the Japanese summary in [README.ja.md](./README.ja.md).
 
 [![npm version](https://badge.fury.io/js/@alberteinshutoin%2Flazy-image.svg)](https://www.npmjs.com/package/@alberteinshutoin/lazy-image)
 [![npm downloads](https://img.shields.io/npm/dm/@alberteinshutoin/lazy-image)](https://www.npmjs.com/package/@alberteinshutoin/lazy-image)
@@ -580,17 +582,16 @@ interface OutputWithMetrics {
   metrics: ProcessingMetrics;
 }
 
-## 品質メトリクス (SSIM/PSNR)
+## Quality Metrics (SSIM/PSNR)
 
-lazy-image は sharp との品質パリティを維持するため、ベンチマークで以下の品質ゲートを設けています:
+lazy-image enforces quality parity with sharp via benchmark gates:
 
 - SSIM ≥ 0.995
 - PSNR ≥ 40 dB
 
-`npm run test:js` で実行されるベンチマーク (`test/benchmarks/sharp-comparison.bench.js`) は、同一条件で生成した sharp 出力と比較し、上記閾値を下回ると失敗します。  
-統合テスト `test/integration/quality-metrics.test.js` では品質メトリクス計算の健全性をスモークテストしています。
+`npm run test:js` runs `test/benchmarks/sharp-comparison.bench.js`, comparing outputs against sharp under identical settings; it fails if either metric drops below the thresholds. Integration test `test/integration/quality-metrics.test.js` smoke-tests the metric calculations.
 
-※ 現時点では品質メトリクスは内部ベンチ・テスト専用です。アプリ側で品質指標を取得したい場合は別IssueでAPI公開を検討してください。
+These metrics are currently internal (bench/test only). If you need programmatic access in applications, open an issue to discuss an API surface.
 
 interface BatchResult {
   source: string;
@@ -1079,7 +1080,7 @@ Built on the shoulders of giants:
 - [mozjpeg](https://github.com/mozilla/mozjpeg) - Mozilla's JPEG encoder
 - [libwebp](https://chromium.googlesource.com/webm/libwebp) - Google's WebP codec
 - [ravif](https://github.com/kornelski/ravif) - Pure Rust AVIF encoder
-- [fast_image_resize](https://github.com/Cykooz/fast_image_resize) - SIMD-accelerated resizer（`rayon` feature有効化で並列リサイズ）
+- [fast_image_resize](https://github.com/Cykooz/fast_image_resize) - SIMD-accelerated resizer (enable the `rayon` feature for parallel resize)
 - [img-parts](https://github.com/paolobarbolini/img-parts) - Image container manipulation
 - [napi-rs](https://napi.rs/) - Rust bindings for Node.js
 


### PR DESCRIPTION
## Summary

This PR unifies the README.md language to English only, removing mixed Japanese/English content.

## Changes

- Converted all Japanese text in README.md to English
- Added reference to README.ja.md for Japanese summary
- Created README.ja.md as a Japanese summary document
- Updated CHANGELOG.md with this change

## Details

- Quality Metrics section: Converted from Japanese to English
- Credits section: Converted Japanese comment to English
- Added link to README.ja.md in the main README

All documentation and comments are now unified in English, with Japanese content moved to a separate summary file.

Closes #255