### PR TITLE
chore(dependabot): target develop branch for all ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@ version: 2
 updates:
   - package-ecosystem: "cargo"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -18,6 +19,7 @@ updates:
 
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -33,6 +35,7 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
Dependabot の PR を develop 向けにするため、`.github/dependabot.yml` に `target-branch: develop` を追加しました。

- cargo
- npm
- github-actions

今後の Dependabot PR は develop をベースに作成されます。