### PR TITLE
ci: Add Node.js version matrix (18, 20, 22) to CI #268

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -124,7 +124,7 @@ jobs:
       # The napi_tests.rs file exists for local development with Node.js installed.
 
   test:
-    name: Test
+    name: Test (Node ${{ matrix.node }})
     needs: build
     strategy:
       fail-fast: false
@@ -136,6 +136,7 @@ jobs:
             artifact: bindings-aarch64-apple-darwin
           - host: windows-latest
             artifact: bindings-x86_64-pc-windows-msvc
+        node: [18, 20, 22]
 
     runs-on: ${{ matrix.settings.host }}
     timeout-minutes: 20
@@ -146,7 +147,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ matrix.node }}
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
This PR adds a Node.js version matrix (18, 20, 22) to the CI test job to ensure compatibility across multiple Node.js versions.

## Changes
- Added Node.js version matrix [18, 20, 22] to the test job
- Updated test job name to include Node.js version: `Test (Node \${{ matrix.node }})`
- Updated Node.js setup step to use `\${{ matrix.node }}` instead of hardcoded version 20

## Testing
The CI will now run tests on Node.js 18, 20, and 22 across all platforms (Ubuntu, macOS, Windows).