### PR TITLE
docs: Add ProcessingMetrics legacy fields deprecation plan #261

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,16 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - EXIF Orientation auto-reset to 1 after auto-orient to prevent double-rotation
   - Zero-copy EXIF sanitization via direct TIFF byte manipulation
   - Currently supports JPEG output; PNG/WebP/AVIF planned for future releases
+- Fused Extract operation (resize+crop) with zero-allocation pipeline path and memory model support (#240)
+- Benchmarks for resize+crop vs sharp plus JS integration tests covering fusion path (#240)
+- Docs: Documented deprecation plan for `ProcessingMetrics` legacy aliases (`decodeTime`, `processTime`, `encodeTime`, `memoryPeak`, `inputSize`, `outputSize`). Marked as `@deprecated` in `index.d.ts`; scheduled for removal in v2.0.0. Migrate to `decodeMs`, `opsMs`, `encodeMs`, `peakRss`, `bytesIn`, `bytesOut`.
 
 ### Performance
 - Optimized codec backends (PNG decode via zune-png, WebP decode via libwebp)
   - Faster PNG/WebP decoding with SIMD/native codecs
   - Fallback to image crate for large PNGs (>16,384px) and animated WebP to preserve compatibility
   - Added safety checks to keep MAX_DIMENSION enforcement consistent
-
-### Added
-- Fused Extract operation (resize+crop) with zero-allocation pipeline path and memory model support (#240)
-- Benchmarks for resize+crop vs sharp plus JS integration tests covering fusion path (#240)
 
 ### Changed
 - Memory semaphore switched to `parking_lot` mutex/condvar for reduced contention under load; added contention benchmark (#241)

--- a/README.md
+++ b/README.md
@@ -588,12 +588,18 @@ interface ProcessingMetrics {
   iccPreserved: boolean;     // ICC profile preserved
   metadataStripped: boolean; // metadata stripped (by default or policy)
   policyViolations: string[];// non-fatal Image Firewall actions
-  // Legacy aliases preserved for compatibility
+  // Legacy aliases (deprecated; will be removed in v2.0.0)
+  /** @deprecated use decodeMs */
   decodeTime: number;
+  /** @deprecated use opsMs */
   processTime: number;
+  /** @deprecated use encodeMs */
   encodeTime: number;
+  /** @deprecated use peakRss */
   memoryPeak: number;
+  /** @deprecated use bytesIn */
   inputSize: number;
+  /** @deprecated use bytesOut */
   outputSize: number;
 }
 
@@ -608,6 +614,10 @@ lazy-image enforces quality parity with sharp via benchmark gates:
 
 - SSIM ≥ 0.995
 - PSNR ≥ 40 dB
+
+### Deprecation plan for legacy metrics fields
+- `decodeTime`, `processTime`, `encodeTime`, `memoryPeak`, `inputSize`, `outputSize` are deprecated aliases of the `*Ms`/`peakRss`/`bytesIn`/`bytesOut` fields.
+- They will remain until **v2.0.0**, after which they are scheduled for removal. Migrate to the new names now to avoid breaking changes.
 
 `npm run test:js` runs `test/benchmarks/sharp-comparison.bench.js`, comparing outputs against sharp under identical settings; it fails if either metric drops below the thresholds. Integration test `test/integration/quality-metrics.test.js` smoke-tests the metric calculations.
 

--- a/docs/metrics-api.md
+++ b/docs/metrics-api.md
@@ -42,7 +42,7 @@ lazy-image exposes structured telemetry via `ImageEngine.toBufferWithMetrics()`.
 - **formatIn / formatOut**: Detected input format (nullable) and requested output format.
 - **iccPreserved / metadataStripped**: Whether ICC profile was preserved or stripped.
 - **policyViolations**: Non-fatal Image Firewall actions that altered output (e.g., forced metadata strip under strict policy).
-- **Legacy aliases**: `decodeTime`, `processTime`, `encodeTime`, `memoryPeak`, `inputSize`, `outputSize` map 1:1 to the new fields for compatibility.
+- **Legacy aliases** (deprecated): `decodeTime`, `processTime`, `encodeTime`, `memoryPeak`, `inputSize`, `outputSize` map 1:1 to the new fields. They will be removed in v2.0.0; migrate to `decodeMs`, `opsMs`, `encodeMs`, `peakRss`, `bytesIn`, `bytesOut`.
 
 ## Validation
 
@@ -53,3 +53,4 @@ lazy-image exposes structured telemetry via `ImageEngine.toBufferWithMetrics()`.
 
 - Additive changes only within minor versions. Breaking changes (field removal/rename or semantic shifts) require a new `version` value.
 - Downstream clients should gate on `version` and ignore unknown fields to remain forward compatible.
+- Legacy aliases are supported through v1.x with @deprecated annotations in `index.d.ts`. Removal is planned for v2.0.0.

--- a/index.d.ts
+++ b/index.d.ts
@@ -188,17 +188,35 @@ export interface ProcessingMetrics {
   metadataStripped: boolean
   /** Non-fatal policy rejections (e.g., strict policy forcing metadata strip) */
   policyViolations: Array<string>
-  /** Time taken to decode the image (milliseconds) - legacy alias of decode_ms */
+  /**
+   * @deprecated Renamed to `decodeMs` and will be removed in v2.0.0.
+   * Time taken to decode the image (milliseconds).
+   */
   decodeTime: number
-  /** Time taken to apply all operations (milliseconds) - legacy alias of ops_ms */
+  /**
+   * @deprecated Renamed to `opsMs` and will be removed in v2.0.0.
+   * Time taken to apply all operations (milliseconds).
+   */
   processTime: number
-  /** Time taken to encode the image (milliseconds) - legacy alias of encode_ms */
+  /**
+   * @deprecated Renamed to `encodeMs` and will be removed in v2.0.0.
+   * Time taken to encode the image (milliseconds).
+   */
   encodeTime: number
-  /** Peak memory usage during processing (RSS, bytes) - legacy alias of peak_rss */
+  /**
+   * @deprecated Renamed to `peakRss` and will be removed in v2.0.0.
+   * Peak memory usage during processing (RSS, bytes).
+   */
   memoryPeak: number
-  /** Input size legacy alias (bytes_in) */
+  /**
+   * @deprecated Renamed to `bytesIn` and will be removed in v2.0.0.
+   * Input size in bytes.
+   */
   inputSize: number
-  /** Output size legacy alias (bytes_out) */
+  /**
+   * @deprecated Renamed to `bytesOut` and will be removed in v2.0.0.
+   * Output size in bytes.
+   */
   outputSize: number
 }
 export interface OutputWithMetrics {


### PR DESCRIPTION
Documents deprecation plan for `ProcessingMetrics` legacy aliases (`decodeTime`, `processTime`, `encodeTime`, `memoryPeak`, `inputSize`, `outputSize`).

- Marked as `@deprecated` in `index.d.ts` with migration targets (`decodeMs`, `opsMs`, `encodeMs`, `peakRss`, `bytesIn`, `bytesOut`)
- Updated `docs/metrics-api.md` and README with removal schedule (v2.0.0)
- CHANGELOG entry under Added

Closes #261