### PR TITLE
refactor: Remove or test dead code marked with #[allow(dead_code)] #269

### DIFF
--- a/src/engine/encoder.rs
+++ b/src/engine/encoder.rs
@@ -52,8 +52,6 @@ fn validate_buffer_len(
 #[derive(Debug, Clone, Copy)]
 pub struct QualitySettings {
     quality: f32,
-    #[allow(dead_code)] // Reserved for future use (e.g., WebP/AVIF fast mode)
-    fast_mode: bool, // Fast mode flag for JPEG encoding
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -69,16 +67,6 @@ impl QualitySettings {
         let clamped = quality.min(100);
         Self {
             quality: clamped as f32,
-            fast_mode: false, // Default: high quality mode
-        }
-    }
-
-    /// Create with fast mode option
-    pub fn with_fast_mode(quality: u8, fast_mode: bool) -> Self {
-        let clamped = quality.min(100);
-        Self {
-            quality: clamped as f32,
-            fast_mode,
         }
     }
 

--- a/src/engine/firewall.rs
+++ b/src/engine/firewall.rs
@@ -6,23 +6,15 @@ use crate::engine::io::extract_icc_profile;
 use crate::error::LazyImageError;
 use std::time::Instant;
 
-#[allow(dead_code)]
 const STRICT_MAX_PIXELS: u64 = 40_000_000; // ~8K x 5K
-#[allow(dead_code)]
 const LENIENT_MAX_PIXELS: u64 = 75_000_000; // generous but below global MAX_PIXELS
-#[allow(dead_code)]
 const STRICT_MAX_BYTES: u64 = 32 * 1024 * 1024; // 32MB input cap
-#[allow(dead_code)]
 const LENIENT_MAX_BYTES: u64 = 48 * 1024 * 1024; // 48MB input cap
-#[allow(dead_code)]
 const STRICT_TIMEOUT_MS: u64 = 5_000; // 5s wall clock (allows JPEG/WebP, strict on slow AVIF)
-#[allow(dead_code)]
 const LENIENT_TIMEOUT_MS: u64 = 30_000; // 30s wall clock (allows AVIF on large images)
-#[allow(dead_code)]
 const LENIENT_METADATA_LIMIT: u64 = 512 * 1024; // 512KB ICC cap
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[allow(dead_code)]
 pub enum FirewallPolicy {
     Disabled,
     Strict,
@@ -31,7 +23,6 @@ pub enum FirewallPolicy {
 }
 
 #[derive(Clone, Debug)]
-#[allow(dead_code)]
 pub struct FirewallConfig {
     pub enabled: bool,
     pub policy: FirewallPolicy,
@@ -56,7 +47,6 @@ impl Default for FirewallConfig {
     }
 }
 
-#[allow(dead_code)]
 impl FirewallConfig {
     pub fn disabled() -> Self {
         Self::default()

--- a/src/engine/io.rs
+++ b/src/engine/io.rs
@@ -577,55 +577,14 @@ fn extract_icc_from_avif_safe(data: &[u8]) -> Option<Vec<u8>> {
 // - Orientation tag reset after auto-orient (prevents double-rotation bugs)
 // - GPS tag stripping by default (privacy-first, exceeds Sharp's capabilities)
 
-use little_exif::exif_tag::ExifTag;
 use little_exif::filetype::FileExtension;
 use little_exif::metadata::Metadata as ExifMetadata;
 
 /// Maximum EXIF data size to process (prevent DoS from malicious inputs)
 const MAX_EXIF_SOURCE_BYTES: usize = 8 * 1024 * 1024;
 
-/// GPS-related EXIF tags to strip for privacy protection.
-/// These tags can reveal sensitive location information.
-/// Note: Currently used conceptually; actual GPS stripping is done via direct TIFF manipulation in encoder.rs
-#[allow(dead_code)]
-const GPS_TAG_IDS: &[u16] = &[
-    0x0000, // GPSVersionID
-    0x0001, // GPSLatitudeRef
-    0x0002, // GPSLatitude
-    0x0003, // GPSLongitudeRef
-    0x0004, // GPSLongitude
-    0x0005, // GPSAltitudeRef
-    0x0006, // GPSAltitude
-    0x0007, // GPSTimeStamp
-    0x0008, // GPSSatellites
-    0x0009, // GPSStatus
-    0x000A, // GPSMeasureMode
-    0x000B, // GPSDOP
-    0x000C, // GPSSpeedRef
-    0x000D, // GPSSpeed
-    0x000E, // GPSTrackRef
-    0x000F, // GPSTrack
-    0x0010, // GPSImgDirectionRef
-    0x0011, // GPSImgDirection
-    0x0012, // GPSMapDatum
-    0x0013, // GPSDestLatitudeRef
-    0x0014, // GPSDestLatitude
-    0x0015, // GPSDestLongitudeRef
-    0x0016, // GPSDestLongitude
-    0x0017, // GPSDestBearingRef
-    0x0018, // GPSDestBearing
-    0x0019, // GPSDestDistanceRef
-    0x001A, // GPSDestDistance
-    0x001B, // GPSProcessingMethod
-    0x001C, // GPSAreaInformation
-    0x001D, // GPSDateStamp
-    0x001E, // GPSDifferential
-    0x001F, // GPSHPositioningError
-];
-
 /// Detect file extension for little_exif from image data magic bytes
 /// Note: Reserved for future PNG/WebP/AVIF EXIF support
-#[allow(dead_code)]
 fn detect_file_extension(data: &[u8]) -> Option<FileExtension> {
     if data.len() < 12 {
         return None;
@@ -672,36 +631,9 @@ fn detect_file_extension(data: &[u8]) -> Option<FileExtension> {
     None
 }
 
-/// Extract EXIF metadata from image data using little_exif.
-/// Returns None if EXIF is not present or cannot be parsed.
-///
-/// Supports: JPEG, PNG, WebP, AVIF, HEIF, TIFF
-/// Note: Reserved for future PNG/WebP/AVIF EXIF support
-#[allow(dead_code)]
-pub fn extract_exif_metadata(data: &[u8]) -> Option<ExifMetadata> {
-    if data.len() < 12 || data.len() > MAX_EXIF_SOURCE_BYTES {
-        return None;
-    }
-
-    let file_ext = detect_file_extension(data)?;
-    let data_vec = data.to_vec();
-
-    std::panic::catch_unwind(|| ExifMetadata::new_from_vec(&data_vec, file_ext).ok())
-        .ok()
-        .flatten()
-}
-
-/// Lossy helper for extracting EXIF - returns None on any error or panic.
-/// Note: Reserved for future PNG/WebP/AVIF EXIF support
-#[allow(dead_code)]
-pub fn extract_exif_metadata_lossy(data: &[u8]) -> Option<ExifMetadata> {
-    extract_exif_metadata(data)
-}
-
 /// Extract raw EXIF bytes from image data.
 /// This is used to store EXIF for later embedding without needing to re-parse.
 /// Returns the raw EXIF APP1 segment data (for JPEG) or equivalent for other formats.
-#[allow(dead_code)] // Used in NAPI feature only, not in fuzzing
 pub fn extract_exif_raw(data: &[u8]) -> Option<Vec<u8>> {
     if data.len() < 12 || data.len() > MAX_EXIF_SOURCE_BYTES {
         return None;
@@ -729,7 +661,6 @@ pub fn extract_exif_raw(data: &[u8]) -> Option<Vec<u8>> {
 }
 
 /// Extract raw EXIF APP1 segment from JPEG data
-#[allow(dead_code)] // Used in NAPI feature only, not in fuzzing
 fn extract_exif_raw_jpeg(data: &[u8]) -> Option<Vec<u8>> {
     const APP1: u8 = 0xE1;
     const SOS: u8 = 0xDA;
@@ -788,64 +719,6 @@ fn extract_exif_raw_jpeg(data: &[u8]) -> Option<Vec<u8>> {
     }
 
     None
-}
-
-/// Sanitize EXIF metadata for safe output:
-/// - Reset Orientation to 1 (if auto_orient was applied, prevents double-rotation)
-/// - Strip GPS tags (if strip_gps is true, for privacy protection)
-///
-/// This function modifies the metadata in place.
-///
-/// # Arguments
-/// * `metadata` - EXIF metadata to sanitize
-/// * `reset_orientation` - If true, set Orientation tag to 1 (Normal)
-/// * `strip_gps` - If true, remove all GPS-related tags
-///
-/// Note: Reserved for future PNG/WebP/AVIF EXIF support (JPEG uses direct TIFF manipulation)
-#[allow(dead_code)]
-pub fn sanitize_exif(metadata: &mut ExifMetadata, reset_orientation: bool, strip_gps: bool) {
-    if reset_orientation {
-        // Set Orientation to 1 (Normal) - pixels are already correctly oriented
-        metadata.set_tag(ExifTag::Orientation(vec![1]));
-    }
-
-    if strip_gps {
-        // Remove all GPS-related tags for privacy
-        // little_exif doesn't have a direct remove_by_id, so we need to iterate
-        // and rebuild without GPS tags
-        strip_gps_tags(metadata);
-    }
-}
-
-/// Strip all GPS-related tags from EXIF metadata.
-/// This is called when strip_gps is enabled (default for security).
-/// Note: Reserved for future use with little_exif-based approach
-#[allow(dead_code)]
-fn strip_gps_tags(_metadata: &mut ExifMetadata) {
-    // little_exif stores tags internally; we need to clear GPS IFD
-    // The library doesn't expose direct tag removal, so we use a workaround:
-    // Create empty GPS tags to overwrite existing ones
-    // Note: This is a limitation of little_exif - it doesn't have remove_tag functionality
-
-    // For now, we'll set GPS tags to empty/zero values to effectively "strip" them
-    // A more robust solution would be to serialize/deserialize without GPS IFD
-
-    // The GPS IFD is separate from main EXIF, so we can clear it by setting
-    // the GPS IFD pointer to null (not directly supported by little_exif)
-
-    // Workaround: We'll handle this at the embedding stage by filtering
-    // For the MVP, we mark that GPS should be stripped and handle it during write
-    let _ = GPS_TAG_IDS; // Acknowledge the constant is used conceptually
-}
-
-/// Check if EXIF metadata contains GPS location data
-/// Note: Reserved for future use
-#[allow(dead_code)]
-pub fn has_gps_data(metadata: &ExifMetadata) -> bool {
-    // Check for common GPS tags by examining the raw data
-    // get_tag returns an iterator, so we check if it yields any items
-    metadata.get_tag(&ExifTag::GPSLatitude(vec![])).count() > 0
-        || metadata.get_tag(&ExifTag::GPSLongitude(vec![])).count() > 0
 }
 
 #[cfg(test)]

--- a/src/engine/memory.rs
+++ b/src/engine/memory.rs
@@ -37,7 +37,6 @@ const BPP_AVIF: u64 = 4;
 const BPP_UNKNOWN: u64 = 4;
 
 /// Minimum safe concurrency when memory is very constrained
-#[allow(dead_code)]
 const MIN_SAFE_CONCURRENCY: usize = 1;
 
 /// Maximum safe concurrency based on memory (even if CPU allows more)
@@ -299,7 +298,6 @@ fn estimate_memory_from_dimensions_with_context(
 
 /// Simple wrapper for callers without format/ops context (kept for compatibility in tests)
 #[cfg(test)]
-#[allow(dead_code)]
 pub fn estimate_memory_from_dimensions(width: u32, height: u32) -> u64 {
     estimate_memory_from_dimensions_with_context(width, height, None, &[], None)
 }

--- a/src/engine/pool.rs
+++ b/src/engine/pool.rs
@@ -101,8 +101,7 @@ pub fn get_pool() -> Arc<ThreadPool> {
 
 /// Explicitly drop the global thread pool so it can be re-created.
 /// This is primarily used in tests and controlled lifecycles (e.g., module reload).
-#[cfg(feature = "napi")]
-#[allow(dead_code)]
+#[cfg(all(test, feature = "napi"))]
 pub(crate) fn shutdown_global_pool() {
     if let Some(pool) = pool_cell().write().take() {
         drop(pool);
@@ -112,8 +111,7 @@ pub(crate) fn shutdown_global_pool() {
 /// Drop and immediately reinitialize the global thread pool.
 /// Useful for scenarios where environment variables (like UV_THREADPOOL_SIZE)
 /// change at runtime and need to be respected by a fresh pool instance.
-#[cfg(feature = "napi")]
-#[allow(dead_code)]
+#[cfg(all(test, feature = "napi"))]
 pub(crate) fn reinitialize_global_pool() -> Arc<ThreadPool> {
     shutdown_global_pool();
     get_pool()


### PR DESCRIPTION
## Summary

This PR removes or tests dead code that was previously marked with `#[allow(dead_code)]`.

## Changes

- Removed unused methods and functions from various engine modules
- Moved test-only code to `#[cfg(test)]` blocks
- Removed unused type aliases and helper functions
- Cleaned up unused constants and imports

## Files Changed

- `src/engine/api.rs`: Removed unused `ensure_source_slice` and `ensure_decoded` methods
- `src/engine/common.rs`: Made `EngineResult` only compile with stress feature
- `src/engine/encoder.rs`: Removed unused `fast_mode` field and `with_fast_mode` method
- `src/engine/firewall.rs`: Removed `#[allow(dead_code)]` attributes (code is actually used)
- `src/engine/io.rs`: Removed unused EXIF-related functions
- `src/engine/memory.rs`: Removed `#[allow(dead_code)]` from `MIN_SAFE_CONCURRENCY`
- `src/engine/pool.rs`: Made test-only functions compile only in test mode
- `src/engine/tasks.rs`: Removed unused type aliases and moved test helpers to `#[cfg(test)]`

## Testing

- All tests pass
- Build succeeds with and without NAPI features
- No linter errors

Closes #269