### PR TITLE
feat: add profile-based encode API helpers

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -33,8 +33,11 @@ Full API reference for lazy-image. For a quick start, see [README.md](../README.
 | Method | Description |
 |--------|-------------|
 | `.toBuffer(format, quality?)` | Encode to Buffer. Format: `'jpeg'`, `'png'`, `'webp'`, `'avif'` (AVIF requires build feature `avif`). Default quality: JPEG=85, WebP=80, AVIF=60. |
+| `.toBufferProfile(format, profile, quality?)` | Encode using high-level profile: `'size-first'`, `'balanced'`, `'speed-first'`. |
 | `.toBufferWithMetrics(format, quality?)` | Encode with performance metrics. Returns `{ data: Buffer, metrics: ProcessingMetrics }`. |
+| `.toBufferWithMetricsProfile(format, profile, quality?)` | Profile-based encode with metrics. |
 | `.toFile(path, format, quality?)` | **Recommended**: Write directly to file (memory-efficient). Returns bytes written. |
+| `.toFileProfile(path, format, profile, quality?)` | Profile-based file encode. |
 | `.processBatch(inputs, outDir, { format, quality?, fastMode?, concurrency? })` | Process multiple images in parallel. Returns array of `BatchResult`. `concurrency`: workers (0 = CPU cores). |
 | `.clone()` | Clone the engine for multi-output (e.g. same pipeline to JPEG + WebP + AVIF). |
 
@@ -46,6 +49,7 @@ Full API reference for lazy-image. For a quick start, see [README.md](../README.
 | `inspectFile(path)` | **Recommended**: Get metadata from file without loading into memory |
 | `.dimensions()` | Get `{ width, height }` (requires decode) |
 | `.hasIccProfile()` | Returns ICC profile size in bytes, or null if none |
+| `resolveEncodeProfile(format, profile, quality?)` | Resolve profile into concrete `{ format, quality, fastMode }` options. |
 | `createStreamingPipeline({ format, quality, ops })` | Disk-backed bounded-memory pipeline. See [TROUBLESHOOTING.md](./TROUBLESHOOTING.md#streaming). |
 
 ---

--- a/index.d.ts
+++ b/index.d.ts
@@ -106,6 +106,13 @@ export declare class ImageEngine {
    */
   toBuffer(format: string, quality?: number | undefined | null, fastMode?: boolean | undefined | null): Promise<Buffer>
   /**
+   * Encode using a high-level profile.
+   * - size-first: smaller output priority
+   * - balanced: default balance
+   * - speed-first: lower latency priority
+   */
+  toBufferProfile(format: string, profile?: EncodeProfile, quality?: number | undefined | null): Promise<Buffer>
+  /**
    * Convenience: encode using the last applied preset by name.
    * Equivalent to calling `preset(name)` then `toBuffer(preset.format, preset.quality)`.
    */
@@ -118,6 +125,8 @@ export declare class ImageEngine {
    * The source data is cloned internally, allowing multiple format outputs.
    */
   toBufferWithMetrics(format: string, quality?: number | undefined | null, fastMode?: boolean | undefined | null): Promise<OutputWithMetrics>
+  /** Encode with metrics using a high-level profile. */
+  toBufferWithMetricsProfile(format: string, profile?: EncodeProfile, quality?: number | undefined | null): Promise<OutputWithMetrics>
   /**
    * Convenience: encode with metrics using a preset name.
    * Equivalent to `preset(name)` then `toBufferWithMetrics(preset.format, preset.quality)`.
@@ -134,6 +143,8 @@ export declare class ImageEngine {
    * Returns the number of bytes written.
    */
   toFile(path: string, format: string, quality?: number | undefined | null, fastMode?: boolean | undefined | null): Promise<number>
+  /** Encode to file using a high-level profile. */
+  toFileProfile(path: string, format: string, profile?: EncodeProfile, quality?: number | undefined | null): Promise<number>
   /** Convenience: encode to file using the preset's recommended format/quality. */
   toFileWithPreset(path: string, presetName: string): Promise<number>
   /**
@@ -258,6 +269,14 @@ export interface FirewallLimitOptions {
   maxPixels?: number
   maxBytes?: number
   timeoutMs?: number
+}
+
+export type EncodeProfile = 'size-first' | 'balanced' | 'speed-first'
+
+export interface ResolvedEncodeProfile {
+  format: string
+  quality?: number
+  fastMode: boolean
 }
 
 /** Image metadata returned by inspect() */
@@ -435,3 +454,9 @@ export declare function createStreamingPipeline(options: {
   writable: NodeJS.WritableStream
   readable: NodeJS.ReadableStream
 }
+
+/**
+ * Resolve encoder options from high-level profile.
+ * Returns normalized `{ format, quality, fastMode }`.
+ */
+export declare function resolveEncodeProfile(format: string, profile?: EncodeProfile, quality?: number | undefined | null): ResolvedEncodeProfile

--- a/index.js
+++ b/index.js
@@ -694,3 +694,91 @@ function getErrorCategory(err) {
 
 module.exports.getErrorCategory = getErrorCategory
 module.exports.createStreamingPipeline = createStreamingPipeline
+
+const DEFAULT_QUALITY_BY_FORMAT = {
+  jpeg: 85,
+  jpg: 85,
+  webp: 80,
+  avif: 60,
+}
+
+const ENCODE_PROFILE_CONFIG = {
+  'size-first': {
+    jpeg: { qualityDelta: -8, fastMode: false },
+    webp: { qualityDelta: -8, fastMode: false },
+    avif: { qualityDelta: -6, fastMode: false },
+    png: { qualityDelta: 0, fastMode: false },
+  },
+  balanced: {
+    jpeg: { qualityDelta: 0, fastMode: false },
+    webp: { qualityDelta: 0, fastMode: false },
+    avif: { qualityDelta: 0, fastMode: false },
+    png: { qualityDelta: 0, fastMode: false },
+  },
+  'speed-first': {
+    jpeg: { qualityDelta: -10, fastMode: true },
+    webp: { qualityDelta: -10, fastMode: false },
+    avif: { qualityDelta: -10, fastMode: false },
+    png: { qualityDelta: 0, fastMode: false },
+  },
+}
+
+function clampQuality(v) {
+  const n = Number(v)
+  if (!Number.isFinite(n)) return undefined
+  return Math.max(0, Math.min(100, Math.round(n)))
+}
+
+/**
+ * Resolve encoder options from high-level profile.
+ * Returns normalized `{ format, quality, fastMode }` usable in toBuffer/toFile APIs.
+ */
+function resolveEncodeProfile(format, profile = 'balanced', quality) {
+  const normalizedFormat = String(format || '').toLowerCase()
+  if (!['jpeg', 'jpg', 'png', 'webp', 'avif'].includes(normalizedFormat)) {
+    throw new Error(`Unsupported format for profile: ${format}`)
+  }
+
+  const normalizedProfile = String(profile || 'balanced').toLowerCase()
+  if (!Object.prototype.hasOwnProperty.call(ENCODE_PROFILE_CONFIG, normalizedProfile)) {
+    throw new Error(`Unsupported encode profile: ${profile}`)
+  }
+
+  const profileConfig = ENCODE_PROFILE_CONFIG[normalizedProfile]
+  const formatKey = normalizedFormat === 'jpg' ? 'jpeg' : normalizedFormat
+  const baseQuality = clampQuality(quality) ?? DEFAULT_QUALITY_BY_FORMAT[formatKey]
+  const delta = (profileConfig[formatKey] || profileConfig.png).qualityDelta
+  const resolvedQuality = baseQuality == null ? undefined : clampQuality(baseQuality + delta)
+  const fastMode = Boolean((profileConfig[formatKey] || profileConfig.png).fastMode)
+
+  return {
+    format: normalizedFormat,
+    quality: resolvedQuality,
+    fastMode,
+  }
+}
+
+module.exports.resolveEncodeProfile = resolveEncodeProfile
+
+if (nativeBinding && nativeBinding.ImageEngine && nativeBinding.ImageEngine.prototype) {
+  const p = nativeBinding.ImageEngine.prototype
+
+  p.toBufferProfile = function toBufferProfile(format, profile = 'balanced', quality) {
+    const resolved = resolveEncodeProfile(format, profile, quality)
+    return this.toBuffer(resolved.format, resolved.quality, resolved.fastMode)
+  }
+
+  p.toBufferWithMetricsProfile = function toBufferWithMetricsProfile(
+    format,
+    profile = 'balanced',
+    quality
+  ) {
+    const resolved = resolveEncodeProfile(format, profile, quality)
+    return this.toBufferWithMetrics(resolved.format, resolved.quality, resolved.fastMode)
+  }
+
+  p.toFileProfile = function toFileProfile(path, format, profile = 'balanced', quality) {
+    const resolved = resolveEncodeProfile(format, profile, quality)
+    return this.toFile(path, resolved.format, resolved.quality, resolved.fastMode)
+  }
+}


### PR DESCRIPTION
## 概要
`size-first / balanced / speed-first` でエンコード設定を扱える高レベルAPIを追加します。

## 変更
- `index.js`
  - `resolveEncodeProfile(format, profile, quality?)` を追加
  - `ImageEngine` に以下を追加
    - `toBufferProfile(...)`
    - `toBufferWithMetricsProfile(...)`
    - `toFileProfile(...)`
- `index.d.ts`
  - 新APIの型定義を追加
- `docs/API.md`
  - 新APIを追記

## 方針
- Rustの既存APIは変更せず、JSレイヤーで非破壊に拡張
- `balanced` をデフォルトにして既存利用との互換を維持

## 検証
- `npm ci`
- `node` で以下を実行して確認
  - `resolveEncodeProfile('jpeg', 'speed-first', 80)`
  - `toBufferProfile` / `toBufferWithMetricsProfile` 呼び出し
