### PR TITLE
ci: gate publish on all release checks

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -384,7 +384,13 @@ jobs:
       id-token: write  # Required for OIDC authentication
     needs:
       - build
+      - test-rust
       - test
+      - quality
+      - perf-safety
+      - supply-chain
+      - coverage
+      - leak-detection
     # Only publish on tag releases (semantic versioning) or manual workflow dispatch
     # CI/README changes are tested by build/test jobs, but don't trigger npm publish
     if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
## Summary
- require all quality and release-safety jobs before publish
- block npm release when perf, supply-chain, coverage, or ASan checks fail

## Testing
- workflow dependency update only
