### PR TITLE
docs: align project philosophy

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -8,6 +8,7 @@
 - セキュリティ優先: 全メタデータ（EXIF/XMP/ICC）をデフォルトで削除。`keepMetadata()` で保持可能
 - ゼロコピー入力パス: `fromPath()/processBatch()` → `toFile()` で入力ファイルを JS ヒープへコピーしない
 - AVIF の ICC は v0.9.x（libavif-sys）で保持。<0.9.0 や ravif のみ構成では破棄
+- 思想と非目標: [docs/PROJECT_PHILOSOPHY.md](./docs/PROJECT_PHILOSOPHY.md)
 
 ## 計測可能な指標
 - JS ヒープ増加: `fromPath → toBufferWithMetrics` で **2MB 以下**（`node --expose-gc docs/scripts/measure-zero-copy.js` で検証）

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ lazy-image reduces image file sizes by 20-30% compared to sharp, trading encodin
 - **Not** a drop-in replacement for sharp — use sharp if you need its full API or maximum throughput.
 - **Security-first**: Metadata stripped by default; `keepMetadata()` to preserve. Zero-copy path: `fromPath()`/`processBatch()` → `toFile()`.
 - Japanese: [README.ja.md](./README.ja.md). **mmap**: Do not modify/delete source files while processing; use a copy or `from(Buffer)` for mutable inputs.
+- Philosophy and non-goals: [docs/PROJECT_PHILOSOPHY.md](./docs/PROJECT_PHILOSOPHY.md).
 
 [![npm version](https://badge.fury.io/js/@alberteinshutoin%2Flazy-image.svg)](https://www.npmjs.com/package/@alberteinshutoin/lazy-image)
 [![npm downloads](https://img.shields.io/npm/dm/@alberteinshutoin/lazy-image)](https://www.npmjs.com/package/@alberteinshutoin/lazy-image)
@@ -50,6 +51,8 @@ console.log(`Wrote ${bytesWritten} bytes`);
 4. **AVIF excellence** — ravif encoder with quality-optimized defaults
 
 **What lazy-image does NOT compete on:** raw encoding speed (sharp/libvips is faster), feature breadth (no drawing, compositing, or GIF), API compatibility with sharp.
+
+**Project philosophy:** optimize for smaller web outputs, bounded memory, and safe defaults first. Any speed claims must be codec- and workload-specific, not a blanket "faster than sharp" promise.
 
 Benchmarks and details: [docs/PERFORMANCE.md](./docs/PERFORMANCE.md). Full compatibility matrix: [docs/COMPATIBILITY.md](./docs/COMPATIBILITY.md).
 

--- a/docs/PROJECT_PHILOSOPHY.md
+++ b/docs/PROJECT_PHILOSOPHY.md
@@ -1,0 +1,22 @@
+# Project Philosophy
+
+`lazy-image` is a focused web-image optimization engine, not a general-purpose image toolkit.
+
+## Priorities
+
+1. Smaller outputs than typical `sharp` defaults for web delivery.
+2. Predictable memory behavior and bounded-resource execution.
+3. Safe defaults for metadata, decompression limits, and operational use.
+4. A non-destructive, lazy pipeline API that fits batch and build workflows.
+
+## Non-goals
+
+- Winning raw JPEG/WebP throughput benchmarks across all workloads.
+- Matching the full breadth of `sharp` or ImageMagick-style editing APIs.
+- Being a drop-in replacement for `sharp`.
+
+## How to interpret performance claims
+
+- For JPEG/WebP, `lazy-image` intentionally trades encode latency for smaller files.
+- For AVIF, `lazy-image` may be faster than `sharp` in some real workloads, but that is an advantage within a narrower target area, not the project's primary identity.
+- The project should describe benchmark wins precisely by codec and workload, and avoid broad claims like "faster than sharp" without scope.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,11 +3,13 @@
 // lazy-image: Web image optimization engine for Node.js
 //
 // Design goals:
-// - Faster than sharp
-// - Smaller output than sharp
-// - Better quality than sharp
-// - Lazy pipeline execution
+// - Smaller web outputs than sharp defaults
+// - Predictable memory usage and safer operational behavior
+// - Lazy, non-destructive pipeline execution
+// - Competitive AVIF support without optimizing for universal throughput wins
 // - Non-blocking async API
+//
+// See docs/PROJECT_PHILOSOPHY.md for the project's priorities and non-goals.
 
 #[cfg(feature = "napi")]
 #[macro_use]


### PR DESCRIPTION
## Summary
- replace the blanket "faster than sharp" design goal with scoped priorities and non-goals
- add a dedicated project philosophy document as the source of truth for positioning
- link the philosophy from the English and Japanese READMEs

## Testing
- not run (documentation and comments only)