### PR TITLE
fix: migrate napi config to current cli fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,21 +57,16 @@
     "typescript": "^5.6.3"
   },
   "napi": {
-    "name": "lazy-image",
-    "triples": {
-      "defaults": false,
-      "additional": [
-        "x86_64-apple-darwin",
-        "aarch64-apple-darwin",
-        "x86_64-pc-windows-msvc",
-        "x86_64-unknown-linux-gnu",
-        "aarch64-unknown-linux-gnu",
-        "x86_64-unknown-linux-musl"
-      ]
-    },
-    "package": {
-      "name": "@alberteinshutoin/lazy-image"
-    }
+    "binaryName": "lazy-image",
+    "packageName": "@alberteinshutoin/lazy-image",
+    "targets": [
+      "x86_64-apple-darwin",
+      "aarch64-apple-darwin",
+      "x86_64-pc-windows-msvc",
+      "x86_64-unknown-linux-gnu",
+      "aarch64-unknown-linux-gnu",
+      "x86_64-unknown-linux-musl"
+    ]
   },
   "optionalDependencies": {
     "@alberteinshutoin/lazy-image-darwin-arm64": "0.12.0",


### PR DESCRIPTION
## Summary
- migrate `package.json` NAPI config from deprecated fields to `binaryName` / `packageName` / `targets`
- preserve the existing artifact target set and package name
- remove noisy `@napi-rs/cli` deprecation warnings from `npm run build`

## Testing
- npm run build
- npm test

Closes #456
