### PR TITLE
fix(io): prevent extract_exif_raw from returning entire file for non-JPEG (#369)

### DIFF
--- a/src/engine/io.rs
+++ b/src/engine/io.rs
@@ -577,13 +577,15 @@ fn extract_icc_from_avif_safe(data: &[u8]) -> Option<Vec<u8>> {
 // - Orientation tag reset after auto-orient (prevents double-rotation bugs)
 // - GPS tag stripping by default (privacy-first, exceeds Sharp's capabilities)
 
+#[allow(unused_imports)]
 use little_exif::filetype::FileExtension;
 
 /// Maximum EXIF data size to process (prevent DoS from malicious inputs)
 const MAX_EXIF_SOURCE_BYTES: usize = 8 * 1024 * 1024;
 
-/// Detect file extension for little_exif from image data magic bytes
-/// Note: Reserved for future PNG/WebP/AVIF EXIF support
+/// Detect file extension for little_exif from image data magic bytes.
+/// Note: Reserved for future PNG/WebP/AVIF EXIF support.
+#[allow(dead_code)]
 fn detect_file_extension(data: &[u8]) -> Option<FileExtension> {
     if data.len() < 12 {
         return None;


### PR DESCRIPTION
## Summary
- Fix `extract_exif_raw()` in `src/engine/io.rs` which was returning the **entire file buffer** as "EXIF data" for non-JPEG formats
- The old fallback used `ExifMetadata::new_from_vec` then returned `Some(data_vec)` — the whole file — wasting memory and bypassing firewall metadata size limits
- Non-JPEG formats now correctly return `None` since EXIF extraction is only implemented for JPEG via `extract_exif_raw_jpeg()`

## Test plan
- [x] `extract_exif_raw_returns_none_for_png` — PNG returns None
- [x] `extract_exif_raw_returns_none_for_webp` — WebP returns None
- [x] `extract_exif_raw_returns_none_for_jpeg_without_exif` — JPEG without EXIF returns None
- [x] `extract_exif_raw_returns_data_for_jpeg_with_exif` — JPEG with injected EXIF returns data
- [x] All `cargo test --no-default-features` pass

Closes #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)