### PR TITLE
fix: update prepublish script for current napi cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "test:clean": "rm -rf .tmp/",
     "test:rust": "cargo test --no-default-features",
     "version": "node scripts/sync-version.js",
-    "prepublishOnly": "napi prepublish --skip-gh-release",
+    "prepublishOnly": "napi pre-publish",
     "test:cow-debug": "CI_COW_DEBUG=1 LAZY_IMAGE_DEBUG_COW=1 cargo test --no-default-features --features cow-debug -- test_cow_debug && node test/unit/cow_debug.test.js",
     "test:bench:quality-dual-axis": "node test/benchmarks/quality-dual-axis.bench.js"
   },


### PR DESCRIPTION
## Summary
- replace the outdated `napi prepublish --skip-gh-release` script with the current `napi pre-publish` command
- restore `npm run prepublishOnly` on `develop` with the installed `@napi-rs/cli`
- keep the change scoped to the publish script only

## Testing
- npm install
- npm run prepublishOnly

Closes #458
