### PR TITLE
refactor: Strengthen AVIF safe abstractions with NonNull and enhanced linting #200

### DIFF
--- a/src/engine/encoder.rs
+++ b/src/engine/encoder.rs
@@ -609,13 +609,15 @@ pub fn encode_avif(img: &DynamicImage, quality: u8, icc: Option<&[u8]>) -> Encod
                 .map_err(|e| LazyImageError::encode_failed("avif".to_string(), e.to_string()))?;
 
             unsafe {
-                let alpha_plane = avif_image.alpha_plane_mut();
+                let alpha_plane = avif_image.alpha_plane_mut().map_err(|e| {
+                    LazyImageError::encode_failed("avif".to_string(), e.to_string())
+                })?;
                 let alpha_row_bytes = avif_image.alpha_row_bytes();
                 for y in 0..height as usize {
                     for x in 0..width as usize {
                         let src_idx = (y * width as usize + x) * 4 + 3;
                         let dst_idx = y * alpha_row_bytes + x;
-                        *alpha_plane.add(dst_idx) = pixels[src_idx];
+                        *alpha_plane.as_ptr().add(dst_idx) = pixels[src_idx];
                     }
                 }
             }

--- a/src/engine/pipeline.rs
+++ b/src/engine/pipeline.rs
@@ -3,9 +3,7 @@
 // Pipeline operations: apply_ops, optimize_ops, resize calculations
 
 use crate::error::LazyImageError;
-use crate::ops::{
-    Operation, OperationContract, OperationEffect, OperationRequirement, ResizeFit,
-};
+use crate::ops::{Operation, OperationContract, OperationEffect, OperationRequirement, ResizeFit};
 use fast_image_resize::{self as fir, ImageBufferError, MulDiv, PixelType, ResizeOptions};
 use image::{DynamicImage, RgbImage, RgbaImage};
 use std::borrow::Cow;


### PR DESCRIPTION
## Summary

This PR strengthens the AVIF safe abstractions by replacing raw pointers with `NonNull` types and adding enhanced linting rules.

## Changes

- **Type Safety**: Replace raw pointers (`*mut avifImage`, `*mut avifEncoder`) with `Option<NonNull<>>` for better type safety and null pointer prevention
- **Enhanced Linting**: Add `#![deny(unsafe_op_in_unsafe_fn)]` to enforce safe unsafe block usage
- **Error Handling**: Improve error handling with proper null checks using `NonNull::new()`
- **Test Support**: Add `take_raw_for_test()` methods for test scenarios requiring manual pointer management
- **API Improvements**: Update `alpha_plane_mut()` to return `Result<NonNull<u8>, LazyImageError>` for better error handling
- **Memory Safety**: Ensure all pointer accesses properly handle released state with `Option<>`
- **Double-Free Prevention**: Fix double-free prevention in Drop implementations using `Option::take()`

## Testing

All existing tests pass, including:
- Drop tracking tests
- Manual release tests
- Error path tests
- Dimension validation tests

## Related Issue

Closes #200