### PR TITLE
feat(api): add resize options object signature for resize()

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Platform-specific binaries (~6–9 MB per platform) are installed automatically.
 
 ```javascript
 await ImageEngine.fromPath('photo.jpg')
-  .resize(800, null)
+  .resize({ width: 800, fit: 'inside' }) // positional args also supported
   .toFile('thumb.jpg', 'jpeg', 85);
 ```
 
@@ -79,7 +79,7 @@ await ImageEngine.fromPath('photo.jpg')
 
 ```javascript
 const buffer = await ImageEngine.fromPath('input.png')
-  .resize(600, null)
+  .resize({ width: 600 })
   .toBuffer('webp', 80);
 ```
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -13,7 +13,7 @@ Full API reference for lazy-image. For a quick start, see [README.md](../README.
 
 | Method | Description |
 |--------|-------------|
-| `.resize(width?, height?, fit?)` | Resize image (`fit`: `'inside'` default, `'cover'` to crop + fill, `'fill'` to ignore aspect ratio) |
+| `.resize(options)` / `.resize(width?, height?, fit?)` | Resize image (`fit`: `'inside'` default, `'cover'` to crop + fill, `'fill'` to ignore aspect ratio) |
 | `.crop(x, y, width, height)` | Crop a region |
 | `.rotate(degrees)` | Rotate (90, 180, 270) |
 | `.flipH()` | Flip horizontally |
@@ -74,6 +74,12 @@ interface ImageMetadata {
 interface Dimensions {
   width: number;
   height: number;
+}
+
+interface ResizeOptions {
+  width?: number;
+  height?: number;
+  fit?: 'inside' | 'cover' | 'fill';
 }
 
 interface PresetResult {

--- a/index.d.ts
+++ b/index.d.ts
@@ -34,6 +34,7 @@ export declare class ImageEngine {
    * - "cover": maintain aspect ratio and crop to fill the box
    * - "fill": ignore aspect ratio and force exact dimensions
    */
+  resize(options: ResizeOptions): ImageEngine
   resize(width?: number | undefined | null, height?: number | undefined | null, fit?: string | undefined | null): ImageEngine
   /** Crop a region from the image. */
   crop(x: number, y: number, width: number, height: number): ImageEngine
@@ -300,6 +301,15 @@ export interface KeepMetadataOptions {
    * This is a security-first default that exceeds Sharp's capabilities
    */
   stripGps?: boolean
+}
+
+export interface ResizeOptions {
+  /** Target width in pixels */
+  width?: number
+  /** Target height in pixels */
+  height?: number
+  /** Resize fit mode */
+  fit?: 'inside' | 'cover' | 'fill'
 }
 
 export interface OutputWithMetrics {

--- a/src/engine/api.rs
+++ b/src/engine/api.rs
@@ -51,6 +51,18 @@ pub struct KeepMetadataOptions {
 }
 
 #[cfg(feature = "napi")]
+#[derive(Default)]
+#[napi(object)]
+pub struct ResizeOptions {
+    /// Target width in pixels
+    pub width: Option<f64>,
+    /// Target height in pixels
+    pub height: Option<f64>,
+    /// Resize fit mode: inside (default), cover, fill
+    pub fit: Option<String>,
+}
+
+#[cfg(feature = "napi")]
 fn napi_err(env: &Env, err: LazyImageError) -> napi::Error {
     // Helper to attach code/category consistently when Env is available
     crate::error::napi_error_with_code(env, err).expect("failed to create napi error")
@@ -491,15 +503,24 @@ impl ImageEngine {
     /// - "inside" (default): maintain aspect ratio and fit within the box
     /// - "cover": maintain aspect ratio and crop to fill the box
     /// - "fill": ignore aspect ratio and force exact dimensions
+    ///
+    /// Supports both signatures:
+    /// - resize({ width?, height?, fit? })
+    /// - resize(width?, height?, fit?)
     #[napi]
     pub fn resize(
         &mut self,
         env: Env,
         this: Reference<ImageEngine>,
-        width: Option<f64>,
+        options_or_width: Either<ResizeOptions, Option<f64>>,
         height: Option<f64>,
         fit: Option<String>,
     ) -> Result<Reference<ImageEngine>> {
+        let (width, height, fit) = match options_or_width {
+            Either::A(options) => (options.width, options.height, options.fit),
+            Either::B(width) => (width, height, fit),
+        };
+
         let fit_mode = if let Some(value) = fit {
             ResizeFit::from_str(&value)
                 .map_err(|_| napi_err(&env, LazyImageError::invalid_resize_fit(value)))?

--- a/test/integration/basic.test.js
+++ b/test/integration/basic.test.js
@@ -75,6 +75,23 @@ async function runTests() {
         // Note: For very small images (1x1), resizing may increase file size
     });
 
+    await asyncTest('resize options object works', async () => {
+        const result = await ImageEngine.from(buffer)
+            .resize({ width: 120, fit: 'cover' })
+            .toBuffer('jpeg', 80);
+        const meta = inspect(result);
+        assert.strictEqual(meta.width, 120, 'resize({ width }) should set output width');
+    });
+
+    await asyncTest('resize options object takes precedence over trailing positional args', async () => {
+        const result = await ImageEngine.from(buffer)
+            .resize({ width: 120 }, 50, 'fill')
+            .toBuffer('jpeg', 80);
+        const meta = inspect(result);
+        assert.strictEqual(meta.width, 120, 'width from options should be used');
+        assert.notStrictEqual(meta.height, 50, 'trailing positional args should be ignored when options object is used');
+    });
+
     await asyncTest('WebP encoding works', async () => {
         const result = await ImageEngine.from(buffer).resize(100).toBuffer('webp', 80);
         assert(result.length > 0, 'output should have content');

--- a/test/type-safety/typescript-typecheck.test.ts
+++ b/test/type-safety/typescript-typecheck.test.ts
@@ -31,6 +31,7 @@ async function testTypeSafety() {
     // Explicit ResizeFit type usage
     const coverFit: ResizeFit = 'cover';
     await ImageEngine.fromPath(imagePath).resize(300, 300, coverFit).toBuffer('jpeg', 75);
+    await ImageEngine.fromPath(imagePath).resize({ width: 320, fit: coverFit }).toBuffer('jpeg', 75);
 
     // Uppercase format is also accepted
     await ImageEngine.fromPath(imagePath).toBuffer('JPEG', 80);


### PR DESCRIPTION
## Summary

- Adds `resize(options)` support while keeping existing positional signature `resize(width?, height?, fit?)`
- Implements overload behavior in Rust NAPI API via `Either<ResizeOptions, Option<f64>>`
- Keeps backward compatibility for existing JS/TS callers
- Updates TypeScript declarations (`index.d.ts`) with `ResizeOptions` and overloaded signature
- Updates docs (`README.md`, `docs/API.md`) and adds runtime/type-safety coverage for options signature
- Options-object path takes precedence over trailing positional args when both are provided

Closes #340

## Test Plan

- [x] `cargo check`
- [x] `cargo check --no-default-features`
- [x] `npm run test:types`
- [x] Runtime smoke: `resize({ width: 120 })` via Node script (output width verified)
