### PR TITLE
docs: align roadmap, benchmarks, and adoption guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@
 
 > **Web image optimization engine for Node.js.** Rust core, smaller outputs than sharp.
 
-lazy-image reduces image file sizes by 20-30% compared to sharp, trading encoding speed for smaller outputs. Ideal for CDN-heavy workloads where bandwidth costs matter more than CPU costs.
+lazy-image reduces image file sizes by 20-30% compared to sharp in its target web-delivery scenarios, trading encoding speed for smaller outputs. Ideal for CDN-heavy workloads where bandwidth costs matter more than CPU costs.
 
 - **Not** a drop-in replacement for sharp — use sharp if you need its full API or maximum throughput.
 - **Security-first**: Metadata stripped by default; `keepMetadata()` to preserve. Zero-copy path: `fromPath()`/`processBatch()` → `toFile()`.
 - Japanese: [README.ja.md](./README.ja.md). **mmap**: Do not modify/delete source files while processing; use a copy or `from(Buffer)` for mutable inputs.
 - Lazy contract: [docs/LAZY_SEMANTICS.md](./docs/LAZY_SEMANTICS.md) explains what is deferred vs eager.
+- Metadata matrix: [docs/METADATA_SUPPORT.md](./docs/METADATA_SUPPORT.md).
 - Philosophy and non-goals: [docs/PROJECT_PHILOSOPHY.md](./docs/PROJECT_PHILOSOPHY.md).
 
 [![npm version](https://badge.fury.io/js/@alberteinshutoin%2Flazy-image.svg)](https://www.npmjs.com/package/@alberteinshutoin/lazy-image)
@@ -56,6 +57,19 @@ console.log(`Wrote ${bytesWritten} bytes`);
 **Project philosophy:** optimize for smaller web outputs, bounded memory, and safe defaults first. Any speed claims must be codec- and workload-specific, not a blanket "faster than sharp" promise.
 
 Benchmarks and details: [docs/PERFORMANCE.md](./docs/PERFORMANCE.md). Full compatibility matrix: [docs/COMPATIBILITY.md](./docs/COMPATIBILITY.md).
+
+---
+
+## Recommended Paths
+
+Start with one of these workflows:
+
+- **Web delivery optimization**: `fromPath() -> resize()/crop() -> toFile()` for the lowest heap usage and the clearest operational path
+- **Upload sanitization**: `fromPath() -> sanitize({ policy: 'strict' }) -> toFile()/toBuffer()` for untrusted user uploads
+- **Build-time / batch generation**: `processBatch()` or `clone()` for static sites, media pipelines, and multi-output generation
+- **Final optimization after editing**: use sharp/ImageMagick for compositing, filters, or animation, then pass the result through lazy-image for final JPEG/WebP/AVIF optimization
+
+Scenario guide: [docs/ADOPTION_GUIDE.md](./docs/ADOPTION_GUIDE.md).
 
 ---
 
@@ -135,6 +149,8 @@ More: batch processing, presets, metrics, streaming — [docs/API.md](./docs/API
 | **Troubleshooting** | [docs/TROUBLESHOOTING.md](./docs/TROUBLESHOOTING.md) |
 | **Security policy & reporting** | [SECURITY.md](./SECURITY.md) |
 | **Roadmap & scope** | [docs/ROADMAP.md](./docs/ROADMAP.md) |
+| **Adoption guide / recommended workflows** | [docs/ADOPTION_GUIDE.md](./docs/ADOPTION_GUIDE.md) |
+| **Metadata support matrix** | [docs/METADATA_SUPPORT.md](./docs/METADATA_SUPPORT.md) |
 | **ROI calculator methodology** | [docs/ROI_CALCULATOR.md](./docs/ROI_CALCULATOR.md) |
 | **Version history** | [docs/VERSION_HISTORY.md](./docs/VERSION_HISTORY.md) |
 | **Specification (spec/)** | [spec/pipeline.md](./spec/pipeline.md), [spec/resize.md](./spec/resize.md), [spec/errors.md](./spec/errors.md), [spec/limits.md](./spec/limits.md), [spec/quality.md](./spec/quality.md), [spec/metadata.md](./spec/metadata.md) |
@@ -148,7 +164,7 @@ More: batch processing, presets, metrics, streaming — [docs/API.md](./docs/API
 
 ## Features (summary)
 
-Smaller JPEG (mozjpeg) · Smaller WebP (libwebp) · AVIF (ravif) · ICC profiles (AVIF in v0.9.x) · EXIF auto-orient · Zero-copy file I/O · Bounded-memory streaming · Image Firewall · GPS auto-strip · Fluent API · Rust core (NAPI-RS) · Cross-platform (macOS, Windows, Linux). Design choices and limits: [docs/ROADMAP.md](./docs/ROADMAP.md) and [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md).
+Smaller JPEG (mozjpeg) · Smaller WebP (libwebp) · AVIF (ravif) · ICC profiles (AVIF in v0.9.x) · EXIF auto-orient · Zero-copy file I/O · Disk-backed bounded-memory pipeline (`createStreamingPipeline()`, not true chunked transform streaming) · Image Firewall · GPS auto-strip · Fluent API · Rust core (NAPI-RS) · Cross-platform (macOS, Windows, Linux). Design choices and limits: [docs/ROADMAP.md](./docs/ROADMAP.md) and [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md).
 
 ---
 

--- a/docs/ADOPTION_GUIDE.md
+++ b/docs/ADOPTION_GUIDE.md
@@ -1,0 +1,95 @@
+# Adoption Guide
+
+lazy-image is strongest when used as a **focused web optimization engine**, not as a general-purpose image editing toolkit.
+
+## Recommended Paths
+
+### 1. File-to-file optimization (default recommendation)
+
+Use this when you want the lowest Node.js heap usage and the clearest production path.
+
+```javascript
+await ImageEngine.fromPath('input.jpg')
+  .resize({ width: 1600, fit: 'inside' })
+  .toFile('output.webp', 'webp', 80);
+```
+
+Best for:
+- CDN/mobile delivery
+- Serverless jobs
+- Batch pipelines
+- Large inputs
+
+### 2. Upload sanitization for untrusted images
+
+Use strict firewall mode for user-uploaded avatars, social images, or form uploads.
+
+```javascript
+await ImageEngine.fromPath('upload.jpg')
+  .sanitize({ policy: 'strict' })
+  .resize({ width: 1024, fit: 'inside' })
+  .toFile('safe-output.jpg', 'jpeg', 85);
+```
+
+Best for:
+- Avatar uploads
+- Community/social platforms
+- Admin dashboards handling user content
+
+### 3. Build-time static asset optimization
+
+Use batch processing or cloning when the same source needs multiple outputs.
+
+```javascript
+const engine = ImageEngine.fromPath('hero.png').resize({ width: 1600 });
+
+await Promise.all([
+  engine.clone().toFile('hero.jpg', 'jpeg', 85),
+  engine.clone().toFile('hero.webp', 'webp', 80),
+  engine.clone().toFile('hero.avif', 'avif', 60),
+]);
+```
+
+Best for:
+- Static site generation
+- CMS export pipelines
+- Media preprocessing jobs
+
+### 4. Final optimization after editing elsewhere
+
+Use another tool for rich editing, then run lazy-image as the final delivery optimizer.
+
+Recommended split:
+- `sharp` / ImageMagick: compositing, overlays, blur, animation, SVG/PDF/TIFF workflows
+- `lazy-image`: final JPEG/WebP/AVIF optimization, metadata stripping, bounded-memory output path
+
+This is often the easiest adoption path because it does not require replacing the existing editing stack.
+
+## When Not to Lead With lazy-image
+
+Use another tool first when you need:
+
+- Compositing or overlays
+- Rich filters such as blur/sharpen/tint
+- Animated images
+- Broad input format coverage such as TIFF, HEIF, PDF, SVG, RAW
+- True chunk-by-chunk streaming transforms
+
+## Streaming Note
+
+`createStreamingPipeline()` is available for **disk-backed bounded-memory processing**. It is useful when you need stream-shaped I/O but still want lazy-image's file-based processing model.
+
+It is **not** equivalent to sharp's true streaming transforms:
+- input is staged to disk first
+- output is produced after file processing completes
+- latency includes temp-file I/O
+
+## Operational Default
+
+If you are unsure where to start, use:
+
+```javascript
+ImageEngine.fromPath(input).resize(...).toFile(output, format, quality)
+```
+
+That path best matches the library's design goals: smaller outputs, bounded memory, and predictable server behavior.

--- a/docs/API.md
+++ b/docs/API.md
@@ -21,7 +21,7 @@ See [LAZY_SEMANTICS.md](./LAZY_SEMANTICS.md) for the exact deferred vs eager con
 | `.flipH()` | Flip horizontally |
 | `.flipV()` | Flip vertically |
 | `.grayscale()` | Convert to grayscale |
-| `.keepMetadata(options?)` | Preserve ICC and EXIF metadata. GPS stripped by default for privacy. See [ARCHITECTURE.md](./ARCHITECTURE.md#metadata-handling). |
+| `.keepMetadata(options?)` | Preserve ICC and EXIF metadata. GPS stripped by default for privacy. XMP is not currently preserved. See [METADATA_SUPPORT.md](./METADATA_SUPPORT.md). |
 | `.brightness(value)` | Adjust brightness (-100 to 100) |
 | `.contrast(value)` | Adjust contrast (-100 to 100) |
 | `.normalizePixelFormat()` | Normalize pixel format to RGB/RGBA without color space conversion. |
@@ -56,7 +56,7 @@ See [LAZY_SEMANTICS.md](./LAZY_SEMANTICS.md) for the exact deferred vs eager con
 | `.dimensions()` | Get `{ width, height }` (requires decode) |
 | `.hasIccProfile()` | Returns ICC profile size in bytes, or null if none |
 | `resolveEncodeProfile(format, profile, quality?)` | Resolve profile into concrete `{ format, quality, fastMode }` options. |
-| `createStreamingPipeline({ format, quality, ops, onMetrics? })` | Disk-backed bounded-memory pipeline. Optional `onMetrics` callback receives `ProcessingMetrics` after file output completes. |
+| `createStreamingPipeline({ format, quality, ops, onMetrics? })` | Disk-backed bounded-memory pipeline. Not a true chunk-by-chunk transform stream. Optional `onMetrics` callback receives `ProcessingMetrics` after file output completes. |
 
 ---
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -29,8 +29,8 @@ You can query at runtime with `supportedInputFormats()` and
 | Compositing / overlays | ❌ | ✅ |
 | Rich filters (blur/sharpen/tint/etc) | ❌ | ✅ |
 | Animated images (GIF/WebP) | ❌ | ✅ |
-| Streaming pipeline | ❌ | ✅ |
-| Metadata | ICC + EXIF (GPS auto-strip) | ✅ (EXIF/XMP/etc) |
+| Streaming pipeline | Disk-backed bounded-memory pipeline (`createStreamingPipeline()`), not true streaming transforms | ✅ |
+| Metadata | ICC + EXIF (GPS auto-strip, XMP unsupported) | ✅ (EXIF/XMP/etc) |
 | AVIF encoding | ✅ (focus area) | ✅ |
 
 ## Non-goals
@@ -44,3 +44,6 @@ You can query at runtime with `supportedInputFormats()` and
 - You want **smaller files** and are OK with a smaller API surface.
 - You care about **AVIF speed** and **JPEG size optimization**.
 - You want clear error taxonomy and strict limits for user uploads.
+- You are fine with a disk-backed bounded-memory pipeline instead of true chunk transform streaming.
+
+For exact metadata behavior, see [METADATA_SUPPORT.md](./METADATA_SUPPORT.md).

--- a/docs/METADATA_SUPPORT.md
+++ b/docs/METADATA_SUPPORT.md
@@ -1,0 +1,59 @@
+# Metadata Support Matrix
+
+This document is the canonical reference for metadata behavior in lazy-image.
+
+## Default Behavior
+
+By default, lazy-image strips metadata for safety and smaller outputs.
+
+- ICC: stripped unless explicitly preserved
+- EXIF: stripped unless explicitly preserved
+- GPS: stripped by default even when EXIF is preserved
+- XMP: not currently preserved
+
+Use `keepMetadata()` to opt into preservation where supported.
+
+```javascript
+await ImageEngine.fromPath('input.jpg')
+  .keepMetadata({ icc: true, exif: true })
+  .toFile('output.jpg', 'jpeg', 85);
+```
+
+## Feature Matrix
+
+| Metadata type | Default | Opt-in API | Current status |
+|---|---|---|---|
+| ICC | stripped | `keepMetadata({ icc: true })` | supported |
+| EXIF | stripped | `keepMetadata({ exif: true })` | supported |
+| GPS | stripped | `keepMetadata({ exif: true, stripGps: false })` | supported, privacy-first default is strip |
+| XMP | stripped | `keepMetadata({ xmp: true })` | not supported, emits runtime warning |
+
+## Output Format Matrix
+
+| Output format | ICC | EXIF | GPS | XMP | Notes |
+|---|---|---|---|---|---|
+| JPEG | supported | supported | stripped by default, opt-in preserve | not supported | Orientation is normalized after auto-orient |
+| PNG | ICC supported | not currently documented as preserved | n/a | not supported | PNG metadata support is narrower than JPEG |
+| WebP | ICC supported | not currently documented as preserved | n/a | not supported | Favor explicit testing before relying on non-ICC metadata |
+| AVIF | ICC supported on v0.9.x+ with `libavif-sys` | not currently documented as preserved | n/a | not supported | On older/ravif-only builds ICC may be dropped |
+
+## Important Caveats
+
+- `xmp: true` currently does **not** preserve XMP. It only emits a warning and continues processing.
+- EXIF Orientation is reset to `1` after auto-orient to avoid downstream double rotation.
+- `sanitize({ policy: 'strict' })` can override metadata preservation and strip metadata for safety.
+- For workflows that depend on exact metadata retention, validate behavior in integration tests against your target output format.
+
+## Recommended Usage
+
+- Web delivery: keep the default strip behavior unless ICC/EXIF is genuinely required
+- Photography / color-sensitive workflows: opt into ICC explicitly
+- Privacy-sensitive uploads: keep GPS stripping enabled
+- Metadata-critical pipelines: prefer JPEG if you need the clearest documented EXIF path today
+
+## References
+
+- [API.md](./API.md)
+- [ARCHITECTURE.md](./ARCHITECTURE.md#metadata-handling)
+- [MIGRATION_FROM_SHARP.md](./MIGRATION_FROM_SHARP.md)
+- [README.md](../README.md)

--- a/docs/MIGRATION_FROM_SHARP.md
+++ b/docs/MIGRATION_FROM_SHARP.md
@@ -8,6 +8,16 @@ This guide helps teams port common sharp workflows to **lazy-image**. The focus 
 - Formats: lazy-image inputs jpeg/png/webp; outputs jpeg/png/webp/avif. Use sharp if you need TIFF, GIF, HEIF, or multi-page inputs.
 - Streaming: lazy-image lacks sharp's true streaming transforms; `createStreamingPipeline()` stages to disk for bounded-memory processing.
 
+## Recommended Coexistence Strategy
+
+In many teams, the best migration is **not** full replacement.
+
+Recommended split:
+- Use `sharp` or another editor for compositing, overlays, filters, animation, and broad input-format support
+- Use `lazy-image` for final JPEG/WebP/AVIF optimization, metadata stripping, and lower-heap file-to-file processing
+
+This keeps existing editing workflows intact while still gaining lazy-image's web-delivery strengths.
+
 ## API Mapping
 | sharp | lazy-image | Notes |
 |-------|-----------|-------|
@@ -47,17 +57,17 @@ const output = await ImageEngine.from(input)
 ```
 
 ## Performance Comparison (when to switch)
-- AVIF: lazy-image is ~6× faster than sharp for large PNG→AVIF conversions and yields ~38% smaller AVIF files (see README benchmarks).
-- JPEG: expect 20–25% smaller files; encoding is slower because compression is prioritized over throughput.
-- WebP: similar or slightly slower throughput; use if you want the safer defaults and metadata stripping.
+- AVIF: in the canonical `PNG -> AVIF (no resize, 5000×5000)` benchmark, lazy-image is **1.70x faster** and produces **40.9% smaller** output. See [TRUE_BENCHMARKS.md](./TRUE_BENCHMARKS.md).
+- JPEG: in the canonical `PNG -> JPEG (no resize, 5000×5000)` benchmark, lazy-image produces **17.0% smaller** output. Encoding speed depends on workload and settings.
+- WebP: use if you want the safer defaults and metadata stripping, but expect sharp to remain faster in many throughput-sensitive workloads.
 - Latency-sensitive or filter-heavy workloads still favor sharp; build-time optimization and batch processing favor lazy-image.
 
 ## FAQ
 **Q. How are ICC profiles handled?**  
-lazy-image strips metadata by default for safety; call `.keepMetadata({ icc: true })` to retain profiles. AVIF ICC is preserved on v0.9.x (libavif-sys). sharp also strips metadata by default—use `.withMetadata()` to preserve ICC/EXIF during transforms.
+lazy-image strips metadata by default for safety; call `.keepMetadata({ icc: true })` to retain profiles. AVIF ICC is preserved on v0.9.x (libavif-sys). sharp also strips metadata by default—use `.withMetadata()` to preserve ICC/EXIF during transforms. See [METADATA_SUPPORT.md](./METADATA_SUPPORT.md).
 
 **Q. What about EXIF/GPS and other metadata?**  
-lazy-image removes EXIF by default and always strips GPS unless `stripGps: false` is set. sharp drops EXIF unless you opt into `.withMetadata()`; scrub GPS manually if you need parity with lazy-image defaults.
+lazy-image removes EXIF by default and always strips GPS unless `stripGps: false` is set. XMP preservation is not currently supported. sharp drops EXIF unless you opt into `.withMetadata()`; scrub GPS manually if you need parity with lazy-image defaults.
 
 **Q. Does lazy-image auto-orient like sharp?**  
 Yes. Both respect EXIF orientation and normalize the tag after rotation. lazy-image resets Orientation to 1 to avoid double-rotation in downstream viewers.

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -2,15 +2,21 @@
 
 lazy-image is optimized for **smaller output and memory safety** rather than raw throughput. This guide helps you choose between lazy-image and sharp and use lazy-image effectively.
 
-## Benchmark Summary (Large Image 5000×5000px)
+## Canonical Benchmark Source
 
-| Feature | Metric | lazy-image | sharp | Verdict |
-|---------|--------|------------|-------|---------|
-| **AVIF Generation** | Time | **13.3s** | 47.4s | lazy-image ~3.5× faster |
-| **JPEG Compression** | File Size | **1.1 MB** | 1.5 MB | lazy-image ~26% smaller |
-| **JPEG Encoding** | Speed | 1.2s | **0.3s** | sharp ~4× faster |
-| **Memory (format conv.)** | Peak RSS | **713 MB** | 2,416 MB | lazy-image ~70% less |
-| **WebP Resize** | Speed | 320ms | **134ms** | sharp ~2.5× faster |
+The canonical benchmark dataset for public performance claims is [TRUE_BENCHMARKS.md](./TRUE_BENCHMARKS.md).
+
+All summary claims in README and migration docs should be derived from that document's exact scenarios rather than mixing numbers from different workloads.
+
+## Benchmark Summary (Canonical Scenarios)
+
+| Scenario | Metric | lazy-image | sharp | Interpretation |
+|---------|--------|------------|-------|----------------|
+| PNG → AVIF (no resize, 5000×5000) | Encode time | **3,137ms** | 5,320ms | lazy-image is **1.70x faster** in this specific format-conversion workload |
+| PNG → AVIF (no resize, 5000×5000) | Output size | **762,711 bytes** | 1,290,501 bytes | lazy-image output is **40.9% smaller** in this workload |
+| PNG → JPEG (no resize, 5000×5000) | Output size | **1,224,894 bytes** | 1,475,223 bytes | lazy-image output is **17.0% smaller** |
+| PNG → WebP (no resize, 5000×5000) | Encode time | 6,777ms | **975ms** | sharp is much faster for this workload |
+| JPEG/WebP real-time resize workloads | Latency | varies by codec and settings | often faster | use sharp if sub-100ms latency is the main priority |
 
 Full data: [TRUE_BENCHMARKS.md](./TRUE_BENCHMARKS.md).
 
@@ -20,7 +26,7 @@ Full data: [TRUE_BENCHMARKS.md](./TRUE_BENCHMARKS.md).
 
 - **Serverless (Lambda, Cloud Run, Vercel, etc.)** — Avoid OOM and smaller cold-start footprint.
 - **Bandwidth-sensitive** — Smaller JPEG/AVIF saves CDN and transfer costs.
-- **AVIF generation** — Production-ready AVIF without timeouts on large files.
+- **AVIF generation** — Strong results in the benchmarked PNG → AVIF format-conversion workloads.
 - **Memory-constrained** — 512MB containers; zero-copy path keeps heap low.
 - **Safety-first** — Rust memory safety; built-in decompression limits and Image Firewall.
 
@@ -32,7 +38,7 @@ Full data: [TRUE_BENCHMARKS.md](./TRUE_BENCHMARKS.md).
 
 ## Philosophy
 
-lazy-image trades raw JPEG/WebP encoding speed for **smaller files** and **stable memory**. “Slow to encode, fast to load.”
+lazy-image trades raw JPEG/WebP encoding speed for **smaller files** and **stable memory**. Treat benchmark wins as **codec- and workload-specific**, not universal throughput claims.
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,110 +1,61 @@
-Here is the updated `ROADMAP.md` organized by OSS standards.
-It strictly separates "Completed" from "Planned" tasks, details specific goals for upcoming versions, and is divided into English (top) and Japanese (bottom) sections.
-
----
-
 # 🗺️ lazy-image Roadmap
 
 > **Vision:** To be the most efficient, secure, and portable web image optimization engine for the cloud age.
 
-This document outlines the development status and future direction of `lazy-image`. We follow Semantic Versioning.
+This document reflects the current state of `develop` and focuses on the work that still meaningfully remains.
 
-## ✅ Completion Status Checklist
+## Current State
 
-### 🏗️ Architecture & Core (v0.8.x - Completed)
+The following foundations are already in place on `develop`:
 
-* [x] **True Lazy Loading**: Defer file I/O until necessary (`fromPath`).
-* [x] **Zero-Copy Architecture**: Prevent pixel copying during format conversion.
-* [x] **Thread Safety**: Fix libuv/rayon thread pool conflicts.
-* [x] **Structured Error Handling**: Replace string errors with typed `ErrorCode`.
-* [x] **Non-destructive API**: Implement `clone()` behavior for `toBuffer` (ADR-001).
+- **Lazy, non-destructive pipeline**: deferred decode, `clone()`, file-based happy path
+- **Zero-copy / mmap path**: `fromPath()` and batch-oriented file processing
+- **Structured errors and operational limits**: typed error taxonomy and Image Firewall
+- **Metadata-safe defaults**: strip by default, GPS strip, opt-in preservation paths
+- **Benchmark and regression tooling**: benchmark docs, regression workflow, zero-copy measurement
+- **Fuzzing in CI**: nightly and PR-targeted fuzz workflows with multiple targets
+- **Release-size tuning**: release LTO, strip, and size-oriented profile tuning
 
-### ⚡ Optimization & Efficiency (v0.8.x - Completed)
+## Current Priorities
 
-* [x] **WebP Speed Tuning**: Optimize default parameters (Method 6 → 4) to match `sharp`. ✅ **Completed in v0.8.1**
+### 1. Reliability proof for v1.x adoption
 
-### ⚡ Optimization & Efficiency (v0.9.x - In Progress)
-* [x] **Strip Metadata by Default**: Remove Exif/XMP for security and smaller file sizes. ✅ **Completed in v0.9.x** (GPS auto-strip, EXIF preservation opt-in)
-* [ ] **Binary Size Reduction**: Enable LTO and strip symbols for faster cold starts.
-* [ ] **Documentation Update**: Publish "True Benchmarks" (AVIF speed / JPEG size).
+- Strengthen long-running leak and sanitizer coverage across NAPI boundaries
+- Continue hardening decode / codec / metadata paths against malformed inputs
+- Keep benchmark regression checks and fuzz coverage aligned with new features
 
-### 🛡️ Reliability & Stability (v1.0.0 - Planned)
+### 2. Documentation and expectation management
 
-* [ ] **Fuzzing Tests**: Implement `cargo-fuzz` to prevent crashes from malformed inputs.
-* [ ] **Memory Leak Detection**: CI integration with Valgrind/Sanitizers.
-* [ ] **API Freeze**: Final review of TypeScript definitions and public Rust API.
+- Keep roadmap, migration docs, benchmark docs, and compatibility docs in sync with the actual implementation
+- Make workload-specific benchmark claims precise and reproducible
+- Clarify partial-support areas such as metadata and disk-backed streaming
+
+### 3. Product fit in real workloads
+
+- Deepen the recommended file-to-file operational path
+- Improve scenario-based adoption guidance for serverless, upload pipelines, and build-time optimization
+- Expand observability and operational ergonomics where they help production adoption most
 
 ---
 
-## 📅 Detailed Version Roadmap
+## Future Directions
 
-### v0.8.1 - "WebP Speed Optimization" (Released 2026-01-01)
+### Near-term
 
-**Focus:** WebP encoding performance parity with sharp.
+- Broader reliability validation and memory-leak detection automation
+- Clearer product docs and compatibility boundaries
+- Ongoing polish for batch, byte-budget, and observability workflows
 
-* **Performance: WebP Optimization** ✅
-* **Goal:** Eliminate the "5x slower than sharp" bottleneck. ✅ **Achieved**
-* **Task:** Change default WebP `method` from 6 to 4. ✅ **Completed**
-* **Task:** Disable heavy preprocessing by default. ✅ **Completed**
-* **Result:** ~4x speed improvement, now matches sharp's performance while maintaining quality parity.
+### Mid-term
 
-### v0.9.0 - "The Optimizer" (Next Release)
+- Better production ergonomics for constrained cloud/container environments
+- More precise telemetry hooks and operational introspection
+- Additional adoption guides and migration aids for real workloads
 
-**Focus:** Winning the benchmarks in all categories (Speed & Size).
+### Long-term
 
-
-* **Efficiency: Secure-by-Default Metadata** ✅ **Completed**
-* **Goal:** Ensure output files are smaller than `sharp`'s and privacy-safe.
-* **Task:** ~~Implement logic to strip Exif, XMP, and Comments during encoding.~~ Done
-* **Task:** ~~Add `.keepMetadata()` API for opt-in preservation.~~ Done (with GPS auto-strip)
-
-
-* **Deployment: Binary Minimization**
-* **Goal:** Reduce binary size from ~9MB to <7MB for AWS Lambda.
-* **Task:** Configure `Cargo.toml` with `lto = "fat"`, `strip = "symbols"`, `codegen-units = 1`.
-
-
-
-### v1.0.0 - "Production Ready" (Stable)
-
-**Focus:** proving reliability for enterprise adoption.
-
-* **Security: Automated Fuzzing**
-* **Goal:** Zero panic/crashes on corrupted inputs.
-* **Task:** Create fuzz targets for the decoder pipeline.
-
-
-* **Stability: Long-running Tests**
-* **Goal:** Prove memory safety across NAPI boundaries over time.
-* **Task:** Add memory leak check jobs to GitHub Actions.
-
-
-* **API: Final Freeze**
-* **Goal:** Guarantee no breaking changes for v1.x lifecycle.
-* **Task:** Audit `index.d.ts` and verify all public interfaces.
-
-
-
-### v1.x - "Serverless Native" (Future)
-
-**Focus:** Advanced cloud-native features.
-
-* **Smart Concurrency (Auto Memory Cap)**
-* **Goal:** Prevent OOM kills in constrained containers (e.g., 512MB limit).
-* **Task:** Detect container memory limits and auto-adjust thread pool size.
-
-
-* **Telemetry Hooks**
-* **Task:** Expose detailed metrics (CPU time, Peak RAM) per request.
-
-
-
-### v2.0 - "Universal Engine" (Long Term)
-
-**Focus:** Beyond Node.js.
-
-* **WebAssembly (Wasm) Support**: Support for Cloudflare Workers and Browsers.
-* **Streaming API**: Native support for Web Streams API.
+- WebAssembly / worker-oriented packaging where the architecture fits
+- Native Web Streams style APIs if and when true streaming execution becomes viable
 
 ---
 
@@ -123,97 +74,62 @@ To maintain focus and stability, the following features are explicitly **out of 
 
 > **ビジョン:** クラウド時代における、最も効率的で、安全で、ポータブルなWeb画像最適化エンジンとなること。
 
-本ドキュメントは `lazy-image` の開発状況と将来の方向性を定義します。本プロジェクトはセマンティックバージョニングに従います。
+このドキュメントは `develop` の現状を反映し、今後本当に残っている課題に絞って整理したものです。
 
-## ✅ 達成状況チェックリスト
+## 現在の状態
 
-### 🏗️ アーキテクチャとコア (v0.8.x - 完了)
+`develop` にはすでに以下の基盤があります。
 
-* [x] **真の遅延読み込み (True Lazy)**: `fromPath` によるファイルIOの遅延化。
-* [x] **ゼロコピー・アーキテクチャ**: フォーマット変換時のピクセルコピー回避。
-* [x] **スレッド安全性**: libuv/rayon スレッドプールの競合解消。
-* [x] **構造化エラーハンドリング**: 文字列エラーの撤廃と `ErrorCode` の導入。
-* [x] **非破壊API**: `toBuffer` の `clone()` 挙動の確定 (ADR-001)。
-
-### ⚡ 最適化と効率性 (v0.9.x - 進行中)
-
-* [x] **WebP 速度チューニング**: デフォルト設定を最適化し `sharp` と同等の速度へ。 ✅ **v0.8.1 で完了**
-* [x] **メタデータ削除のデフォルト化**: Exif/XMPを削除し、セキュリティとサイズを改善。 ✅ **v0.9.x で完了** (GPS自動削除、EXIF保持オプトイン)
-* [ ] **バイナリサイズ削減**: LTO有効化によるコールドスタート高速化。
-* [ ] **ドキュメント更新**: 「真実のベンチマーク」（AVIF速度/JPEGサイズ）の公開。
-
-### 🛡️ 信頼性と安定性 (v1.0.0 - 計画中)
-
-* [ ] **ファジングテスト**: 不正な入力データによるクラッシュ防止。
-* [ ] **メモリリーク検知**: Valgrind/Sanitizer によるCIテスト導入。
-* [ ] **API 凍結**: TypeScript定義とRust公開APIの最終確定。
+- **lazy / 非破壊パイプライン**: deferred decode、`clone()`、file-to-file の主導線
+- **zero-copy / mmap 経路**: `fromPath()` とバッチ処理向けファイル経路
+- **構造化エラーと制限**: typed error taxonomy と Image Firewall
+- **安全なメタデータデフォルト**: デフォルト strip、GPS strip、必要時のみ opt-in
+- **ベンチマーク運用**: benchmark docs、regression workflow、zero-copy 計測
+- **CI fuzzing**: 複数ターゲットを持つ PR / nightly fuzz workflow
+- **リリースサイズ最適化**: release LTO、strip、サイズ指向の profile tuning
 
 ---
 
-## 📅 バージョン別詳細ロードマップ
+## 現在の優先課題
 
-### v0.9.0 - "The Optimizer" (次回リリース)
+### 1. v1.x 採用に向けた信頼性の証明
 
-**目標:** ベンチマークにおける弱点（WebPの速度・ファイルサイズ）を完全に克服する。
+- NAPI 境界を含む長時間稼働・リーク検知の強化
+- 壊れた入力に対する decode / codec / metadata 経路の継続的 hardening
+- 新機能追加時も benchmark regression と fuzz coverage を維持
 
-* **Performance: WebP 最適化**
-* **ゴール:** 「sharpより5倍遅い」状態の解消。
-* **タスク:** デフォルトの `method` を 6 から 4 へ変更。
-* **タスク:** 重い前処理（preprocessing）をデフォルトで無効化。
+### 2. ドキュメントと期待値管理
 
+- roadmap / migration / benchmark / compatibility docs を実装と同期させる
+- workload ごとの benchmark claim を正確に再現可能な形で示す
+- metadata や disk-backed streaming のような partial-support 領域を明確化する
 
-* **Efficiency: セキュア・デフォルト (メタデータ削除)** ✅ **完了**
-* **ゴール:** `sharp` よりも出力ファイルを小さくし、プライバシーを保護する。
-* **タスク:** ~~エンコード時に Exif, XMP, Comments を自動削除するロジックの実装。~~ 完了
-* **タスク:** ~~`.keepMetadata()` API（オプトイン機能）の追加。~~ 完了 (GPS自動削除付き)
+### 3. 実運用でのプロダクト適合
 
+- file-to-file の主導線をさらに明確にする
+- serverless、upload pipeline、build-time optimization 向けの導入ガイドを充実させる
+- 本当に運用価値の高い observability / ergonomics に投資する
 
-* **Deployment: バイナリ最小化**
-* **ゴール:** AWS Lambda 向けにバイナリサイズを ~9MB から 7MB以下へ。
-* **タスク:** `Cargo.toml` にて `lto = "fat"`, `strip = "symbols"` 等を適用。
+---
 
+## 将来の方向性
 
+### 近い将来
 
-### v1.0.0 - "Production Ready" (安定版)
+- リーク検知や sanitizer の自動化強化
+- 互換性と期待値のドキュメント整備
+- batch、byte-budget、observability の運用磨き込み
 
-**目標:** 企業採用に耐えうる「信頼性」の証明。
+### 中期
 
-* **Security: 自動ファジング**
-* **ゴール:** 破損した画像によるパニック発生率ゼロ。
-* **タスク:** デコーダーに対する `cargo-fuzz` ターゲットの作成。
+- 制約の強いクラウド / コンテナ環境向け ergonomics の向上
+- テレメトリーと運用 introspection の拡張
+- 実務ユースケースに沿った移行ガイドの追加
 
+### 長期
 
-* **Stability: 長時間稼働テスト**
-* **ゴール:** NAPI境界におけるメモリ安全性の証明。
-* **タスク:** GitHub Actions にメモリリーク検知ジョブを追加。
-
-
-* **API: 完全凍結**
-* **ゴール:** v1.x 系における破壊的変更なしの保証。
-* **タスク:** `index.d.ts` の全監査とインターフェース確定。
-
-
-
-### v1.x - "Serverless Native" (将来)
-
-**目標:** クラウドネイティブ機能の強化。
-
-* **スマート・コンカレンシー (自動メモリ制御)**
-* **ゴール:** 低メモリコンテナ（例: 512MB）での OOM Kill 回避。
-* **タスク:** コンテナのメモリ制限を検知し、スレッドプールサイズを自動調整。
-
-
-* **テレメトリー**
-* **タスク:** リクエストごとのCPU時間やピークメモリ使用量の取得API。
-
-
-
-### v2.0 - "Universal Engine" (長期)
-
-**目標:** Node.js の枠を超える。
-
-* **WebAssembly (Wasm) 対応**: Cloudflare Workers やブラウザでの動作。
-* **ストリーミング API**: Web Streams API のネイティブサポート。
+- 適合する形での WebAssembly / worker 向け展開
+- 実行モデルが整った場合の native Web Streams 風 API
 
 ---
 

--- a/docs/TRUE_BENCHMARKS.md
+++ b/docs/TRUE_BENCHMARKS.md
@@ -1,9 +1,19 @@
-# True Benchmarks: AVIF Speed & JPEG Size Advantages
+# True Benchmarks: Canonical Benchmark Dataset
+
+This document is the **canonical benchmark source** for public performance claims in lazy-image documentation.
+
+Use this file when citing benchmark numbers in:
+
+- `README.md`
+- `docs/PERFORMANCE.md`
+- `docs/MIGRATION_FROM_SHARP.md`
+
+Do not mix numbers from different workloads without clearly labeling the scenario.
 
 This document provides comprehensive benchmark documentation showing the actual performance characteristics of lazy-image, with a focus on:
 
-- **AVIF encoding speed advantages** (lazy-image is 1.70x faster than sharp for format conversion)
-- **JPEG file size advantages** (mozjpeg optimization produces 17-20% smaller files)
+- **AVIF encoding speed advantages** in a specific PNG → AVIF format-conversion workload
+- **JPEG file size advantages** in benchmarked web-delivery scenarios
 
 ## Test Environment
 
@@ -35,7 +45,7 @@ npm run test:bench:compare
 
 ## AVIF Encoding Speed Advantages
 
-lazy-image significantly outperforms sharp in AVIF encoding speed, making it ideal for next-generation image formats.
+In the benchmarked no-resize PNG → AVIF scenario below, lazy-image outperforms sharp in AVIF encoding speed.
 
 ### Performance Results
 
@@ -206,7 +216,7 @@ WebP: 0.7% smaller files (but slower encoding)
 Memory: Zero-copy architecture for format conversions
 ```
 
-**Summary**: lazy-image excels at **AVIF generation** (both speed and file size for format conversion) and **JPEG compression efficiency** (17-20% smaller files). For WebP, lazy-image produces slightly smaller files but with slower encoding speed.
+**Summary**: lazy-image excels at **AVIF generation** in the benchmarked format-conversion workload and **JPEG compression efficiency** in the benchmarked delivery-oriented scenarios. For WebP, lazy-image produces slightly smaller files but with slower encoding speed.
 
 ---
 

--- a/docs/VERSIONING_PLAN.md
+++ b/docs/VERSIONING_PLAN.md
@@ -1,241 +1,32 @@
-# 📋 Versioning Plan & Issue Prioritization
+# 📋 Versioning Plan & Priorities
 
-> **Current Version**: v0.9.0 (2026-01-21)  
-> **Goal**: v1.0.0 "Production Ready" release
+> **Current package version**: v0.12.x  
+> **Working baseline**: `develop`
 
-このドキュメントは、v0.9.0からv1.0.0までのバージョニングプランと、各issueの優先順位を定義します。
+このドキュメントは、古い issue 番号ベースの固定計画ではなく、`develop` の現状に合った優先順位を簡潔に示します。
 
----
+## 現在の優先順位
 
-## 🎯 Version Roadmap Overview
+### P1
 
-```
-v0.9.0 (Current) ──┐
-                    │
-                    └──> v1.0.0 ──> v1.x ──> v2.0
-                    "Production Ready"  "Serverless"  "Universal"
-```
+- 長時間稼働と NAPI 境界を含むリーク検知の強化
+- benchmark / migration / compatibility / roadmap の整合性維持
+- metadata と streaming の部分対応領域の期待値管理
 
----
+### P2
 
-## 📦 v0.9.0 - "The Optimizer" (Next Release)
+- serverless / upload / build pipeline 向けの導入ドキュメント拡充
+- observability と batch ergonomics の改善
+- 既存 benchmark / fuzz / regression 運用の継続的改善
 
-**目標**: パフォーマンスと効率性の最適化、v1.0.0への準備
+### P3
 
-### Must-Have (v0.9.0必須)
+- worker / wasm 向け展開の検討
+- true streaming execution model が成立する場合の新 API 検討
 
-#### P0 - Critical
-- **#83**: stability: Add memory leak detection to CI with Valgrind/Sanitizers
-  - **理由**: v1.0.0の前提条件。CIでの自動検知が必須
-  - **状態**: 部分的に実装済み（sanitizersジョブは存在）が、完全な統合が必要
-  - **作業**: CIジョブの完全な統合とドキュメント化
+## リリース方針
 
-#### P1 - High Priority
-- **#132**: performance: Replace fast_image_resize Fallback Logic (確実性の担保)
-  - **理由**: パフォーマンスの予測可能性はv1.0.0の品質要件
-  - **影響**: すべての画像で一貫した高速処理を保証
-  - **作業**: フォールバックロジックの除去、データ正規化の実装
+- patch/minor: additive changes, docs alignment, performance/safety improvements
+- major: API removal, semantic shifts, or new execution-model assumptions
 
-- **#133**: security: Safety Audit & Abstraction for libavif FFI (AVIFの安全化)
-  - **理由**: メモリ安全性はv1.0.0の必須要件
-  - **影響**: AVIFエンコーディングの安全性向上
-  - **作業**: SafeAvifImageラッパーの実装
-
-- **#106**: 虚偽の「ColorSpace」APIの撤廃または実装
-  - **理由**: APIの一貫性と明確性。v1.0.0前に解決すべき
-  - **影響**: ユーザー混乱の解消、APIの明確化
-  - **作業**: 実装または完全な撤廃
-
-### Should-Have (v0.9.0推奨)
-
-#### P2 - Medium Priority
-- **#129**: refactor: Decompose ImageEngine (神クラスの解体)
-  - **理由**: 保守性向上。v1.0.0前のリファクタリング推奨
-  - **影響**: コードレビュー効率向上、バグ発見率向上
-  - **作業**: モジュール分割の実装
-
-- **#130**: performance: Minimize NAPI Copy Overhead (コピーゼロ化)
-  - **理由**: パフォーマンス改善。大きな画像処理で効果的
-  - **影響**: メモリコピーオーバーヘッドの削減
-  - **作業**: External Bufferの実装
-
-- **#100**: test: カバレッジ改善のためのテスト追加
-  - **理由**: テストカバレッジの向上はv1.0.0の品質要件
-  - **影響**: バグ発見率の向上
-  - **作業**: 不足しているテストケースの追加
-
-- **#111**: ADR実装と現状の乖離の解消
-  - **理由**: ドキュメントの正確性はv1.0.0の品質要件
-  - **影響**: 開発者体験の向上
-  - **作業**: ADRと実装の整合性確認と更新
-
-### Nice-to-Have (v0.9.0オプション)
-
-#### P3 - Low Priority
-- **#131**: performance: Optimize Error Type Conversions (エラーのアロケーション排除)
-  - **理由**: マイクロ最適化。影響は限定的
-  - **影響**: エラー発生時のパフォーマンス向上（限定的）
-  - **作業**: `Cow<'static, str>`への移行
-
----
-
-## 🏆 v1.0.0 - "Production Ready" (Stable Release)
-
-**目標**: 企業採用に耐えうる「信頼性」の証明
-
-### Must-Have (v1.0.0必須)
-
-#### P0 - Critical
-- **#83**: stability: Add memory leak detection to CI with Valgrind/Sanitizers
-  - **状態**: v0.9.0で実装済みである必要がある
-  - **検証**: CIで全てのメモリリーク検知テストがパスすること
-
-#### P1 - High Priority
-- **#128**: performance: True Zero-Copy / Memory Mapping Implementation (メモリマップの導入)
-  - **理由**: 大容量ファイル処理でのOOMリスク削減はv1.0.0の品質要件
-  - **影響**: 4GB以上のファイルでも安全に処理可能
-  - **作業**: memmap2クレートの統合
-
-- **#132**: performance: Replace fast_image_resize Fallback Logic
-  - **状態**: v0.9.0で実装済みである必要がある
-
-- **#133**: security: Safety Audit & Abstraction for libavif FFI
-  - **状態**: v0.9.0で実装済みである必要がある
-
-- **#106**: 虚偽の「ColorSpace」APIの撤廃または実装
-  - **状態**: v0.9.0で実装済みである必要がある
-
-### Should-Have (v1.0.0推奨)
-
-#### P2 - Medium Priority
-- **#129**: refactor: Decompose ImageEngine
-  - **状態**: v0.9.0で実装済みであることが推奨される
-
-- **#130**: performance: Minimize NAPI Copy Overhead
-  - **状態**: v0.9.0で実装済みであることが推奨される
-
-- **#100**: test: カバレッジ改善のためのテスト追加
-  - **状態**: v0.9.0で実装済みであることが推奨される
-
-### 既に実装済み（確認済み）
-
-- ✅ **#82**: security: Implement fuzzing tests with cargo-fuzz (CLOSED)
-  - ファジングテストは実装済み（FUZZING.md参照）
-  - CIへの統合は検討が必要
-
-- ✅ **#84**: api: Final API freeze and TypeScript definitions audit (CLOSED)
-  - API凍結は完了
-
----
-
-## 🚀 v1.x - "Serverless Native" (Future)
-
-**目標**: クラウドネイティブ機能の強化
-
-### P1 - High Priority
-- **#85**: performance: Smart concurrency with auto memory cap detection
-  - **理由**: サーバーレス環境でのOOM回避
-  - **影響**: 512MBコンテナでの安全な動作
-  - **作業**: メモリ検出と自動調整の実装
-
-### P3 - Low Priority
-- **#86**: observability: Add telemetry hooks for detailed metrics
-  - **理由**: 運用監視のためのメトリクス
-  - **影響**: パフォーマンス分析の容易化
-
----
-
-## 🌐 v2.0 - "Universal Engine" (Long Term)
-
-**目標**: Node.jsの枠を超える
-
-### P3 - Low Priority
-- **#87**: wasm: Add WebAssembly support for Cloudflare Workers and browsers
-- **#88**: api: Add native support for Web Streams API
-
----
-
-## 📊 Issue Priority Summary
-
-### v0.9.0 Must-Have
-1. **#83** (P0) - メモリリーク検知CI統合
-2. **#132** (P1) - fast_image_resizeフォールバック除去
-3. **#133** (P1) - AVIF FFI安全化
-4. **#106** (P1) - ColorSpace API整理
-
-### v0.9.0 Should-Have
-5. **#129** (P2) - ImageEngine分解
-6. **#130** (P2) - NAPIコピーゼロ化
-7. **#100** (P2) - テストカバレッジ改善
-8. **#111** (P2) - ADR整合性
-
-### v1.0.0 Must-Have
-9. **#128** (P1) - メモリマップ実装
-
-### v1.x Future
-10. **#85** (P1) - スマートコンカレンシー
-11. **#86** (P3) - テレメトリー
-12. **#87** (P3) - WASMサポート
-13. **#88** (P3) - Web Streams API
-
----
-
-## 🗓️ Release Timeline (推奨)
-
-### v0.9.0 - "The Optimizer"
-**目標リリース**: 2026年2月
-**マイルストーン**:
-- Week 1-2: P0/P1必須タスクの実装 (#83, #132, #133, #106)
-- Week 3-4: P2推奨タスクの実装 (#129, #130, #100, #111)
-- Week 5: テスト、ドキュメント更新、リリース準備
-
-### v1.0.0 - "Production Ready"
-**目標リリース**: 2026年3-4月
-**マイルストーン**:
-- Week 1-2: #128 (メモリマップ実装)
-- Week 3: 全機能の統合テスト、パフォーマンス検証
-- Week 4: ドキュメント最終確認、リリース準備
-
-### v1.x - "Serverless Native"
-**目標リリース**: 2026年後半
-- #85 (スマートコンカレンシー)
-- #86 (テレメトリー)
-
-### v2.0 - "Universal Engine"
-**目標リリース**: 2027年以降
-- #87 (WASM)
-- #88 (Web Streams)
-
----
-
-## ✅ v1.0.0 Release Checklist
-
-### 必須要件
-- [ ] メモリリーク検知がCIで完全に動作している (#83)
-- [ ] fast_image_resizeフォールバックが除去されている (#132)
-- [ ] AVIF FFIが安全化されている (#133)
-- [ ] ColorSpace APIが整理されている (#106)
-- [ ] メモリマップ実装が完了している (#128)
-- [ ] ファジングテストがCIで実行されている（#82は実装済み、CI統合を確認）
-- [ ] API凍結が完了している（#84はCLOSED、最終確認）
-
-### 推奨要件
-- [ ] ImageEngineがモジュール分割されている (#129)
-- [ ] NAPIコピーゼロ化が実装されている (#130)
-- [ ] テストカバレッジが十分である (#100)
-- [ ] ADRと実装が整合している (#111)
-
-### 品質要件
-- [ ] 全テストがパスしている
-- [ ] ベンチマークが安定している
-- [ ] ドキュメントが最新である
-- [ ] セキュリティ監査が完了している
-
----
-
-## 📝 Notes
-
-- **v0.9.0**はv1.0.0への準備リリース。必須タスクを優先し、推奨タスクは時間があれば実装
-- **v1.0.0**は安定版リリース。破壊的変更は行わない
-- **v1.x**は機能追加リリース。後方互換性を維持
-- **v2.0**は破壊的変更を含む可能性がある
+詳細な中長期方針は [ROADMAP.md](./ROADMAP.md) を参照してください。


### PR DESCRIPTION
## Summary
- align roadmap and versioning docs with the actual state of `develop`
- define `docs/TRUE_BENCHMARKS.md` as the canonical benchmark source and update downstream docs to match
- clarify disk-backed streaming behavior, add a metadata support matrix, and add an adoption guide with recommended workflows

## Testing
- `npm run test:pack-contract`

Closes #460
Closes #461
Closes #462
Closes #463
Closes #464