### PR TITLE
fix(firewall): enforce pixel limits at sanitize() time for lazy path

### DIFF
--- a/src/engine/api.rs
+++ b/src/engine/api.rs
@@ -675,6 +675,21 @@ impl ImageEngine {
                 self.firewall
                     .scan_metadata(bytes)
                     .map_err(|e| napi_err(&env, e))?;
+
+                // When the image is not yet decoded (lazy path, e.g. fromPath),
+                // read the header to check dimensions against the firewall policy.
+                // This ensures sanitize() rejects oversized images immediately for
+                // both from(buffer) and fromPath(path) construction paths.
+                if self.decoded.is_none() {
+                    let cursor = Cursor::new(bytes);
+                    if let Ok(reader) = ImageReader::new(cursor).with_guessed_format() {
+                        if let Ok((w, h)) = reader.into_dimensions() {
+                            self.firewall
+                                .enforce_pixels(w, h)
+                                .map_err(|e| napi_err(&env, e))?;
+                        }
+                    }
+                }
             }
         }
 

--- a/src/engine/firewall.rs
+++ b/src/engine/firewall.rs
@@ -434,6 +434,66 @@ mod tests {
         assert_eq!(size.unwrap(), 208);
     }
 
+    /// Verify that header-based dimension check catches oversized images
+    /// without full decode. This simulates the sanitize() lazy-path fix (#370):
+    /// read dimensions from header, then enforce_pixels() against the firewall policy.
+    #[test]
+    fn enforce_pixels_rejects_oversized_image_from_header() {
+        use image::{ImageFormat, ImageReader};
+        use std::io::Cursor;
+
+        // Create a 3000x3000 image (9M pixels, exceeds strict's 40M? No — 9M < 40M).
+        // Use a custom policy with a 1M pixel limit to trigger rejection.
+        let img = image::DynamicImage::ImageRgb8(ImageBuffer::from_fn(200, 200, |x, y| {
+            Rgb([x as u8, y as u8, 0])
+        }));
+        let mut png_data = Vec::new();
+        img.write_to(&mut Cursor::new(&mut png_data), ImageFormat::Png)
+            .unwrap();
+
+        let cfg = FirewallConfig {
+            enabled: true,
+            policy: FirewallPolicy::Custom,
+            max_pixels: Some(10_000), // 10k pixels — 200×200=40k exceeds this
+            max_bytes: None,
+            timeout_ms: None,
+            reject_metadata: false,
+            metadata_max_bytes: None,
+            exif_max_bytes: None,
+        };
+
+        // Simulate lazy-path sanitize: read header → enforce_pixels
+        let cursor = Cursor::new(&png_data);
+        let reader = ImageReader::new(cursor).with_guessed_format().unwrap();
+        let (w, h) = reader.into_dimensions().unwrap();
+        let result = cfg.enforce_pixels(w, h);
+        assert!(
+            result.is_err(),
+            "enforce_pixels should reject 200x200 (40k pixels) against 10k limit"
+        );
+    }
+
+    /// Verify that enforce_pixels allows images within limits when reading from header.
+    #[test]
+    fn enforce_pixels_allows_small_image_from_header() {
+        use image::{ImageFormat, ImageReader};
+        use std::io::Cursor;
+
+        let img = image::DynamicImage::ImageRgb8(ImageBuffer::from_fn(10, 10, |x, y| {
+            Rgb([x as u8, y as u8, 0])
+        }));
+        let mut png_data = Vec::new();
+        img.write_to(&mut Cursor::new(&mut png_data), ImageFormat::Png)
+            .unwrap();
+
+        let cfg = FirewallConfig::strict(); // strict: 40M pixels
+
+        let cursor = Cursor::new(&png_data);
+        let reader = ImageReader::new(cursor).with_guessed_format().unwrap();
+        let (w, h) = reader.into_dimensions().unwrap();
+        assert!(cfg.enforce_pixels(w, h).is_ok());
+    }
+
     #[test]
     fn scan_exif_size_returns_none_for_jpeg_without_exif() {
         let img = image::DynamicImage::ImageRgb8(ImageBuffer::from_fn(2, 2, |x, y| {


### PR DESCRIPTION
## Summary

- Add header-based dimension check in `sanitize()` for the lazy decode path (`fromPath()`)
- When the image is not yet decoded, read the header to extract dimensions and run `enforce_pixels()` against the firewall policy
- This ensures consistent early rejection for both `from(buffer)` and `fromPath(path)` construction paths

**Before**: `fromPath(oversized).sanitize({ policy: 'strict' })` would succeed at `sanitize()` time and only fail at encode time
**After**: `fromPath(oversized).sanitize({ policy: 'strict' })` fails immediately at `sanitize()` time, matching `from(buffer)` behavior

## Test plan

- [x] New test: `enforce_pixels_rejects_oversized_image_from_header` — header-based check catches oversized images
- [x] New test: `enforce_pixels_allows_small_image_from_header` — small images pass correctly
- [x] All 359 existing Rust tests pass (`cargo test --no-default-features`)
- [ ] CI: verify JS integration tests with both `from()` and `fromPath()` paths

Fixes #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)