### PR TITLE
refactor: remove redundant EncodeTask cloning in NAPI tasks

### DIFF
--- a/src/engine/tasks.rs
+++ b/src/engine/tasks.rs
@@ -230,6 +230,197 @@ pub struct EncodeTask {
     pub(crate) last_error: Option<LazyImageError>,
 }
 
+fn decode_internal_from_parts<'a>(
+    source: Option<&'a Source>,
+    decoded: Option<&'a Arc<DynamicImage>>,
+    firewall: &FirewallConfig,
+) -> std::result::Result<Cow<'a, DynamicImage>, LazyImageError> {
+    // Prefer already decoded image (already validated)
+    // Return borrowed reference - no deep copy until mutation is needed
+    if let Some(img_arc) = decoded {
+        check_dimensions(img_arc.width(), img_arc.height())?;
+        firewall.enforce_pixels(img_arc.width(), img_arc.height())?;
+        return Ok(Cow::Borrowed(img_arc.as_ref()));
+    }
+
+    // Get bytes from source - zero-copy for Memory and Mapped sources
+    let bytes = match source {
+        Some(source) => {
+            if let Some(bytes) = source.as_bytes() {
+                bytes
+            } else {
+                // Path sources require loading first - this should not happen in normal flow
+                // as from_path() converts Path to Mapped. If this occurs, it's a programming error.
+                return Err(LazyImageError::decode_failed(
+                    "Path source requires loading first. Use Mapped source (from_path) instead."
+                        .to_string(),
+                ));
+            }
+        }
+        None => {
+            return Err(LazyImageError::source_consumed());
+        }
+    };
+
+    firewall.enforce_source_len(bytes.len())?;
+    firewall.scan_metadata(bytes)?;
+
+    ensure_dimensions_safe(bytes)?;
+
+    let (img, _detected_format) = decode_image(bytes)?;
+
+    // Security check: reject decompression bombs
+    let (w, h) = img.dimensions();
+    check_dimensions(w, h)?;
+    firewall.enforce_pixels(w, h)?;
+
+    Ok(Cow::Owned(img))
+}
+
+fn process_and_encode_from_parts(
+    source: Option<&Source>,
+    decoded: Option<&Arc<DynamicImage>>,
+    ops: &[Operation],
+    format: &OutputFormat,
+    icc_profile: Option<&Arc<Vec<u8>>>,
+    icc_present: bool,
+    exif_data: Option<&Arc<Vec<u8>>>,
+    auto_orient: bool,
+    keep_icc: bool,
+    keep_exif: bool,
+    strip_gps: bool,
+    firewall: &FirewallConfig,
+    mut metrics: Option<&mut crate::ProcessingMetrics>,
+) -> std::result::Result<Vec<u8>, LazyImageError> {
+    // Get input size from source
+    // Use len() method which works for both Memory and Mapped sources
+    let input_size = source.map(|s| s.len() as u64).unwrap_or(0);
+    let input_bytes = source.and_then(|s| s.as_bytes());
+    let input_format = input_bytes.and_then(detect_input_format);
+
+    // Memory backpressure: estimate before decode and acquire weighted permit
+    let estimated_memory = source
+        .and_then(|s| s.as_bytes())
+        .and_then(|bytes| memory::estimate_memory_from_header(bytes, ops, Some(format)))
+        .unwrap_or(memory::ESTIMATED_MEMORY_PER_OPERATION);
+    let permit = memory::memory_semaphore().acquire(estimated_memory);
+    // keep guard alive for entire processing scope
+    let _permit_guard = permit;
+
+    // Centralize metrics recording
+    let mut metrics_recorder = MetricsRecorder::new(metrics.as_deref_mut(), input_size);
+
+    // Pre-read orientation from EXIF header (before full decode)
+    let orientation = if auto_orient {
+        if let Some(bytes) = input_bytes {
+            // Enforce byte limit & metadata scan before EXIF parsing to honor firewall settings
+            firewall.enforce_source_len(bytes.len())?;
+            firewall.scan_metadata(bytes)?;
+            crate::engine::decoder::detect_exif_orientation(bytes)
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    // 1. Decode
+    let img = decode_internal_from_parts(source, decoded, firewall)?;
+    firewall.enforce_timeout(metrics_recorder.start_total, "decode")?;
+    metrics_recorder.mark_decode_done();
+
+    // 2. Apply operations
+    let with_auto_orient;
+    let effective_ops = if let Some(o) = orientation {
+        // Clone only when we need to inject AutoOrient at the front.
+        with_auto_orient = {
+            let mut op_list = ops.to_vec();
+            op_list.insert(0, Operation::AutoOrient { orientation: o });
+            op_list
+        };
+        with_auto_orient.as_slice()
+    } else {
+        ops
+    };
+    let icc_state = if icc_present {
+        IccState::Present
+    } else {
+        IccState::Absent
+    };
+    let initial_state = ColorState::from_dynamic_image(&img, icc_state);
+    let tracked = apply_ops_tracked(img, effective_ops, initial_state)?;
+    let final_color_state = tracked.state;
+    let processed = tracked.image;
+    firewall.enforce_timeout(metrics_recorder.start_total, "process")?;
+    metrics_recorder.mark_process_done();
+
+    // 3. Encode - only preserve ICC profile if keep_icc is true
+    let icc = if keep_icc {
+        icc_profile.map(|v| v.as_slice())
+    } else {
+        None // Strip metadata by default for security & smaller files
+    };
+
+    // 4. Encode image to target format
+    let mut result = match format {
+        OutputFormat::Jpeg { quality, fast_mode } => {
+            encode_jpeg_with_settings(&processed, *quality, icc, *fast_mode)
+        }
+        OutputFormat::Png => encode_png(&processed, icc),
+        OutputFormat::WebP { quality } => encode_webp(&processed, *quality, icc),
+        OutputFormat::Avif { quality } => encode_avif(&processed, *quality, icc),
+    }?;
+
+    // 5. Embed EXIF metadata if requested (JPEG only for now)
+    if keep_exif {
+        if let Some(exif_data) = exif_data {
+            if let OutputFormat::Jpeg { .. } = format {
+                // Embed EXIF with sanitization:
+                // - Reset Orientation to 1 if auto_orient was applied
+                // - Strip GPS tags if strip_gps is true (default)
+                result = embed_exif_jpeg(
+                    result,
+                    exif_data.as_slice(),
+                    auto_orient, // reset orientation if auto-orient was applied
+                    strip_gps,
+                )?;
+            }
+            // TODO: PNG/WebP EXIF embedding (less common, lower priority)
+        }
+    }
+    firewall.enforce_timeout(metrics_recorder.start_total, "encode")?;
+
+    // Get final resource usage & finalize metrics
+    let final_usage = get_resource_usage();
+    // Use tracked color state to reason about ICC preservation.
+    let icc_present = matches!(final_color_state.icc, IccState::Present);
+    let icc_preserved = keep_icc && icc_present;
+    // metadata_stripped: true when source had ICC but we did not preserve it
+    let metadata_stripped = icc_present && !icc_preserved;
+    let metadata_blocked_by_policy =
+        (keep_icc || keep_exif) && firewall.reject_metadata && icc_present;
+    let mut policy_violations = Vec::new();
+    if metadata_blocked_by_policy {
+        policy_violations.push("firewall_rejected_metadata".to_string());
+    }
+
+    let metrics_context = MetricsContext {
+        input_format,
+        output_format: format.as_str().to_string(),
+        icc_preserved,
+        metadata_stripped,
+        policy_violations,
+    };
+    metrics_recorder.finalize(
+        processed.dimensions(),
+        result.len(),
+        &final_usage,
+        metrics_context,
+    );
+
+    Ok(result)
+}
+
 impl EncodeTask {
     /// Decode image from source bytes
     /// Uses mozjpeg (libjpeg-turbo) for JPEG, falls back to image crate for others
@@ -242,46 +433,7 @@ impl EncodeTask {
     pub(crate) fn decode_internal(
         &self,
     ) -> std::result::Result<Cow<'_, DynamicImage>, LazyImageError> {
-        // Prefer already decoded image (already validated)
-        // Return borrowed reference - no deep copy until mutation is needed
-        if let Some(ref img_arc) = self.decoded {
-            check_dimensions(img_arc.width(), img_arc.height())?;
-            self.firewall
-                .enforce_pixels(img_arc.width(), img_arc.height())?;
-            return Ok(Cow::Borrowed(img_arc.as_ref()));
-        }
-
-        // Get bytes from source - zero-copy for Memory and Mapped sources
-        let bytes = match self.source.as_ref() {
-            Some(source) => {
-                if let Some(bytes) = source.as_bytes() {
-                    bytes
-                } else {
-                    // Path sources require loading first - this should not happen in normal flow
-                    // as from_path() converts Path to Mapped. If this occurs, it's a programming error.
-                    return Err(LazyImageError::decode_failed(
-                        "Path source requires loading first. Use Mapped source (from_path) instead.".to_string(),
-                    ));
-                }
-            }
-            None => {
-                return Err(LazyImageError::source_consumed());
-            }
-        };
-
-        self.firewall.enforce_source_len(bytes.len())?;
-        self.firewall.scan_metadata(bytes)?;
-
-        ensure_dimensions_safe(bytes)?;
-
-        let (img, _detected_format) = decode_image(bytes)?;
-
-        // Security check: reject decompression bombs
-        let (w, h) = img.dimensions();
-        check_dimensions(w, h)?;
-        self.firewall.enforce_pixels(w, h)?;
-
-        Ok(Cow::Owned(img))
+        decode_internal_from_parts(self.source.as_ref(), self.decoded.as_ref(), &self.firewall)
     }
 
     /// Process image: decode → apply ops → encode
@@ -292,135 +444,23 @@ impl EncodeTask {
     /// Note: Takes &self (not &mut self) to allow sharing without cloning Arc-wrapped data.
     pub(crate) fn process_and_encode(
         &self,
-        mut metrics: Option<&mut crate::ProcessingMetrics>,
+        metrics: Option<&mut crate::ProcessingMetrics>,
     ) -> std::result::Result<Vec<u8>, LazyImageError> {
-        // Get input size from source
-        // Use len() method which works for both Memory and Mapped sources
-        let input_size = self.source.as_ref().map(|s| s.len() as u64).unwrap_or(0);
-        let input_bytes = self.source.as_ref().and_then(|s| s.as_bytes());
-        let input_format = input_bytes.and_then(detect_input_format);
-
-        // Memory backpressure: estimate before decode and acquire weighted permit
-        let estimated_memory = self
-            .source
-            .as_ref()
-            .and_then(|s| s.as_bytes())
-            .and_then(|bytes| {
-                memory::estimate_memory_from_header(bytes, &self.ops, Some(&self.format))
-            })
-            .unwrap_or(memory::ESTIMATED_MEMORY_PER_OPERATION);
-        let permit = memory::memory_semaphore().acquire(estimated_memory);
-        // keep guard alive for entire processing scope
-        let _permit_guard = permit;
-
-        // Centralize metrics recording
-        let mut metrics_recorder = MetricsRecorder::new(metrics.as_deref_mut(), input_size);
-
-        // Pre-read orientation from EXIF header (before full decode)
-        let orientation = if self.auto_orient {
-            if let Some(bytes) = input_bytes {
-                // Enforce byte limit & metadata scan before EXIF parsing to honor firewall settings
-                self.firewall.enforce_source_len(bytes.len())?;
-                self.firewall.scan_metadata(bytes)?;
-                crate::engine::decoder::detect_exif_orientation(bytes)
-            } else {
-                None
-            }
-        } else {
-            None
-        };
-
-        // 1. Decode
-        let img = self.decode_internal()?;
-        self.firewall
-            .enforce_timeout(metrics_recorder.start_total, "decode")?;
-        metrics_recorder.mark_decode_done();
-
-        // 2. Apply operations
-        let mut effective_ops = self.ops.clone();
-        if let Some(o) = orientation {
-            // Insert at the very beginning to normalize before user operations
-            effective_ops.insert(0, Operation::AutoOrient { orientation: o });
-        }
-        let icc_state = if self.icc_present {
-            IccState::Present
-        } else {
-            IccState::Absent
-        };
-        let initial_state = ColorState::from_dynamic_image(&img, icc_state);
-        let tracked = apply_ops_tracked(img, &effective_ops, initial_state)?;
-        let final_color_state = tracked.state;
-        let processed = tracked.image;
-        self.firewall
-            .enforce_timeout(metrics_recorder.start_total, "process")?;
-        metrics_recorder.mark_process_done();
-
-        // 3. Encode - only preserve ICC profile if keep_icc is true
-        let icc = if self.keep_icc {
-            self.icc_profile.as_ref().map(|v| v.as_slice())
-        } else {
-            None // Strip metadata by default for security & smaller files
-        };
-
-        // 4. Encode image to target format
-        let mut result = match &self.format {
-            OutputFormat::Jpeg { quality, fast_mode } => {
-                encode_jpeg_with_settings(&processed, *quality, icc, *fast_mode)
-            }
-            OutputFormat::Png => encode_png(&processed, icc),
-            OutputFormat::WebP { quality } => encode_webp(&processed, *quality, icc),
-            OutputFormat::Avif { quality } => encode_avif(&processed, *quality, icc),
-        }?;
-
-        // 5. Embed EXIF metadata if requested (JPEG only for now)
-        if self.keep_exif {
-            if let Some(exif_data) = &self.exif_data {
-                if let OutputFormat::Jpeg { .. } = &self.format {
-                    // Embed EXIF with sanitization:
-                    // - Reset Orientation to 1 if auto_orient was applied
-                    // - Strip GPS tags if strip_gps is true (default)
-                    result = embed_exif_jpeg(
-                        result,
-                        exif_data.as_slice(),
-                        self.auto_orient, // reset orientation if auto-orient was applied
-                        self.strip_gps,
-                    )?;
-                }
-                // TODO: PNG/WebP EXIF embedding (less common, lower priority)
-            }
-        }
-        self.firewall
-            .enforce_timeout(metrics_recorder.start_total, "encode")?;
-
-        // Get final resource usage & finalize metrics
-        let final_usage = get_resource_usage();
-        // Use tracked color state to reason about ICC preservation.
-        let icc_present = matches!(final_color_state.icc, IccState::Present);
-        let icc_preserved = self.keep_icc && icc_present;
-        // metadata_stripped: true when source had ICC but we did not preserve it
-        let metadata_stripped = icc_present && !icc_preserved;
-        let metadata_blocked_by_policy =
-            (self.keep_icc || self.keep_exif) && self.firewall.reject_metadata && icc_present;
-        let mut policy_violations = Vec::new();
-        if metadata_blocked_by_policy {
-            policy_violations.push("firewall_rejected_metadata".to_string());
-        }
-
-        let metrics_context = MetricsContext {
-            input_format,
-            output_format: self.format.as_str().to_string(),
-            icc_preserved,
-            metadata_stripped,
-            policy_violations,
-        };
-        metrics_recorder.finalize(
-            processed.dimensions(),
-            result.len(),
-            &final_usage,
-            metrics_context,
-        );
-
-        Ok(result)
+        process_and_encode_from_parts(
+            self.source.as_ref(),
+            self.decoded.as_ref(),
+            &self.ops,
+            &self.format,
+            self.icc_profile.as_ref(),
+            self.icc_present,
+            self.exif_data.as_ref(),
+            self.auto_orient,
+            self.keep_icc,
+            self.keep_exif,
+            self.strip_gps,
+            &self.firewall,
+            metrics,
+        )
     }
 }
 
@@ -517,7 +557,7 @@ mod non_napi_tests {
 
     #[test]
     fn process_and_encode_outputs_image() {
-        let mut task = make_task_with_decoded(OutputFormat::Png);
+        let task = make_task_with_decoded(OutputFormat::Png);
         let encoded = task
             .process_and_encode(None)
             .expect("encode should succeed");
@@ -609,7 +649,9 @@ mod non_napi_tests {
             quality: 80,
             fast_mode: true,
         });
-        let result = task.process_and_encode(None).expect("encode should succeed");
+        let result = task
+            .process_and_encode(None)
+            .expect("encode should succeed");
         // JPEG magic bytes
         assert_eq!(&result[0..2], &[0xFF, 0xD8]);
         assert_eq!(&result[result.len() - 2..], &[0xFF, 0xD9]);
@@ -621,7 +663,9 @@ mod non_napi_tests {
             quality: 80,
             fast_mode: false,
         });
-        let result = task.process_and_encode(None).expect("encode should succeed");
+        let result = task
+            .process_and_encode(None)
+            .expect("encode should succeed");
         assert_eq!(&result[0..2], &[0xFF, 0xD8]);
     }
 
@@ -676,28 +720,23 @@ impl Task for EncodeWithMetricsTask {
     type JsValue = crate::OutputWithMetrics;
 
     fn compute(&mut self) -> Result<Self::Output> {
-        // P2 Optimization: Share EncodeTask fields via reference instead of cloning
-        // Since EncodeWithMetricsTask has the same fields as EncodeTask, create a view
-        let task = EncodeTask {
-            source: self.source.clone(),
-            decoded: self.decoded.clone(),
-            ops: self.ops.clone(),
-            format: self.format.clone(),
-            icc_profile: self.icc_profile.clone(),
-            icc_present: self.icc_present,
-            exif_data: self.exif_data.clone(),
-            auto_orient: self.auto_orient,
-            keep_icc: self.keep_icc,
-            keep_exif: self.keep_exif,
-            strip_gps: self.strip_gps,
-            firewall: self.firewall.clone(),
-            #[cfg(feature = "napi")]
-            last_error: None,
-        };
-
         use crate::ProcessingMetrics;
         let mut metrics = ProcessingMetrics::default();
-        match task.process_and_encode(Some(&mut metrics)) {
+        match process_and_encode_from_parts(
+            self.source.as_ref(),
+            self.decoded.as_ref(),
+            &self.ops,
+            &self.format,
+            self.icc_profile.as_ref(),
+            self.icc_present,
+            self.exif_data.as_ref(),
+            self.auto_orient,
+            self.keep_icc,
+            self.keep_exif,
+            self.strip_gps,
+            &self.firewall,
+            Some(&mut metrics),
+        ) {
             Ok(data) => {
                 self.last_error = None;
                 Ok((data, metrics))
@@ -764,26 +803,21 @@ impl Task for WriteFileTask {
         use std::io::Write;
         use tempfile::NamedTempFile;
 
-        // P2 Optimization: Create EncodeTask without redundant mut
-        let encode_task = EncodeTask {
-            source: self.source.clone(),
-            decoded: self.decoded.clone(),
-            ops: self.ops.clone(),
-            format: self.format.clone(),
-            icc_profile: self.icc_profile.clone(),
-            icc_present: self.icc_present,
-            exif_data: self.exif_data.clone(),
-            auto_orient: self.auto_orient,
-            keep_icc: self.keep_icc,
-            keep_exif: self.keep_exif,
-            strip_gps: self.strip_gps,
-            firewall: self.firewall.clone(),
-            #[cfg(feature = "napi")]
-            last_error: None,
-        };
-
-        // Process image using shared logic (now using &self not &mut self)
-        let data = match encode_task.process_and_encode(None) {
+        let data = match process_and_encode_from_parts(
+            self.source.as_ref(),
+            self.decoded.as_ref(),
+            &self.ops,
+            &self.format,
+            self.icc_profile.as_ref(),
+            self.icc_present,
+            self.exif_data.as_ref(),
+            self.auto_orient,
+            self.keep_icc,
+            self.keep_exif,
+            self.strip_gps,
+            &self.firewall,
+            None,
+        ) {
             Ok(data) => data,
             Err(lazy_err) => {
                 // Store the error for use in reject


### PR DESCRIPTION
## Summary
- refactor shared decode/process/encode logic into reference-based helpers in `src/engine/tasks.rs`
- remove redundant `EncodeTask` reconstruction in `EncodeWithMetricsTask::compute` and `WriteFileTask::compute`
- avoid unnecessary deep clone of `ops: Vec<Operation>` when auto-orient is not injected

## Why
`EncodeWithMetricsTask` / `WriteFileTask` rebuilt `EncodeTask` by cloning all fields, including `ops`, causing avoidable allocations.

## Changes
- add `decode_internal_from_parts(...)`
- add `process_and_encode_from_parts(...)`
- keep `EncodeTask::{decode_internal, process_and_encode}` as thin wrappers for behavior compatibility
- use reference-based helper calls from both NAPI task implementations

## Validation
- `cargo test --no-default-features non_napi_tests -- --nocapture`

Closes #378
