### PR TITLE
docs: add ROI calculator and cost-savings methodology

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,30 @@ Benchmarks and details: [docs/PERFORMANCE.md](./docs/PERFORMANCE.md). Full compa
 
 ---
 
+## Cost Savings Example (ROI)
+
+Assume:
+- average image size before optimization: **1.0 MB**
+- average reduction with lazy-image: **25%**
+- CDN transfer rate: **$0.085/GB** (example: CloudFront pay-as-you-go, US/EU next 9TB tier)
+
+| Scenario | Transfer with sharp | Transfer with lazy-image | Monthly savings |
+|---|---:|---:|---:|
+| 1M image deliveries / month | 976.6 GB | 732.4 GB | **$20.75** |
+| 10M image deliveries / month | 9.54 TB | 7.15 TB | **$207.52** |
+| 100M image deliveries / month | 95.37 TB | 71.53 TB | **$2,075.20** |
+
+Break-even intuition:
+- Encoding overhead is paid **once per generated image**
+- Bandwidth savings are realized **every time the image is delivered**
+- If each generated image is viewed multiple times, lazy-image generally wins quickly
+
+Use the interactive calculator:
+- [docs/roi-calculator.html](./docs/roi-calculator.html)
+- Methodology and formulas: [docs/ROI_CALCULATOR.md](./docs/ROI_CALCULATOR.md)
+
+---
+
 ## Installation
 
 ```bash
@@ -105,6 +129,7 @@ More: batch processing, presets, metrics, streaming — [docs/API.md](./docs/API
 | **Troubleshooting** | [docs/TROUBLESHOOTING.md](./docs/TROUBLESHOOTING.md) |
 | **Security policy & reporting** | [SECURITY.md](./SECURITY.md) |
 | **Roadmap & scope** | [docs/ROADMAP.md](./docs/ROADMAP.md) |
+| **ROI calculator methodology** | [docs/ROI_CALCULATOR.md](./docs/ROI_CALCULATOR.md) |
 | **Version history** | [docs/VERSION_HISTORY.md](./docs/VERSION_HISTORY.md) |
 | **Specification (spec/)** | [spec/pipeline.md](./spec/pipeline.md), [spec/resize.md](./spec/resize.md), [spec/errors.md](./spec/errors.md), [spec/limits.md](./spec/limits.md), [spec/quality.md](./spec/quality.md), [spec/metadata.md](./spec/metadata.md) |
 | **Error codes** | [docs/ERROR_CODES.md](./docs/ERROR_CODES.md) |

--- a/docs/ROI_CALCULATOR.md
+++ b/docs/ROI_CALCULATOR.md
@@ -1,0 +1,78 @@
+# ROI Calculator Methodology
+
+This document explains the formulas behind `docs/roi-calculator.html` and the static ROI example in the README.
+
+## Purpose
+
+The ROI model helps answer:
+1. How much transfer data is reduced by smaller output files.
+2. What that reduction means in monthly/yearly CDN cost.
+3. When additional encode time is offset by bandwidth savings.
+
+## Inputs
+
+Required for bandwidth savings:
+- `image_deliveries_per_month`: number of image responses served per month.
+- `avg_size_mb_before`: average file size before optimization (MB).
+- `reduction_percent`: expected size reduction percentage with lazy-image.
+- `cdn_cost_per_gb`: transfer price in USD per GB.
+
+Optional for break-even model:
+- `unique_images_generated_per_month`: number of unique images encoded.
+- `extra_encode_ms_per_image`: extra encode time compared with sharp.
+- `compute_cost_per_vcpu_hour`: effective compute price.
+
+## Formulas
+
+`transfer_before_gb = image_deliveries_per_month * avg_size_mb_before / 1024`
+
+`transfer_after_gb = transfer_before_gb * (1 - reduction_percent / 100)`
+
+`saved_gb = transfer_before_gb - transfer_after_gb`
+
+`monthly_bandwidth_savings_usd = saved_gb * cdn_cost_per_gb`
+
+`yearly_bandwidth_savings_usd = monthly_bandwidth_savings_usd * 12`
+
+Break-even support model:
+
+`extra_encode_hours = unique_images_generated_per_month * extra_encode_ms_per_image / (1000 * 60 * 60)`
+
+`extra_encode_cost_usd = extra_encode_hours * compute_cost_per_vcpu_hour`
+
+`net_monthly_savings_usd = monthly_bandwidth_savings_usd - extra_encode_cost_usd`
+
+Per-image break-even views (approximation):
+
+`savings_per_view_per_image = (avg_size_mb_before / 1024) * (reduction_percent / 100) * cdn_cost_per_gb`
+
+`encode_cost_per_image = extra_encode_ms_per_image / (1000 * 60 * 60) * compute_cost_per_vcpu_hour`
+
+`break_even_views_per_image = encode_cost_per_image / savings_per_view_per_image`
+
+## Pricing Notes (Realistic Usage)
+
+Use your actual invoice rate. CDN pricing varies by region, volume, and contract:
+- AWS CloudFront is generally usage-based (`$/GB`) with regional and tiered pricing.
+- Cloudflare often uses plan-based pricing and optional overage/usage components.
+- Enterprise contracts may differ significantly from public list prices.
+
+The README example uses `$0.085/GB` as a practical reference point, not a universal constant.
+
+## Worked Example (README)
+
+Assumptions:
+- `avg_size_mb_before = 1.0`
+- `reduction_percent = 25`
+- `cdn_cost_per_gb = 0.085`
+
+For `10,000,000` monthly deliveries:
+- `transfer_before_gb = 9,765.63 GB`
+- `saved_gb = 2,441.41 GB`
+- `monthly_bandwidth_savings_usd = 207.52`
+
+## Caveats
+
+- Savings depend on cache hit rate and delivery patterns.
+- If images are encoded once and served many times, bandwidth savings dominate.
+- For highly dynamic images encoded on every request, include compute costs in your decision.

--- a/docs/roi-calculator.html
+++ b/docs/roi-calculator.html
@@ -1,0 +1,246 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>lazy-image ROI Calculator</title>
+  <style>
+    :root {
+      --bg: #f5f7fb;
+      --card: #ffffff;
+      --text: #1f2937;
+      --muted: #6b7280;
+      --border: #d1d5db;
+      --accent: #0f766e;
+      --accent-soft: #ccfbf1;
+      --danger: #b91c1c;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: "Avenir Next", "Segoe UI", sans-serif;
+      background: linear-gradient(180deg, #eef2ff 0%, var(--bg) 30%);
+      color: var(--text);
+    }
+    .wrap {
+      max-width: 980px;
+      margin: 0 auto;
+      padding: 24px 16px 48px;
+    }
+    .card {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      padding: 20px;
+      box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+      margin-bottom: 16px;
+    }
+    h1 { margin: 0 0 8px; font-size: 1.7rem; }
+    p { margin: 0 0 10px; line-height: 1.55; }
+    .muted { color: var(--muted); font-size: 0.95rem; }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 12px;
+      margin-top: 12px;
+    }
+    label {
+      display: block;
+      font-size: 0.92rem;
+      font-weight: 700;
+      margin-bottom: 6px;
+    }
+    input {
+      width: 100%;
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 10px 12px;
+      font-size: 0.98rem;
+      color: var(--text);
+      background: #fff;
+    }
+    .result-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 10px;
+      margin-top: 10px;
+    }
+    .stat {
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 12px;
+      background: #fff;
+    }
+    .k { font-size: 0.8rem; color: var(--muted); margin-bottom: 4px; }
+    .v { font-size: 1.2rem; font-weight: 800; }
+    .highlight {
+      border-color: #99f6e4;
+      background: var(--accent-soft);
+    }
+    .negative {
+      color: var(--danger);
+    }
+    .positive {
+      color: var(--accent);
+    }
+    @media (max-width: 640px) {
+      h1 { font-size: 1.4rem; }
+      .card { padding: 16px; }
+    }
+  </style>
+</head>
+<body>
+  <main class="wrap">
+    <section class="card">
+      <h1>lazy-image ROI Calculator</h1>
+      <p>Estimate how much CDN transfer cost you can save by reducing average image size.</p>
+      <p class="muted">Formula details: <a href="./ROI_CALCULATOR.md">ROI_CALCULATOR.md</a></p>
+      <div class="grid">
+        <div>
+          <label for="images">Image deliveries per month</label>
+          <input id="images" type="number" min="0" step="1000" value="10000000" />
+        </div>
+        <div>
+          <label for="sizeMb">Average size before optimization (MB)</label>
+          <input id="sizeMb" type="number" min="0" step="0.01" value="1.0" />
+        </div>
+        <div>
+          <label for="reduction">Average reduction (%)</label>
+          <input id="reduction" type="number" min="0" max="95" step="1" value="25" />
+        </div>
+        <div>
+          <label for="cdnCost">CDN transfer cost ($/GB)</label>
+          <input id="cdnCost" type="number" min="0" step="0.001" value="0.085" />
+        </div>
+      </div>
+    </section>
+
+    <section class="card">
+      <p><strong>Break-even model</strong> (optional): compare bandwidth savings vs. one-time encoding overhead.</p>
+      <div class="grid">
+        <div>
+          <label for="unique">Unique generated images per month</label>
+          <input id="unique" type="number" min="0" step="100" value="100000" />
+        </div>
+        <div>
+          <label for="extraMs">Extra encode time vs sharp (ms/image)</label>
+          <input id="extraMs" type="number" min="0" step="1" value="120" />
+        </div>
+        <div>
+          <label for="cpuRate">Compute cost ($ per vCPU-hour)</label>
+          <input id="cpuRate" type="number" min="0" step="0.001" value="0.04" />
+        </div>
+      </div>
+      <p class="muted">If your workload is pre-generated or cached heavily, encoding overhead impact is usually smaller.</p>
+    </section>
+
+    <section class="card">
+      <h2>Results</h2>
+      <div class="result-grid">
+        <div class="stat">
+          <div class="k">Transfer before</div>
+          <div class="v" id="beforeGb">-</div>
+        </div>
+        <div class="stat">
+          <div class="k">Transfer after</div>
+          <div class="v" id="afterGb">-</div>
+        </div>
+        <div class="stat">
+          <div class="k">Data saved</div>
+          <div class="v" id="savedGb">-</div>
+        </div>
+        <div class="stat highlight">
+          <div class="k">Bandwidth savings / month</div>
+          <div class="v positive" id="monthlySavings">-</div>
+        </div>
+        <div class="stat">
+          <div class="k">Bandwidth savings / year</div>
+          <div class="v positive" id="yearlySavings">-</div>
+        </div>
+        <div class="stat">
+          <div class="k">Extra encode compute / month</div>
+          <div class="v" id="encodeCost">-</div>
+        </div>
+        <div class="stat highlight">
+          <div class="k">Net savings / month</div>
+          <div class="v" id="netSavings">-</div>
+        </div>
+        <div class="stat">
+          <div class="k">Break-even views per image</div>
+          <div class="v" id="breakevenViews">-</div>
+        </div>
+      </div>
+      <p class="muted" id="interpretation"></p>
+    </section>
+  </main>
+
+  <script>
+    const ids = ["images", "sizeMb", "reduction", "cdnCost", "unique", "extraMs", "cpuRate"];
+
+    function n(id) {
+      return Number(document.getElementById(id).value || 0);
+    }
+
+    function fmtGb(v) {
+      if (!Number.isFinite(v)) return "-";
+      return `${v.toLocaleString(undefined, { maximumFractionDigits: 2 })} GB`;
+    }
+
+    function fmtUsd(v) {
+      if (!Number.isFinite(v)) return "-";
+      return `$${v.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+    }
+
+    function calc() {
+      const images = n("images");
+      const sizeMb = n("sizeMb");
+      const reductionPct = Math.max(0, Math.min(95, n("reduction")));
+      const cdnCost = n("cdnCost");
+      const unique = n("unique");
+      const extraMs = n("extraMs");
+      const cpuRate = n("cpuRate");
+
+      const beforeGb = images * sizeMb / 1024;
+      const afterGb = beforeGb * (1 - reductionPct / 100);
+      const savedGb = beforeGb - afterGb;
+      const monthlySavings = savedGb * cdnCost;
+      const yearlySavings = monthlySavings * 12;
+
+      const encodeHours = unique * extraMs / (1000 * 60 * 60);
+      const encodeCost = encodeHours * cpuRate;
+      const netSavings = monthlySavings - encodeCost;
+
+      const savingsPerViewPerImage = (sizeMb / 1024) * (reductionPct / 100) * cdnCost;
+      const encodeCostPerImage = extraMs / (1000 * 60 * 60) * cpuRate;
+      const breakevenViews = savingsPerViewPerImage > 0 ? encodeCostPerImage / savingsPerViewPerImage : Infinity;
+
+      document.getElementById("beforeGb").textContent = fmtGb(beforeGb);
+      document.getElementById("afterGb").textContent = fmtGb(afterGb);
+      document.getElementById("savedGb").textContent = fmtGb(savedGb);
+      document.getElementById("monthlySavings").textContent = fmtUsd(monthlySavings);
+      document.getElementById("yearlySavings").textContent = fmtUsd(yearlySavings);
+      document.getElementById("encodeCost").textContent = fmtUsd(encodeCost);
+
+      const netEl = document.getElementById("netSavings");
+      netEl.textContent = fmtUsd(netSavings);
+      netEl.className = `v ${netSavings >= 0 ? "positive" : "negative"}`;
+
+      const breakEl = document.getElementById("breakevenViews");
+      breakEl.textContent = Number.isFinite(breakevenViews)
+        ? breakevenViews.toLocaleString(undefined, { maximumFractionDigits: 2 })
+        : "-";
+
+      const text = netSavings >= 0
+        ? `Estimated monthly net savings are positive. With current assumptions, break-even is around ${breakEl.textContent} views per generated image.`
+        : "Estimated monthly net savings are negative. Re-check reduction %, CDN rate, and compute assumptions.";
+      document.getElementById("interpretation").textContent = text;
+    }
+
+    ids.forEach((id) => {
+      document.getElementById(id).addEventListener("input", calc);
+    });
+
+    calc();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a static ROI section to README with monthly transfer savings examples
- add interactive calculator at `docs/roi-calculator.html`
- add formula and assumptions doc at `docs/ROI_CALCULATOR.md`
- add ROI methodology link in README docs table

## Why
- clarify business impact of smaller file sizes for non-technical stakeholders
- provide break-even guidance for slower encoding trade-offs

Closes #337
