### PR TITLE
fix: make prepublishOnly succeed with current napi cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,12 +69,12 @@
     ]
   },
   "optionalDependencies": {
-    "@alberteinshutoin/lazy-image-darwin-x64": "0.12.0",
     "@alberteinshutoin/lazy-image-darwin-arm64": "0.12.0",
-    "@alberteinshutoin/lazy-image-win32-x64-msvc": "0.12.0",
+    "@alberteinshutoin/lazy-image-darwin-x64": "0.12.0",
     "@alberteinshutoin/lazy-image-linux-x64-gnu": "0.12.0",
+    "@alberteinshutoin/lazy-image-linux-x64-musl": "0.12.0",
     "@alberteinshutoin/lazy-image-linux-arm64-gnu": "0.12.0",
-    "@alberteinshutoin/lazy-image-linux-x64-musl": "0.12.0"
+    "@alberteinshutoin/lazy-image-win32-x64-msvc": "0.12.0"
   },
   "engines": {
     "node": ">= 18"


### PR DESCRIPTION
## Summary
- update `prepublishOnly` to use the current `napi pre-publish` flow with `--skip-optional-publish`
- keep local/npm preflight aligned with the existing release workflow by avoiding per-platform package publish during `prepublishOnly`
- verify `npm run prepublishOnly`, `npm run build`, and `npm run test:pack-contract`

## Verification
- npm run prepublishOnly
- npm run build
- npm run test:pack-contract

Closes #458