### PR TITLE
feat: add ESM support (#494)

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -1,0 +1,21 @@
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const mod = require('./index.js');
+
+// Re-export all named exports from the CJS module
+export const {
+  ImageEngine,
+  ErrorCategory,
+  ErrorCode,
+  inspect,
+  inspectFile,
+  supportedInputFormats,
+  supportedOutputFormats,
+  version,
+  getErrorCategory,
+  createStreamingPipeline,
+  resolveEncodeProfile,
+} = mod;
+
+// Default export for convenience
+export default mod;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,17 @@
   "version": "0.12.0",
   "description": "Web image optimization engine for Node.js - smaller files than sharp, powered by Rust + mozjpeg",
   "main": "index.js",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./index.mjs",
+      "require": "./index.js"
+    },
+    "./streaming": {
+      "import": "./streaming/pipeline.mjs",
+      "require": "./streaming/pipeline.js"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/albert-einshutoin/lazy-image"
@@ -82,6 +93,7 @@
   },
   "files": [
     "index.js",
+    "index.mjs",
     "index.d.ts",
     "streaming/",
     "docs/",

--- a/streaming/pipeline.mjs
+++ b/streaming/pipeline.mjs
@@ -1,0 +1,3 @@
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+export const { createStreamingPipeline } = require('./pipeline.js');


### PR DESCRIPTION
## Summary
- Add ESM wrapper modules (`index.mjs`, `streaming/pipeline.mjs`) using `createRequire` to re-export all named exports from CJS entry points
- Add `exports` field to `package.json` with conditional `import`/`require` resolution for both root (`.`) and `./streaming` sub-paths
- Add `index.mjs` to the `files` array for npm publish inclusion

## Test plan
- [x] `npm run build` succeeds
- [x] `npm test` passes (all JS + Rust tests)
- [x] `node -e "import('./index.mjs').then(m => console.log(Object.keys(m)))"` lists all 12 named exports
- [x] `node -e "import('./streaming/pipeline.mjs').then(m => console.log(Object.keys(m)))"` lists `createStreamingPipeline`
- [ ] CI passes on all platforms

Closes #494

🤖 Generated with [Claude Code](https://claude.com/claude-code)