### PR TITLE
chore: clean up build warnings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -356,20 +356,6 @@ export interface OutputWithMetrics {
   metrics: ProcessingMetrics
 }
 
-/** Result of applying a preset and encoding to buffer */
-export interface PresetBufferResult {
-  /** Encoded image data */
-  data: Buffer
-  /** Recommended output format */
-  format: CanonicalOutputFormat
-  /** Recommended quality (None for PNG) */
-  quality?: number
-  /** Target width (None if aspect ratio preserved) */
-  width?: number
-  /** Target height (None if aspect ratio preserved) */
-  height?: number
-}
-
 /** Result of applying a preset, contains recommended output settings */
 export interface PresetResult {
   /** Recommended output format */

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1478,7 +1478,7 @@ mod tests {
                 #[cfg(feature = "napi")]
                 last_error: None,
             };
-            let err = task.decode_internal().unwrap_err();
+            let err = task.decode().unwrap_err();
             assert!(matches!(err, LazyImageError::FirewallViolation { .. }));
         }
 
@@ -1505,7 +1505,7 @@ mod tests {
                 #[cfg(feature = "napi")]
                 last_error: None,
             };
-            let err = task.decode_internal().unwrap_err();
+            let err = task.decode().unwrap_err();
             assert!(matches!(err, LazyImageError::FirewallViolation { .. }));
         }
     }

--- a/src/engine/api.rs
+++ b/src/engine/api.rs
@@ -1494,22 +1494,6 @@ pub struct PresetResult {
 }
 
 #[cfg(feature = "napi")]
-/// Result of applying a preset and encoding to buffer
-#[napi(object)]
-pub struct PresetBufferResult {
-    /// Encoded image data
-    pub data: Buffer,
-    /// Recommended output format
-    pub format: String,
-    /// Recommended quality (None for PNG)
-    pub quality: Option<u8>,
-    /// Target width (None if aspect ratio preserved)
-    pub width: Option<u32>,
-    /// Target height (None if aspect ratio preserved)
-    pub height: Option<u32>,
-}
-
-#[cfg(feature = "napi")]
 #[napi(object)]
 pub struct BatchOptions {
     /// Output format ("jpeg", "png", "webp", "avif")

--- a/src/engine/memory.rs
+++ b/src/engine/memory.rs
@@ -534,6 +534,7 @@ fn project_operation(dims: (u32, u32), current_bpp: u64, op: &Operation) -> ((u3
     }
 }
 
+#[cfg(test)]
 fn estimate_memory_from_dimensions_with_context(
     width: u32,
     height: u32,

--- a/src/engine/tasks.rs
+++ b/src/engine/tasks.rs
@@ -396,20 +396,6 @@ fn process_and_encode_from_parts(
 }
 
 impl EncodeTask {
-    /// Decode image from source bytes
-    /// Uses mozjpeg (libjpeg-turbo) for JPEG, falls back to image crate for others
-    ///
-    /// **True Copy-on-Write**: Returns `Cow::Borrowed` if image is already decoded,
-    /// `Cow::Owned` if decoding was required. The caller can avoid deep copies
-    /// when no mutation is needed (e.g., format conversion only).
-    ///
-    /// Returns LazyImageError directly (not wrapped in napi::Error) for use in process_and_encode.
-    pub(crate) fn decode_internal(
-        &self,
-    ) -> std::result::Result<Cow<'_, DynamicImage>, LazyImageError> {
-        decode_internal_from_parts(self.source.as_ref(), self.decoded.as_ref(), &self.firewall)
-    }
-
     /// Process image: decode → apply ops → encode
     /// This is the core processing pipeline shared by toBuffer and toFile.
     /// Returns LazyImageError directly (not wrapped in napi::Error) so that
@@ -442,7 +428,7 @@ impl EncodeTask {
 #[cfg(test)]
 impl EncodeTask {
     pub(crate) fn decode(&self) -> std::result::Result<Cow<'_, DynamicImage>, LazyImageError> {
-        self.decode_internal()
+        decode_internal_from_parts(self.source.as_ref(), self.decoded.as_ref(), &self.firewall)
     }
 }
 
@@ -554,7 +540,7 @@ mod non_napi_tests {
             strip_gps: true,
             firewall: FirewallConfig::disabled(),
         };
-        let err = task.decode_internal().unwrap_err();
+        let err = task.decode().unwrap_err();
         assert!(matches!(err, LazyImageError::SourceConsumed));
     }
 
@@ -578,7 +564,7 @@ mod non_napi_tests {
             strip_gps: true,
             firewall,
         };
-        let err = task.decode_internal().unwrap_err();
+        let err = task.decode().unwrap_err();
         assert!(matches!(err, LazyImageError::FirewallViolation { .. }));
     }
 


### PR DESCRIPTION
## Summary
- remove unused preset buffer result bindings and generated TypeScript type
- make helper code test-only where it is only exercised by tests
- eliminate the current `cargo` dead-code warnings seen during `npm run build`

## Verification
- npm run build
- npm test

Related to #467
Related to #468
Related to #469