### PR TITLE
fix: export missing TypeScript types (#472)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -141,7 +141,7 @@ export declare class ImageEngine {
    */
   toFile(path: string, format: OutputFormat, quality?: number | undefined | null, fastMode?: boolean | undefined | null): Promise<number>
   /** Encode and write directly to a file asynchronously, returning metrics. */
-  toFileWithMetrics(path: string, format: string, quality?: number | undefined | null, fastMode?: boolean | undefined | null): Promise<FileOutputWithMetrics>
+  toFileWithMetrics(path: string, format: OutputFormat, quality?: number | undefined | null, fastMode?: boolean | undefined | null): Promise<FileOutputWithMetrics>
   /** Convenience: encode to file using the preset's recommended format/quality. */
   toFileWithPreset(path: string, presetName: PresetName): Promise<number>
   /**
@@ -480,6 +480,49 @@ export declare function createStreamingPipeline(options: {
 }): {
   writable: NodeJS.WritableStream
   readable: NodeJS.ReadableStream
+}
+
+export interface TargetBytesOptions {
+  /** Target file size in bytes */
+  targetBytes: number
+  /** Alias for targetBytes */
+  maxBytes?: number
+  /** Minimum quality to try (default: 30) */
+  minQuality?: number
+  /** Maximum quality to try (default: 100) */
+  maxQuality?: number
+  /** Enable fast encoding mode */
+  fastMode?: boolean
+  /** Behaviour when budget cannot be met: 'best-effort' (default) or 'strict' */
+  qualityFloorPolicy?: 'best-effort' | 'strict'
+}
+
+export interface BufferTargetBytesResult {
+  /** Encoded image data */
+  data: Buffer
+  /** Quality level that was used */
+  quality: number
+  /** Actual output size in bytes */
+  bytesOut: number
+  /** Whether the byte budget was met */
+  budgetMet: boolean
+  /** Requested target bytes */
+  targetBytes: number
+  /** Processing metrics */
+  metrics: ProcessingMetrics
+}
+
+export interface FileTargetBytesResult {
+  /** Bytes written to disk */
+  bytesWritten: number
+  /** Quality level that was used */
+  quality: number
+  /** Whether the byte budget was met */
+  budgetMet: boolean
+  /** Requested target bytes */
+  targetBytes: number
+  /** Processing metrics */
+  metrics: ProcessingMetrics
 }
 
 export declare function resolveEncodeProfile(format: OutputFormat, profile?: EncodeProfile, quality?: number | undefined | null): ResolvedEncodeProfile

--- a/scripts/postbuild-fixup.js
+++ b/scripts/postbuild-fixup.js
@@ -332,6 +332,49 @@ export declare function createStreamingPipeline(options: {
   readable: NodeJS.ReadableStream
 }
 
+export interface TargetBytesOptions {
+  /** Target file size in bytes */
+  targetBytes: number
+  /** Alias for targetBytes */
+  maxBytes?: number
+  /** Minimum quality to try (default: 30) */
+  minQuality?: number
+  /** Maximum quality to try (default: 100) */
+  maxQuality?: number
+  /** Enable fast encoding mode */
+  fastMode?: boolean
+  /** Behaviour when budget cannot be met: 'best-effort' (default) or 'strict' */
+  qualityFloorPolicy?: 'best-effort' | 'strict'
+}
+
+export interface BufferTargetBytesResult {
+  /** Encoded image data */
+  data: Buffer
+  /** Quality level that was used */
+  quality: number
+  /** Actual output size in bytes */
+  bytesOut: number
+  /** Whether the byte budget was met */
+  budgetMet: boolean
+  /** Requested target bytes */
+  targetBytes: number
+  /** Processing metrics */
+  metrics: ProcessingMetrics
+}
+
+export interface FileTargetBytesResult {
+  /** Bytes written to disk */
+  bytesWritten: number
+  /** Quality level that was used */
+  quality: number
+  /** Whether the byte budget was met */
+  budgetMet: boolean
+  /** Requested target bytes */
+  targetBytes: number
+  /** Processing metrics */
+  metrics: ProcessingMetrics
+}
+
 export declare function resolveEncodeProfile(format: OutputFormat, profile?: EncodeProfile, quality?: number | undefined | null): ResolvedEncodeProfile
 `;
 
@@ -371,6 +414,7 @@ function patchIndexDts() {
   content = replaceIfNeeded(content, 'export interface PresetResult {\n  /** Recommended output format */\n  format: string', 'export interface PresetResult {\n  /** Recommended output format */\n  format: CanonicalOutputFormat');
   content = replaceIfNeeded(content, '  /** Detected input format (lowercase: jpeg, png, webp, avif, etc.) */\n  formatIn?: string', '  /** Detected input format reported by runtime metrics */\n  formatIn?: InputFormat');
   content = replaceIfNeeded(content, '  /** Output format */\n  formatOut: string', '  /** Output format */\n  formatOut: CanonicalOutputFormat');
+  content = replaceIfNeeded(content, '  toFileWithMetrics(path: string, format: string,', '  toFileWithMetrics(path: string, format: OutputFormat,');
   content = replaceIfNeeded(content, '  fit?: string', '  fit?: ResizeFit');
   content = replaceIfNeeded(content, '  policy?: string', '  policy?: FirewallPolicy');
   content = replaceIfNeeded(content, 'export declare function supportedInputFormats(): Array<string>', 'export declare function supportedInputFormats(): Array<CanonicalInputFormat>');


### PR DESCRIPTION
## Summary

- Export `TargetBytesOptions`, `BufferTargetBytesResult`, `FileTargetBytesResult` interfaces from `index.d.ts` — previously used in method signatures but never declared
- Patch `toFileWithMetrics()` format parameter from `string` → `OutputFormat` for consistency with all other methods

## Changes

- `scripts/postbuild-fixup.js`: Added 3 interface definitions to `dtsExtraBlock`, added `replaceIfNeeded` patch for `toFileWithMetrics`
- `index.d.ts`: Regenerated with all types exported

## Test plan

- [x] `npm run build` succeeds
- [x] `npm test` passes
- [x] Verified `TargetBytesOptions`, `BufferTargetBytesResult`, `FileTargetBytesResult` present in output `index.d.ts`
- [x] Verified `toFileWithMetrics` uses `OutputFormat`

Closes #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)