### PR TITLE
fix: refresh lockfile integrity hashes for 0.10.2 tarballs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
     "node_modules/@alberteinshutoin/lazy-image-darwin-arm64": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-darwin-arm64/-/lazy-image-darwin-arm64-0.10.2.tgz",
-      "integrity": "sha512-wserB2Yor5n9DSycWar4WU8X84eWbjXGZ2JgdupzoSfI56c8ipN2JCaI+i0V/kAa/0Ul4jvPga8hgTxWOdRo6Q==",
       "cpu": [
         "arm64"
       ],
@@ -46,7 +45,6 @@
     "node_modules/@alberteinshutoin/lazy-image-darwin-x64": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-darwin-x64/-/lazy-image-darwin-x64-0.10.2.tgz",
-      "integrity": "sha512-A6VcIuf1iWIOjiVVY/JwsXbLU3wskhNXRcC8bo4mvNtvpvkH/QWKKVXAkbYrBsvjiNTEX01LdDupYNZoRKyiJw==",
       "cpu": [
         "x64"
       ],
@@ -66,7 +64,6 @@
     "node_modules/@alberteinshutoin/lazy-image-linux-x64-gnu": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-linux-x64-gnu/-/lazy-image-linux-x64-gnu-0.10.2.tgz",
-      "integrity": "sha512-jH4JY79rwWPGWY24bK/xLHzdMu6xXZrzfkammtIUskl+hYkTWa3fkzRM7GTc0hh6dn7c/akxsVqLrgsl3bCAaQ==",
       "cpu": [
         "x64"
       ],
@@ -82,7 +79,6 @@
     "node_modules/@alberteinshutoin/lazy-image-linux-x64-musl": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-linux-x64-musl/-/lazy-image-linux-x64-musl-0.10.2.tgz",
-      "integrity": "sha512-lTtdJaKQHLsUmDXd88mInvI32/QSd41sJZgQ21EH5tWUPwQnDY0z7hXzCcI8NLGsPDwF4qCyDleIhys+qmGGMg==",
       "cpu": [
         "x64"
       ],
@@ -98,7 +94,6 @@
     "node_modules/@alberteinshutoin/lazy-image-win32-x64-msvc": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-win32-x64-msvc/-/lazy-image-win32-x64-msvc-0.10.2.tgz",
-      "integrity": "sha512-YoEPcu9hcSjUFu/itZrZpSX5YFaeFNOdH0h29e+5sm6dIsjkkjAA8asMjYwzyRLDl8UhD8rdpQvo9UTKNk8GSg==",
       "cpu": [
         "x64"
       ],

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -79,6 +79,11 @@ function syncPackageLock(pkg) {
             /-[0-9]+\.[0-9]+\.[0-9]+\.tgz$/,
             `-${pkg.version}.tgz`
           );
+          // Clear integrity so next `npm install` regenerates it for the new tarball.
+          // Otherwise npm ci can fail with integrity mismatch after publish.
+          if (entry.integrity) {
+            delete entry.integrity;
+          }
         }
         changed = true;
       }


### PR DESCRIPTION
## 概要
レビュー指摘に対応: バージョンアップ時に platform パッケージの `resolved` は更新されるが `integrity` が古いまま残り、publish 後に `npm ci` が integrity mismatch で失敗する問題を修正。

## 変更内容
1. **sync-version.js**: `resolved` を更新する際に `integrity` を削除するよう変更
   - 次回 `npm install` で正しい tarball の hash が再計算される
   - 将来のバージョンアップでも同問題を防止

2. **package-lock.json**: 0.10.2 の platform エントリから stale な integrity（0.10.1 由来）を削除

## 補足
- 0.10.2 の npm publish はまだ進行中
- integrity 削除後、publish 完了時に `npm install` を実行すると正しい integrity が lockfile に追加される（CI でも同様）
- optional deps で integrity がない場合、npm は fetch してインストールを続行

Made with [Cursor](https://cursor.com)