### PR TITLE
fix: enforce strict quality contract

### DIFF
--- a/docs/INPUT_VALIDATION.md
+++ b/docs/INPUT_VALIDATION.md
@@ -7,7 +7,7 @@ This project now enforces consistent runtime validation at the NAPI boundary. Th
 - `crop(x, y, width, height)`: offsets must be ≥ 0; width/height must be > 0 and ≤ `MAX_DIMENSION`.
 
 ## Quality and format options
-- `quality` must be a finite integer ≥ 0. Values > 100 are clamped to 100 before encoding.
+- `quality` must be a finite integer in the range `1..=100` when provided. Out-of-range values are rejected instead of clamped.
 - `fastMode` remains a boolean; format strings are still validated against supported codecs.
 
 ## Brightness / contrast

--- a/docs/QUALITY_EFFORT_SPEED_MAPPING.md
+++ b/docs/QUALITY_EFFORT_SPEED_MAPPING.md
@@ -1,6 +1,6 @@
 # Quality / Effort / Speed Mapping
 
-This document freezes how `QualitySettings` converts a quality value (0-100) into encoder parameters. The quality bands are shared across formats so the same number yields the same banded behavior.
+This document freezes how `QualitySettings` converts a quality value (1-100) into encoder parameters. The quality bands are shared across formats so the same number yields the same banded behavior.
 
 ## Shared Quality Bands
 
@@ -9,14 +9,14 @@ This document freezes how `QualitySettings` converts a quality value (0-100) int
 | High | 85-100 | Visual fidelity first | 6 | Lowest noise, best detail |
 | Balanced | 70-84 | Quality/latency balance | 7 | Default “high quality” tier |
 | Fast | 50-69 | Size/throughput oriented | 8 | Keep quality reasonable while speeding up |
-| Fastest | 0-49 | Lowest latency | 9 | Prioritize speed over fidelity |
+| Fastest | 1-49 | Lowest latency | 9 | Prioritize speed over fidelity |
 
 ## Format-specific mapping
 
 ### JPEG (mozjpeg)
 - `fast_mode: false` (default) enables aggressive quality optimizations.
 - `fast_mode: true` matches sharp/libjpeg-turbo speed profile.
-- Smoothing: 90+ → 0, 70-89 → 5, 60-69 → 10, 0-59 → 18.
+- Smoothing: 90+ → 0, 70-89 → 5, 60-69 → 10, 1-59 → 18.
 
 ### WebP
 - `method: 4`, `pass: 1`, `preprocessing: 0` are fixed (sharp-equivalent).

--- a/docs/QUALITY_SEMANTICS.md
+++ b/docs/QUALITY_SEMANTICS.md
@@ -3,9 +3,9 @@
 This document clarifies what a `quality` number means for each encoder and how to pick values consistently.
 
 ## TL;DR
-- The same 0–100 number maps to shared bands (High / Balanced / Fast / Fastest) across formats (see `docs/QUALITY_EFFORT_SPEED_MAPPING.md`).
+- The same 1–100 number maps to shared bands (High / Balanced / Fast / Fastest) across formats (see `docs/QUALITY_EFFORT_SPEED_MAPPING.md`).
 - Default qualities are tuned per format: **JPEG 85**, **WebP 80**, **AVIF 60**. PNG ignores `quality`.
-- Values are clamped to 0–100. Passing `undefined` uses the format default.
+- Values must be in the range 1–100. Passing `undefined` uses the format default.
 
 ## Format Semantics
 | Format | Uses `quality`? | Encoder knobs affected | Default | Notes |
@@ -26,7 +26,7 @@ Use these ranges when you want similar subjective quality across formats:
 | Lowest latency | 50–65 | 50–65 | 35–55 | Use when speed trumps fidelity. |
 
 ## API expectations
-- `quality` range: **0–100**, clamped. Values <0 → 0, >100 → 100.
+- `quality` range: **1–100**. Values outside the range are rejected.
 - If you need deterministic size/latency, prefer sticking to the shared bands rather than arbitrary single numbers.
 - For PNG outputs, omit the quality argument to signal intent clearly (it is ignored either way).
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -102,7 +102,7 @@ export declare class ImageEngine {
   /**
    * Encode to buffer asynchronously.
    * format: "jpeg", "jpg", "png", "webp", "avif"
-   * quality: 1-100 (default: JPEG=85, WebP=80, AVIF=60, ignored for PNG)
+   * quality: 1-100 for lossy formats (default: JPEG=85, WebP=80, AVIF=60). Omit for PNG.
    * fastMode: If true, uses faster encoding for JPEG (2-4x faster, slightly larger files). Default: false.
    *
    * **Non-destructive**: This method can be called multiple times on the same engine instance.
@@ -169,7 +169,7 @@ export declare class ImageEngine {
    * - output_dir: Directory to write processed images
    * - options: Output settings
    *   - format: Output format ("jpeg", "png", "webp", "avif")
-   *   - quality: Optional quality (1-100, uses format-specific default if None)
+   *   - quality: Optional quality (1-100, uses format-specific default if omitted; omit for PNG)
    *   - fastMode: Optional fast mode flag (only applies to JPEG, default: false)
    *   - concurrency: Optional number of parallel workers:
    *     - 0 or undefined: Auto-detect based on CPU cores and memory limits (smart concurrency)
@@ -187,7 +187,7 @@ export declare class ImageEngine {
 export interface BatchOptions {
   /** Output format ("jpeg", "png", "webp", "avif") */
   format: string
-  /** Optional quality (1-100), uses format default when omitted */
+  /** Optional quality (1-100), uses format default when omitted. Omit for PNG. */
   quality?: number
   /** Optional fast mode flag (JPEG only, default: false) */
   fastMode?: boolean

--- a/src/codecs/avif_safe.rs
+++ b/src/codecs/avif_safe.rs
@@ -269,8 +269,8 @@ impl SafeAvifEncoder {
     /// Set encoder quality settings.
     ///
     /// # Arguments
-    /// * `quality` - Quality value (0-100)
-    /// * `quality_alpha` - Alpha quality value (0-100)
+    /// * `quality` - Quality value (1-100)
+    /// * `quality_alpha` - Alpha quality value (1-100)
     /// * `speed` - Encoding speed (0-10, where 0 is slowest/best)
     /// * `max_threads` - Maximum number of threads to use
     pub fn configure(&mut self, quality: u8, quality_alpha: u8, speed: i32, max_threads: i32) {

--- a/src/engine/api.rs
+++ b/src/engine/api.rs
@@ -15,6 +15,7 @@ use crate::engine::io::{extract_exif_raw, extract_icc_profile_lossy, load_file_s
 use crate::engine::tasks::{
     BatchResult, BatchTask, EncodeTask, EncodeWithMetricsTask, WriteFileTask,
 };
+#[cfg(feature = "napi")]
 use crate::error::LazyImageError;
 #[cfg(feature = "napi")]
 use crate::ops::{Operation, OutputFormat, PresetConfig, ResizeFit};
@@ -22,7 +23,9 @@ use crate::ops::{Operation, OutputFormat, PresetConfig, ResizeFit};
 use crate::ops::{Operation, PresetConfig};
 #[cfg(feature = "napi")]
 use image::ImageReader;
-use image::{DynamicImage, GenericImageView};
+use image::DynamicImage;
+#[cfg(feature = "napi")]
+use image::GenericImageView;
 #[cfg(feature = "napi")]
 use std::io::Cursor;
 #[cfg(feature = "napi")]
@@ -215,16 +218,15 @@ mod validation {
             None => Ok(None),
             Some(v) => {
                 let int = ensure_finite_integer("quality", v)?;
-                if int < 0 {
+                if !(1..=100).contains(&int) {
                     return Err(LazyImageError::invalid_argument(
                         "quality",
                         int.to_string(),
-                        "must be >= 0",
+                        "must be 1-100",
                     ));
                 }
-                let clamped = int.min(100);
-                let value = u8::try_from(clamped).map_err(|_| {
-                    LazyImageError::invalid_argument("quality", int.to_string(), "must be <= 255")
+                let value = u8::try_from(int).map_err(|_| {
+                    LazyImageError::invalid_argument("quality", int.to_string(), "must be 1-100")
                 })?;
                 Ok(Some(value))
             }
@@ -855,7 +857,7 @@ impl ImageEngine {
 
     /// Encode to buffer asynchronously.
     /// format: "jpeg", "jpg", "png", "webp", "avif"
-    /// quality: 1-100 (default: JPEG=85, WebP=80, AVIF=60, ignored for PNG)
+    /// quality: 1-100 for lossy formats (default: JPEG=85, WebP=80, AVIF=60). Omit for PNG.
     /// fastMode: If true, uses faster encoding for JPEG (2-4x faster, slightly larger files). Default: false.
     ///
     /// **Non-destructive**: This method can be called multiple times on the same engine instance.
@@ -1246,7 +1248,7 @@ impl ImageEngine {
     /// - output_dir: Directory to write processed images
     /// - options: Output settings
     ///   - format: Output format ("jpeg", "png", "webp", "avif")
-    ///   - quality: Optional quality (1-100, uses format-specific default if None)
+    ///   - quality: Optional quality (1-100, uses format-specific default if omitted; omit for PNG)
     ///   - fastMode: Optional fast mode flag (only applies to JPEG, default: false)
     ///   - concurrency: Optional number of parallel workers:
     ///     - 0 or undefined: Auto-detect based on CPU cores and memory limits (smart concurrency)
@@ -1377,7 +1379,7 @@ pub struct PresetBufferResult {
 pub struct BatchOptions {
     /// Output format ("jpeg", "png", "webp", "avif")
     pub format: String,
-    /// Optional quality (1-100), uses format default when omitted
+    /// Optional quality (1-100), uses format default when omitted. Omit for PNG.
     pub quality: Option<f64>,
     /// Optional fast mode flag (JPEG only, default: false)
     pub fast_mode: Option<bool>,

--- a/src/engine/encoder.rs
+++ b/src/engine/encoder.rs
@@ -46,7 +46,19 @@ fn validate_buffer_len(
     Ok(())
 }
 
-/// Single source of truth for mapping quality (0-100) to per-format encoder knobs.
+fn validate_lossy_quality(quality: u8) -> EncoderResult<u8> {
+    if (1..=100).contains(&quality) {
+        Ok(quality)
+    } else {
+        Err(LazyImageError::invalid_argument(
+            "quality",
+            quality.to_string(),
+            "must be 1-100",
+        ))
+    }
+}
+
+/// Single source of truth for mapping quality (1-100) to per-format encoder knobs.
 /// Bands are fixed (WebP filter_strength keeps sharp-compatible 80/60 thresholds):
 /// - High (>=85): Quality first, AVIF speed 6
 /// - Balanced (70-84): Balanced, AVIF speed 7
@@ -67,9 +79,8 @@ enum QualityBand {
 
 impl QualitySettings {
     pub fn new(quality: u8) -> Self {
-        let clamped = quality.min(100);
         Self {
-            quality: clamped as f32,
+            quality: quality as f32,
         }
     }
 
@@ -156,10 +167,10 @@ pub fn encode_jpeg(img: &DynamicImage, quality: u8, icc: Option<&[u8]>) -> Encod
 ///
 /// # Arguments
 /// * `img` - Image to encode
-/// * `quality` - Quality (0-100)
+/// * `quality` - Quality (1-100)
 /// * `icc` - Optional ICC profile
 /// * `fast_mode` - If true, disables expensive optimizations for faster encoding
-///                 (matches Sharp/libjpeg-turbo defaults)
+///   (matches Sharp/libjpeg-turbo defaults)
 pub fn encode_jpeg_with_settings(
     img: &DynamicImage,
     quality: u8,
@@ -168,7 +179,7 @@ pub fn encode_jpeg_with_settings(
 ) -> EncoderResult<Vec<u8>> {
     run_with_panic_policy("encode:jpeg", || {
         use std::borrow::Cow;
-        let quality = quality.min(100);
+        let quality = validate_lossy_quality(quality)?;
 
         // Zero-copy optimization: avoid conversion if already RGB8
         let rgb: Cow<'_, image::RgbImage> = match img {
@@ -474,6 +485,7 @@ pub fn embed_icc_png(png_data: Vec<u8>, icc: &[u8]) -> EncoderResult<Vec<u8>> {
 pub fn encode_webp(img: &DynamicImage, quality: u8, icc: Option<&[u8]>) -> EncoderResult<Vec<u8>> {
     run_with_panic_policy("encode:webp", || {
         use std::borrow::Cow;
+        let quality = validate_lossy_quality(quality)?;
 
         let mut config = webp::WebPConfig::new()
             .map_err(|_| LazyImageError::internal_panic("failed to create WebPConfig"))?;
@@ -554,8 +566,8 @@ pub fn encode_avif(img: &DynamicImage, quality: u8, icc: Option<&[u8]>) -> Encod
     run_with_panic_policy("encode:avif", || {
         use std::borrow::Cow;
 
-        let clamped_quality = quality.min(100);
-        let settings = QualitySettings::new(clamped_quality);
+        let quality = validate_lossy_quality(quality)?;
+        let settings = QualitySettings::new(quality);
         let (width, height) = img.dimensions();
         validate_encode_dimensions(width, height, "avif")?;
 
@@ -624,12 +636,7 @@ pub fn encode_avif(img: &DynamicImage, quality: u8, icc: Option<&[u8]>) -> Encod
         let capped = cmp::min(8, cpu_threads);
         let encoder_threads = cmp::max(2, capped) as i32;
 
-        encoder.configure(
-            clamped_quality,
-            clamped_quality,
-            settings.avif_speed(),
-            encoder_threads,
-        );
+        encoder.configure(quality, quality, settings.avif_speed(), encoder_threads);
 
         let mut output = SafeAvifRwData::new();
 

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -221,6 +221,14 @@ pub enum OutputFormat {
 }
 
 impl OutputFormat {
+    fn validate_quality(quality: u8) -> Result<u8, String> {
+        if (1..=100).contains(&quality) {
+            Ok(quality)
+        } else {
+            Err(format!("invalid quality: {quality}. must be 1-100"))
+        }
+    }
+
     /// Create OutputFormat from string with format-specific default quality.
     ///
     /// Default quality by format (when quality is None):
@@ -237,7 +245,7 @@ impl OutputFormat {
     ///
     /// # Arguments
     /// * `format` - Output format string (jpeg, png, webp, avif)
-    /// * `quality` - Quality value (0-100, None uses format-specific default)
+    /// * `quality` - Quality value (1-100, None uses format-specific default)
     /// * `fast_mode` - Fast mode flag (only applies to JPEG, default: false)
     pub fn from_str_with_options(
         format: &str,
@@ -246,20 +254,34 @@ impl OutputFormat {
     ) -> Result<Self, String> {
         match format.to_lowercase().as_str() {
             "jpeg" | "jpg" => {
-                let q = quality.unwrap_or(85); // JPEG default: 85
+                let q = quality
+                    .map(Self::validate_quality)
+                    .transpose()?
+                    .unwrap_or(85); // JPEG default: 85
                 Ok(Self::Jpeg {
                     quality: q,
                     fast_mode,
                 })
             }
-            "png" => Ok(Self::Png),
+            "png" => {
+                if let Some(quality) = quality {
+                    Self::validate_quality(quality)?;
+                }
+                Ok(Self::Png)
+            }
             "webp" => {
-                let q = quality.unwrap_or(80); // WebP default: 80
+                let q = quality
+                    .map(Self::validate_quality)
+                    .transpose()?
+                    .unwrap_or(80); // WebP default: 80
                 Ok(Self::WebP { quality: q })
             }
             #[cfg(feature = "avif")]
             "avif" => {
-                let q = quality.unwrap_or(60); // AVIF default: 60 (high compression efficiency)
+                let q = quality
+                    .map(Self::validate_quality)
+                    .transpose()?
+                    .unwrap_or(60); // AVIF default: 60 (high compression efficiency)
                 Ok(Self::Avif { quality: q })
             }
             #[cfg(not(feature = "avif"))]
@@ -498,6 +520,18 @@ mod tests {
 
             let format = OutputFormat::from_str("jpeg", Some(100)).unwrap();
             assert!(matches!(format, OutputFormat::Jpeg { quality: 100, .. }));
+        }
+
+        #[test]
+        fn test_quality_below_range_is_rejected() {
+            let err = OutputFormat::from_str("jpeg", Some(0)).unwrap_err();
+            assert!(err.contains("must be 1-100"));
+        }
+
+        #[test]
+        fn test_quality_above_range_is_rejected() {
+            let err = OutputFormat::from_str("jpeg", Some(101)).unwrap_err();
+            assert!(err.contains("must be 1-100"));
         }
 
         #[test]

--- a/test/integration/edge-cases.test.js
+++ b/test/integration/edge-cases.test.js
@@ -177,9 +177,18 @@ async function runTests() {
     // EDGE CASES - Quality values
     // ========================================================================
     
-    await asyncTest('handles quality 0 (minimum)', async () => {
-        const result = await ImageEngine.from(buffer).resize(100).toBuffer('jpeg', 0);
-        assert(result.length > 0, 'should produce output even with quality 0');
+    await asyncTest('rejects quality 0', async () => {
+        let threw = false;
+        try {
+            await ImageEngine.from(buffer).resize(100).toBuffer('jpeg', 0);
+        } catch (e) {
+            threw = true;
+            const category = getErrorCategory(e);
+            assert.strictEqual(category, ErrorCategory.UserError, 'quality 0 should be UserError');
+            assert(e.message.includes('quality'), 'error should mention quality');
+            assert(e.message.includes('1-100'), 'error should mention 1-100');
+        }
+        assert(threw, 'quality 0 should throw');
     });
     
     await asyncTest('handles quality 100 (maximum)', async () => {
@@ -187,10 +196,18 @@ async function runTests() {
         assert(result.length > 0, 'should produce output with quality 100');
     });
     
-    await asyncTest('clamps quality > 100 to valid range', async () => {
-        // Quality should be clamped internally
-        const result = await ImageEngine.from(buffer).resize(100).toBuffer('jpeg', 150);
-        assert(result.length > 0, 'should handle quality > 100');
+    await asyncTest('rejects quality > 100', async () => {
+        let threw = false;
+        try {
+            await ImageEngine.from(buffer).resize(100).toBuffer('jpeg', 150);
+        } catch (e) {
+            threw = true;
+            const category = getErrorCategory(e);
+            assert.strictEqual(category, ErrorCategory.UserError, 'quality > 100 should be UserError');
+            assert(e.message.includes('quality'), 'error should mention quality');
+            assert(e.message.includes('1-100'), 'error should mention 1-100');
+        }
+        assert(threw, 'quality > 100 should throw');
     });
     
     // ========================================================================

--- a/test/integration/input-validation.test.js
+++ b/test/integration/input-validation.test.js
@@ -62,6 +62,34 @@ async function asyncTest(name, fn) {
         assert(threw, 'NaN quality should throw');
     });
 
+    await asyncTest('toBuffer rejects quality 0', async () => {
+        let threw = false;
+        try {
+            await ImageEngine.from(BUFFER).resize(100).toBuffer('jpeg', 0);
+        } catch (e) {
+            threw = true;
+            assert.strictEqual(e.errorCode, 'E400', 'invalid_argument should map to E400');
+            const category = getErrorCategory(e);
+            assert.strictEqual(category, ErrorCategory.UserError, 'category should be UserError');
+            assert(e.message.includes('1-100'), 'message should mention 1-100');
+        }
+        assert(threw, 'quality 0 should throw');
+    });
+
+    await asyncTest('toBuffer rejects quality above 100', async () => {
+        let threw = false;
+        try {
+            await ImageEngine.from(BUFFER).resize(100).toBuffer('jpeg', 101);
+        } catch (e) {
+            threw = true;
+            assert.strictEqual(e.errorCode, 'E400', 'invalid_argument should map to E400');
+            const category = getErrorCategory(e);
+            assert.strictEqual(category, ErrorCategory.UserError, 'category should be UserError');
+            assert(e.message.includes('1-100'), 'message should mention 1-100');
+        }
+        assert(threw, 'quality above 100 should throw');
+    });
+
     await asyncTest('processBatch rejects negative concurrency', async () => {
         const tmpDir = resolveTemp('validation_negative_concurrency');
         let threw = false;
@@ -104,4 +132,3 @@ async function asyncTest(name, fn) {
         process.exit(1);
     }
 })();
-

--- a/tests/edge_cases.rs
+++ b/tests/edge_cases.rs
@@ -264,9 +264,10 @@ mod quality_boundary_tests {
     fn test_quality_0() {
         let img = create_test_image(100, 100);
         let result = encode_jpeg(&img, 0, None);
-        assert!(result.is_ok());
-        let encoded = result.unwrap();
-        assert_eq!(&encoded[0..2], &[0xFF, 0xD8]);
+        assert!(matches!(
+            result,
+            Err(LazyImageError::InvalidArgument { .. })
+        ));
     }
 
     #[test]
@@ -291,18 +292,20 @@ mod quality_boundary_tests {
     fn test_quality_over_100() {
         let img = create_test_image(100, 100);
         let result = encode_jpeg(&img, 101, None);
-        assert!(result.is_ok());
-        let encoded = result.unwrap();
-        assert_eq!(&encoded[0..2], &[0xFF, 0xD8]);
+        assert!(matches!(
+            result,
+            Err(LazyImageError::InvalidArgument { .. })
+        ));
     }
 
     #[test]
     fn test_quality_webp_0() {
         let img = create_test_image(100, 100);
         let result = encode_webp(&img, 0, None);
-        assert!(result.is_ok());
-        let encoded = result.unwrap();
-        assert_eq!(&encoded[0..4], b"RIFF");
+        assert!(matches!(
+            result,
+            Err(LazyImageError::InvalidArgument { .. })
+        ));
     }
 
     #[test]
@@ -316,13 +319,11 @@ mod quality_boundary_tests {
     #[cfg(feature = "avif")]
     fn test_quality_avif_0() {
         let img = create_test_image(100, 100);
-        // AVIFはquality=0も受け入れる（rav1eの実装では品質0も有効）
-        // 品質0は最低品質（最大圧縮）を意味する
         let result = encode_avif(&img, 0, None);
-        assert!(
-            result.is_ok(),
-            "AVIF encoding with quality=0 should succeed"
-        );
+        assert!(matches!(
+            result,
+            Err(LazyImageError::InvalidArgument { .. })
+        ));
     }
 
     #[test]
@@ -584,28 +585,32 @@ mod encoder_error_tests {
     #[test]
     fn test_encode_jpeg_invalid_quality() {
         let img = create_test_image(100, 100);
-        // quality > 100 はクランプされ、エンコードは成功する
         let result = encode_jpeg(&img, 150, None);
-        assert!(result.is_ok(), "encode_jpeg should accept quality > 100");
+        assert!(matches!(
+            result,
+            Err(LazyImageError::InvalidArgument { .. })
+        ));
     }
 
     #[test]
     fn test_encode_webp_invalid_quality() {
         let img = create_test_image(100, 100);
-        // quality > 100 はクランプされ、エンコードは成功する
         let result = encode_webp(&img, 150, None);
-        assert!(result.is_ok(), "encode_webp should accept quality > 100");
-        let encoded = result.unwrap();
-        assert_eq!(&encoded[0..4], b"RIFF");
+        assert!(matches!(
+            result,
+            Err(LazyImageError::InvalidArgument { .. })
+        ));
     }
 
     #[test]
     #[cfg(feature = "avif")]
     fn test_encode_avif_invalid_quality() {
         let img = create_test_image(100, 100);
-        // quality > 100 はクランプされ、エンコードは成功する
         let result = encode_avif(&img, 150, None);
-        assert!(result.is_ok(), "encode_avif should accept quality > 100");
+        assert!(matches!(
+            result,
+            Err(LazyImageError::InvalidArgument { .. })
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- reject out-of-range quality values instead of clamping them silently
- align Rust, N-API, TypeScript, and docs around a single 1-100 quality contract
- add regression tests for invalid quality handling across encoders and public APIs

## Testing
- cargo test --no-default-features
- node test/integration/edge-cases.test.js
- node test/integration/input-validation.test.js
- npx tsc --noEmit