### PR TITLE
fix: always enforce base safety limits at decode (#492)

### DIFF
--- a/src/engine/firewall.rs
+++ b/src/engine/firewall.rs
@@ -6,6 +6,14 @@ use crate::engine::io::extract_icc_profile;
 use crate::error::LazyImageError;
 use std::time::Instant;
 
+// Base safety limits enforced at decode time regardless of firewall policy.
+// These match the global MAX_DIMENSION / MAX_PIXELS constants and act as an
+// always-on safety net against decompression bombs even when sanitize() is not
+// called.  Policy-specific limits (strict/lenient) are layered on top.
+const BASE_MAX_DIMENSION: u32 = crate::engine::MAX_DIMENSION; // 32_768
+const BASE_MAX_PIXELS: u64 = crate::engine::MAX_PIXELS; // 100_000_000
+const BASE_METADATA_LIMIT: u64 = 10 * 1024 * 1024; // 10 MB — reject obviously malicious ICC/EXIF even without sanitize()
+
 const STRICT_MAX_PIXELS: u64 = 40_000_000; // ~8K x 5K
 const LENIENT_MAX_PIXELS: u64 = 75_000_000; // generous but below global MAX_PIXELS
 const STRICT_MAX_BYTES: u64 = 32 * 1024 * 1024; // 32MB input cap
@@ -104,6 +112,31 @@ impl FirewallConfig {
         }
     }
 
+    /// Always-on base safety check for image dimensions.
+    /// Rejects images exceeding `BASE_MAX_DIMENSION` or `BASE_MAX_PIXELS`
+    /// **regardless** of whether the firewall is enabled.  This ensures that
+    /// `toBuffer()` / `toFile()` without `sanitize()` still reject
+    /// decompression bombs.
+    ///
+    /// When the firewall IS enabled, `enforce_pixels()` applies the stricter
+    /// policy-specific limits on top of these base limits.
+    pub fn enforce_base_limits(&self, width: u32, height: u32) -> Result<(), LazyImageError> {
+        if width > BASE_MAX_DIMENSION || height > BASE_MAX_DIMENSION {
+            return Err(LazyImageError::dimension_exceeds_limit(
+                width.max(height),
+                BASE_MAX_DIMENSION,
+            ));
+        }
+        let pixels = width as u64 * height as u64;
+        if pixels > BASE_MAX_PIXELS {
+            return Err(LazyImageError::pixel_count_exceeds_limit(
+                pixels,
+                BASE_MAX_PIXELS,
+            ));
+        }
+        Ok(())
+    }
+
     pub fn enforce_source_len(&self, len: usize) -> Result<(), LazyImageError> {
         if !self.enabled {
             return Ok(());
@@ -173,6 +206,32 @@ impl FirewallConfig {
                     "Image Firewall: processing exceeded {}ms timeout at {} stage (elapsed: {}ms). \
                      Use .limits({{ timeoutMs: {} }}) for longer operations or switch to lenient policy.",
                     limit_ms, stage, elapsed_ms, elapsed_ms + 5000
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Always-on base metadata size check.
+    /// Rejects ICC profiles larger than `BASE_METADATA_LIMIT` (10 MB) and EXIF
+    /// segments larger than `BASE_METADATA_LIMIT` even when the firewall is
+    /// disabled.  This catches obviously malicious payloads without requiring
+    /// the caller to opt-in via `sanitize()`.
+    pub fn scan_metadata_base(&self, data: &[u8]) -> Result<(), LazyImageError> {
+        if let Some(icc) = extract_icc_profile(data)? {
+            let icc_len = icc.len() as u64;
+            if icc_len > BASE_METADATA_LIMIT {
+                return Err(LazyImageError::firewall_violation(format!(
+                    "Image safety: ICC profile ({icc_len} bytes) exceeds base limit of {BASE_METADATA_LIMIT} bytes. \
+                     This may indicate a malformed or malicious file."
+                )));
+            }
+        }
+        if let Some(exif_size) = scan_exif_size(data) {
+            if exif_size > BASE_METADATA_LIMIT {
+                return Err(LazyImageError::firewall_violation(format!(
+                    "Image safety: EXIF metadata ({exif_size} bytes) exceeds base limit of {BASE_METADATA_LIMIT} bytes. \
+                     This may indicate a malformed or malicious file."
                 )));
             }
         }
@@ -349,6 +408,54 @@ mod tests {
         result.extend(std::iter::repeat(0xAA).take(exif_payload_size));
         result.extend_from_slice(&jpeg_data[2..]);
         result
+    }
+
+    // =========================================================================
+    // Always-on base limit tests
+    // =========================================================================
+
+    #[test]
+    fn base_limits_enforced_even_when_disabled() {
+        let cfg = FirewallConfig::disabled();
+        assert!(!cfg.enabled);
+
+        // Small image passes
+        assert!(cfg.enforce_base_limits(100, 100).is_ok());
+
+        // Dimension exceeding BASE_MAX_DIMENSION fails
+        let over = crate::engine::MAX_DIMENSION + 1;
+        let err = cfg.enforce_base_limits(over, 1).unwrap_err();
+        assert!(matches!(
+            err,
+            crate::error::LazyImageError::DimensionExceedsLimit { .. }
+        ));
+
+        // Pixel count exceeding BASE_MAX_PIXELS fails
+        // 10001 x 10001 = 100_020_001 > 100_000_000
+        let err = cfg.enforce_base_limits(10001, 10001).unwrap_err();
+        assert!(matches!(
+            err,
+            crate::error::LazyImageError::PixelCountExceedsLimit { .. }
+        ));
+    }
+
+    #[test]
+    fn base_metadata_limit_enforced_even_when_disabled() {
+        let cfg = FirewallConfig::disabled();
+        assert!(!cfg.enabled);
+
+        // Small ICC passes
+        let small_png = png_with_icc(256);
+        assert!(cfg.scan_metadata_base(&small_png).is_ok());
+
+        // Oversized ICC (> 10MB) fails
+        let oversized_png = png_with_icc((BASE_METADATA_LIMIT + 1) as usize);
+        let err = cfg.scan_metadata_base(&oversized_png).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("ICC profile") && msg.contains("exceeds base limit"),
+            "Expected base metadata limit message, got: {msg}"
+        );
     }
 
     #[test]

--- a/src/engine/tasks.rs
+++ b/src/engine/tasks.rs
@@ -197,6 +197,8 @@ fn decode_internal_from_parts<'a>(
     // Prefer already decoded image (already validated)
     // Return borrowed reference - no deep copy until mutation is needed
     if let Some(img_arc) = decoded {
+        // Always-on base safety limits (even without sanitize())
+        firewall.enforce_base_limits(img_arc.width(), img_arc.height())?;
         check_dimensions(img_arc.width(), img_arc.height())?;
         firewall.enforce_pixels(img_arc.width(), img_arc.height())?;
         return Ok(Cow::Borrowed(img_arc.as_ref()));
@@ -221,6 +223,9 @@ fn decode_internal_from_parts<'a>(
         }
     };
 
+    // Always-on base metadata size check (even without sanitize())
+    firewall.scan_metadata_base(bytes)?;
+
     firewall.enforce_source_len(bytes.len())?;
     firewall.scan_metadata(bytes)?;
 
@@ -230,6 +235,8 @@ fn decode_internal_from_parts<'a>(
 
     // Security check: reject decompression bombs
     let (w, h) = img.dimensions();
+    // Always-on base safety limits (even without sanitize())
+    firewall.enforce_base_limits(w, h)?;
     check_dimensions(w, h)?;
     firewall.enforce_pixels(w, h)?;
 
@@ -542,6 +549,40 @@ mod non_napi_tests {
         };
         let err = task.decode().unwrap_err();
         assert!(matches!(err, LazyImageError::SourceConsumed));
+    }
+
+    /// Verify that base dimension/pixel limits are enforced at decode time
+    /// even when the firewall is disabled (i.e., sanitize() was NOT called).
+    /// This is the core fix for #492.
+    #[test]
+    fn base_limits_enforced_without_sanitize() {
+        // Create a PNG with dimensions exceeding MAX_PIXELS (100M)
+        // We can't easily create such a huge image, so instead verify via
+        // enforce_base_limits which is called in the decode path.
+        let cfg = FirewallConfig::disabled();
+        assert!(!cfg.enabled);
+
+        // 10001 x 10001 = 100_020_001 > 100M pixels
+        let err = cfg.enforce_base_limits(10001, 10001).unwrap_err();
+        assert!(matches!(
+            err,
+            crate::error::LazyImageError::PixelCountExceedsLimit { .. }
+        ));
+    }
+
+    /// Verify that base metadata scan runs at decode time without sanitize().
+    #[test]
+    fn base_metadata_scan_runs_without_sanitize() {
+        let cfg = FirewallConfig::disabled();
+        assert!(!cfg.enabled);
+
+        // Small metadata passes
+        let img: ImageBuffer<Rgba<u8>, Vec<u8>> =
+            ImageBuffer::from_pixel(4, 4, Rgba([10, 20, 30, 255]));
+        let mut bytes = Vec::new();
+        img.write_to(&mut std::io::Cursor::new(&mut bytes), ImageFormat::Png)
+            .unwrap();
+        assert!(cfg.scan_metadata_base(&bytes).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add always-on base dimension (32768px), pixel count (100M), and metadata size (10MB) checks that run at decode time regardless of whether `sanitize()` is called
- Previously these safety checks only fired when the firewall was explicitly enabled via `sanitize()`, allowing `toBuffer()`/`toFile()` without `sanitize()` to bypass firewall limits
- Policy-specific limits (strict: 40M pixels, lenient: 75M) continue to layer on top when `sanitize()` is called

## Changes

- `src/engine/firewall.rs`: Added `enforce_base_limits()` and `scan_metadata_base()` methods that always enforce base safety thresholds (not gated by `self.enabled`)
- `src/engine/tasks.rs`: Call `enforce_base_limits()` and `scan_metadata_base()` in `decode_internal_from_parts()` for both the pre-decoded and from-source paths
- Added tests verifying base limits work with `FirewallConfig::disabled()`

Closes #492

## Test plan

- [x] `cargo test --no-default-features` — all 50 tests pass (4 new)
- [x] `cargo clippy --no-default-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `npm run build && npm run test:js` — all JS tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)