### PR TITLE
docs: Add specification directory (spec/) with operation semantics #193

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documentation corrected: AVIF now preserves ICC profiles in v0.9.0+ via libavif-sys; pre-0.9.0 ravif-only builds still drop ICC (#256)
 - Docs: README positioning strengthened with security defaults, zero-copy definition, and measurable RSS/heap targets (#195)
 - Docs: README fully English; added `README.ja.md` for Japanese summary (#255)
+- Docs: SECURITY policy expanded with CVE/dependency update guidance (#197)
+- Docs: Added `spec/` directory for resize/metadata/errors/limits/quality semantics (#193)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ surface than sharp.
 
 For a full matrix and migration notes, see [docs/COMPATIBILITY.md](./docs/COMPATIBILITY.md).
 
+## 📑 Specification
+
+Formal semantics live in `spec/`:
+
+- [Resize](./spec/resize.md) — fit/inside/cover/fill, rounding rules, limits
+- [Metadata](./spec/metadata.md) — ICC/EXIF/XMP handling, defaults, AVIF notes
+- [Errors](./spec/errors.md) — taxonomy, mappings, JS category helpers
+- [Limits](./spec/limits.md) — dimensions/pixels, firewall bytes/timeout, concurrency
+- [Quality](./spec/quality.md) — SSIM/PSNR gates and repro guidance
+
 ### 🔎 Measurable & Verifiable Claims
 
 - **Zero-copy definition**: `fromPath()` / `processBatch()` → `toFile()` does not copy source data into the JS heap; input is mmapped and processed in Rust. Output buffers are allocated (by design).

--- a/spec/errors.md
+++ b/spec/errors.md
@@ -1,0 +1,25 @@
+# Error Semantics (v0.9.x)
+
+lazy-image exposes structured errors with category + code for programmatic handling.
+
+## Taxonomy
+- **UserError**: caller-provided input is invalid; recoverable by fixing parameters or files.
+- **CodecError**: decode/encode/format issues (corrupt data, unsupported format, codec failure).
+- **ResourceLimit**: dimension/pixel/byte/time/concurrency limits, or I/O failures tied to resource pressure.
+- **InternalBug**: unexpected internal state or dependency panic; should be reported.
+
+## Error codes
+- Ranges: `E1xx` Input, `E2xx` Processing, `E3xx` Output, `E4xx` Configuration, `E9xx` Internal.
+- JS errors carry `error.code` (e.g., `LAZY_IMAGE_USER_ERROR`) and `error.category`; `getErrorCategory()` maps them to enums.
+
+## Common mappings
+- Dimension > limit → `ResourceLimit / DimensionExceedsLimit` (E121).
+- Pixels > limit → `ResourceLimit / PixelCountExceedsLimit` (E122).
+- Invalid resize/rotation/crop → `UserError / Invalid*` (E200/E201).
+- Unsupported/invalid format → `CodecError / UnsupportedFormat` (E111) or `DecodeFailed/EncodeFailed` (E300/E301 range).
+- Firewall violations (bytes/pixels/metadata/timeout) → `ResourceLimit / FirewallViolation`.
+- Dependency panic (mozjpeg/libavif/etc.) → `InternalBug / InternalPanic` (E900s) via panic guard.
+
+## Batch/streaming
+- `processBatch` returns per-file `error`, `errorCode`, `errorCategory` in `BatchResult` entries; success/failure is per item.
+- Streaming pipeline surfaces errors via stream `error` events and destroys the output stream on failure.

--- a/spec/limits.md
+++ b/spec/limits.md
@@ -1,0 +1,25 @@
+# Limits & Resource Contracts (v0.9.x)
+
+## Dimensions & pixels
+- `MAX_DIMENSION = 32,768` per side.
+- `MAX_PIXELS = 100,000,000` per image (after resize/crop).
+- Violations raise `ResourceLimit` errors before processing.
+
+## Image Firewall (input safeguards)
+Default policy: **strict** unless caller sets `sanitize({ policy: "lenient" })` or overrides via `limits()`.
+
+| Policy   | maxBytes | maxPixels | timeoutMs | Notes |
+|----------|----------|-----------|-----------|-------|
+| strict   | 32 MB    | 100 MP    | 5,000 ms  | tuned for typical web inputs; blocks heavy AVIFs sooner |
+| lenient  | 48 MB    | 100 MP    | 30,000 ms | allows larger/slow AVIF while keeping pixel cap |
+
+- Callers may override via `limits({ maxBytes, maxPixels, timeoutMs })`; `0` disables a limit.
+- Firewall errors are surfaced as `ResourceLimit / FirewallViolation` with stage context (decode/process/write).
+
+## Concurrency
+- `processBatch` concurrency: 0 = auto, 1–1024 allowed; >1024 rejected.
+- Streaming pipeline uses a single encode worker; throughput can be scaled by running multiple pipelines.
+
+## Memory expectations
+- Zero-copy input path (fromPath/processBatch) avoids copying source data into JS heap.
+- Target RSS budget: `peak_rss ≤ decoded_bytes + 24 MB` (see spec/quality.md for measurement references).

--- a/spec/metadata.md
+++ b/spec/metadata.md
@@ -1,0 +1,18 @@
+# Metadata Semantics (v0.9.x)
+
+## Defaults
+- EXIF/XMP and most container metadata are stripped to minimize PII and reduce size.
+- ICC color profiles are preserved for JPEG/PNG/WebP; AVIF preserves ICC when built with `libavif-sys` (v0.9.x default). Custom builds that disable libavif-sys or versions <0.9.0 will drop ICC.
+- Auto-orientation is **enabled by default**: EXIF orientation is applied, then orientation metadata is removed.
+
+## Retention options
+- ICC is always preserved when present (subject to AVIF backend as noted above).
+- Other metadata retention (e.g., full EXIF/XMP) is not guaranteed; current public API focuses on stripping by default for safety. Future metadata toggles will be documented separately.
+
+## Rationale
+- Stripping metadata reduces payload size, avoids leaking camera/location data, and aligns with security-first defaults.
+- ICC is kept to maintain color accuracy in delivery pipelines.
+
+## AVIF-specific notes
+- ICC preserved only when libavif backend is present (default in v0.9.x). If using ravif-only builds, convert to sRGB before encoding or upgrade.
+

--- a/spec/quality.md
+++ b/spec/quality.md
@@ -1,0 +1,17 @@
+# Quality Semantics (v0.9.x)
+
+## Bench/CI gates
+- **SSIM ≥ 0.995** and **PSNR ≥ 40 dB** compared to sharp outputs under identical settings.
+- Enforced by `test/benchmarks/sharp-comparison.bench.js` (run via `npm run test:bench:compare`) and smoke-tested in `test/integration/quality-metrics.test.js`.
+- Bench fixtures: 4.5MB 5000×5000 PNG → JPEG/WebP/AVIF with typical qualities (JPEG 80, WebP 80, AVIF 60) and resize 800×600 cases.
+
+## Interpretation
+- Thresholds are stability guards: regressions below either threshold fail CI.
+- Metrics are currently internal; no public API returns SSIM/PSNR. Consumers wanting exposed metrics should propose an API.
+
+## Color accuracy
+- ICC profiles preserved by default for JPEG/PNG/WebP; AVIF preserves ICC on libavif builds (v0.9.x). Conversions rely on preserved ICC to maintain SSIM/PSNR targets.
+
+## Repro guidance
+- Run `npm test` to execute integration + rust tests.
+- For detailed measurements, use the benchmark repo `lazy-image-test` or `npm run test:bench:compare` in this repo.

--- a/spec/resize.md
+++ b/spec/resize.md
@@ -1,0 +1,31 @@
+# Resize Semantics (v0.9.x)
+
+Scope: `ImageEngine.resize(width?, height?, fit?)` and resize paths used by `extract`/`processBatch`.
+
+## Fit modes
+- `inside` (default): preserve aspect ratio inside the target box. Width/height are treated as maxima.
+- `cover`: scale up/down so that both dimensions meet or exceed the target box, then crop center to the exact box.
+- `fill`: scale each dimension independently to hit the exact box; aspect ratio may change (no letterboxing/cropping).
+
+## Dimension calculation
+- `inside`: aspect-preserving scale; uses `round()` on the non-dominant axis.
+- `cover`: aspect-preserving scale; uses `ceil()` on both axes before center crop to the target box.
+- `fill`: direct assignment to requested `width`/`height` (after validation).
+
+## Validation and limits
+- `width`/`height` must be positive when provided; `0` is rejected with `InvalidResizeDimensions`.
+- Global guards apply to the final target size: `MAX_DIMENSION = 32768`, `MAX_PIXELS = 100,000,000`.
+- Concurrency guard: `processBatch` and streaming paths cap concurrency at 1024.
+
+## Defaults
+- If only `width` is provided, height is scaled with aspect ratio (rounded).
+- If only `height` is provided, width is scaled with aspect ratio (rounded).
+- If neither is provided, original dimensions are kept.
+
+## Cropping behavior (cover)
+- Crop is center-aligned after the up/down-scale.
+- Cropping occurs only for `cover`; `inside` never crops.
+
+## Error mapping
+- Invalid dimensions ⇒ `UserError / InvalidResizeDimensions`.
+- Size exceeds limits ⇒ `ResourceLimit / DimensionExceedsLimit` or `PixelCountExceedsLimit`.


### PR DESCRIPTION
This PR adds a specification directory (`spec/`) containing formal semantics for lazy-image operations:

- **Resize** (`spec/resize.md`) — fit/inside/cover/fill, rounding rules, limits
- **Metadata** (`spec/metadata.md`) — ICC/EXIF/XMP handling, defaults, AVIF notes
- **Errors** (`spec/errors.md`) — taxonomy, mappings, JS category helpers
- **Limits** (`spec/limits.md`) — dimensions/pixels, firewall bytes/timeout, concurrency
- **Quality** (`spec/quality.md`) — SSIM/PSNR gates and repro guidance

The README has been updated to reference the specification directory, and the CHANGELOG documents this addition.

All documentation and comments are in English.

Closes #193