### PR TITLE
refactor: replace metadata boolean flags with MetadataPolicy struct

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -90,6 +90,7 @@ pub use stress::run_stress_iteration;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::engine::api::MetadataPolicy;
     use crate::engine::firewall::FirewallConfig;
     use crate::engine::tasks::EncodeTask;
     use crate::error::LazyImageError;
@@ -1390,9 +1391,7 @@ mod tests {
                 icc_present: false,
                 exif_data: None,
                 auto_orient: true,
-                keep_icc: false,
-                keep_exif: false,
-                strip_gps: true,
+                metadata_policy: MetadataPolicy::default_policy(),
                 firewall: FirewallConfig::disabled(),
                 #[cfg(feature = "napi")]
                 last_error: None,
@@ -1416,9 +1415,7 @@ mod tests {
                 icc_present: false,
                 exif_data: None,
                 auto_orient: true,
-                keep_icc: false,
-                keep_exif: false,
-                strip_gps: true,
+                metadata_policy: MetadataPolicy::default_policy(),
                 firewall: FirewallConfig::disabled(),
                 #[cfg(feature = "napi")]
                 last_error: None,
@@ -1440,9 +1437,7 @@ mod tests {
                 icc_present: false,
                 exif_data: None,
                 auto_orient: true,
-                keep_icc: false,
-                keep_exif: false,
-                strip_gps: true,
+                metadata_policy: MetadataPolicy::default_policy(),
                 firewall: FirewallConfig::disabled(),
                 #[cfg(feature = "napi")]
                 last_error: None,
@@ -1471,9 +1466,7 @@ mod tests {
                 icc_present: false,
                 exif_data: None,
                 auto_orient: true,
-                keep_icc: false,
-                keep_exif: false,
-                strip_gps: true,
+                metadata_policy: MetadataPolicy::default_policy(),
                 firewall,
                 #[cfg(feature = "napi")]
                 last_error: None,
@@ -1498,9 +1491,7 @@ mod tests {
                 icc_present: false,
                 exif_data: None,
                 auto_orient: true,
-                keep_icc: false,
-                keep_exif: false,
-                strip_gps: true,
+                metadata_policy: MetadataPolicy::default_policy(),
                 firewall,
                 #[cfg(feature = "napi")]
                 last_error: None,

--- a/src/engine/api.rs
+++ b/src/engine/api.rs
@@ -328,6 +328,65 @@ mod validation {
     }
 }
 
+/// Policy for which metadata to preserve in output images.
+///
+/// Centralizes the keep-ICC / keep-EXIF / strip-GPS decision so that every
+/// output path reads a single source of truth instead of resolving ad-hoc
+/// boolean combinations.
+#[derive(Clone, Debug)]
+pub struct MetadataPolicy {
+    /// Whether to preserve ICC profile in output (default: false)
+    pub icc: bool,
+    /// Whether to preserve EXIF metadata in output (default: false)
+    pub exif: bool,
+    /// Whether to keep GPS tags in EXIF (default: false — stripped for privacy)
+    pub gps: bool,
+}
+
+impl MetadataPolicy {
+    /// Default: strip all metadata for security and smaller file sizes.
+    /// GPS is stripped by default for privacy (exceeds Sharp's capabilities).
+    pub fn default_policy() -> Self {
+        Self {
+            icc: false,
+            exif: false,
+            gps: false,
+        }
+    }
+
+    /// Strip all metadata (firewall strict mode).
+    pub fn strip_all() -> Self {
+        Self {
+            icc: false,
+            exif: false,
+            gps: false,
+        }
+    }
+
+    /// Apply firewall override: if reject_metadata is true, strip everything.
+    pub fn apply_firewall(&mut self, reject_metadata: bool) {
+        if reject_metadata {
+            *self = Self::strip_all();
+        }
+    }
+
+    /// Resolve final ICC policy.
+    pub fn effective_icc(&self) -> bool {
+        self.icc
+    }
+
+    /// Resolve final EXIF policy.
+    pub fn effective_exif(&self) -> bool {
+        self.exif
+    }
+
+    /// Whether GPS tags should be stripped from EXIF.
+    /// Returns true when GPS should be stripped (i.e., gps == false).
+    pub fn strip_gps(&self) -> bool {
+        !self.gps
+    }
+}
+
 /// The main image processing engine.
 ///
 /// Usage:
@@ -357,15 +416,8 @@ pub struct ImageEngine {
     pub(crate) exif_data: OnceLock<Option<Arc<Vec<u8>>>>,
     /// Whether to auto-apply EXIF Orientation (default: true)
     pub(crate) auto_orient: bool,
-    /// Whether to preserve ICC profile in output.
-    /// Default is false (strip all) for security and smaller file sizes.
-    pub(crate) keep_icc: bool,
-    /// Whether to preserve EXIF metadata in output.
-    /// Default is false (strip all) for security and smaller file sizes.
-    pub(crate) keep_exif: bool,
-    /// Whether to strip GPS tags from EXIF (default: true for privacy)
-    /// This is a security-first feature that exceeds Sharp's capabilities.
-    pub(crate) strip_gps: bool,
+    /// Single source of truth for metadata preservation decisions.
+    pub(crate) metadata_policy: MetadataPolicy,
     /// Whether we already emitted a warning about XMP being unsupported.
     pub(crate) xmp_warning_emitted: bool,
     pub(crate) firewall: FirewallConfig,
@@ -393,9 +445,7 @@ impl ImageEngine {
             icc_profile: OnceLock::new(),
             exif_data: OnceLock::new(),
             auto_orient: true,
-            keep_icc: false, // Strip metadata by default for security & smaller files
-            keep_exif: false, // Strip EXIF by default for security
-            strip_gps: true, // Strip GPS by default for privacy (exceeds Sharp)
+            metadata_policy: MetadataPolicy::default_policy(),
             xmp_warning_emitted: false,
             firewall: FirewallConfig::disabled(),
         }
@@ -431,9 +481,7 @@ impl ImageEngine {
             icc_profile: OnceLock::new(),
             exif_data: OnceLock::new(),
             auto_orient: true,
-            keep_icc: false, // Strip metadata by default for security & smaller files
-            keep_exif: false, // Strip EXIF by default for security
-            strip_gps: true, // Strip GPS by default for privacy (exceeds Sharp)
+            metadata_policy: MetadataPolicy::default_policy(),
             xmp_warning_emitted: false,
             firewall: FirewallConfig::disabled(),
         })
@@ -467,9 +515,7 @@ impl ImageEngine {
             icc_profile,
             exif_data,
             auto_orient: self.auto_orient,
-            keep_icc: self.keep_icc,
-            keep_exif: self.keep_exif,
-            strip_gps: self.strip_gps,
+            metadata_policy: self.metadata_policy.clone(),
             xmp_warning_emitted: self.xmp_warning_emitted,
             firewall: self.firewall.clone(),
         })
@@ -624,9 +670,9 @@ impl ImageEngine {
             self.xmp_warning_emitted = true;
         }
 
-        self.keep_icc = icc;
-        self.keep_exif = exif;
-        self.strip_gps = strip_gps;
+        self.metadata_policy.icc = icc;
+        self.metadata_policy.exif = exif;
+        self.metadata_policy.gps = !strip_gps; // gps=true means keep, strip_gps=true means remove
         Ok(this)
     }
 
@@ -657,10 +703,9 @@ impl ImageEngine {
 
         self.firewall = FirewallConfig::apply_policy(policy);
         if self.firewall.reject_metadata {
-            self.keep_icc = false;
-            self.keep_exif = false;
+            self.metadata_policy.apply_firewall(true);
             // No need to clear the OnceLock fields: output methods already
-            // check keep_icc/keep_exif flags and skip metadata when false.
+            // check metadata_policy and skip metadata when firewall is active.
         }
 
         if let Some(decoded) = &self.decoded {
@@ -895,17 +940,16 @@ impl ImageEngine {
         let source = self.source.clone();
         let decoded = self.decoded.clone();
         let ops = self.ops.clone();
-        let keep_icc = self.keep_icc && !self.firewall.reject_metadata;
-        let keep_exif = self.keep_exif && !self.firewall.reject_metadata;
+        let mut policy = self.metadata_policy.clone();
+        policy.apply_firewall(self.firewall.reject_metadata);
         let auto_orient = self.auto_orient;
-        // Lazy: only extract metadata when the caller actually wants it preserved
         let icc_present = self.icc_profile().is_some();
-        let icc_profile = if keep_icc {
+        let icc_profile = if policy.effective_icc() {
             self.icc_profile().cloned()
         } else {
             None
         };
-        let exif_data = if keep_exif {
+        let exif_data = if policy.effective_exif() {
             self.exif_data().cloned()
         } else {
             None
@@ -920,9 +964,7 @@ impl ImageEngine {
             icc_present,
             exif_data,
             auto_orient,
-            keep_icc,
-            keep_exif,
-            strip_gps: self.strip_gps,
+            metadata_policy: policy,
             firewall: self.firewall.clone(),
             #[cfg(feature = "napi")]
             last_error: None,
@@ -996,16 +1038,16 @@ impl ImageEngine {
         let source = self.source.clone();
         let decoded = self.decoded.clone();
         let ops = self.ops.clone();
-        let keep_icc = self.keep_icc && !self.firewall.reject_metadata;
-        let keep_exif = self.keep_exif && !self.firewall.reject_metadata;
+        let mut policy = self.metadata_policy.clone();
+        policy.apply_firewall(self.firewall.reject_metadata);
         let auto_orient = self.auto_orient;
         let icc_present = self.icc_profile().is_some();
-        let icc_profile = if keep_icc {
+        let icc_profile = if policy.effective_icc() {
             self.icc_profile().cloned()
         } else {
             None
         };
-        let exif_data = if keep_exif {
+        let exif_data = if policy.effective_exif() {
             self.exif_data().cloned()
         } else {
             None
@@ -1020,9 +1062,7 @@ impl ImageEngine {
             icc_present,
             exif_data,
             auto_orient,
-            keep_icc,
-            keep_exif,
-            strip_gps: self.strip_gps,
+            metadata_policy: policy,
             firewall: self.firewall.clone(),
             #[cfg(feature = "napi")]
             last_error: None,
@@ -1104,16 +1144,16 @@ impl ImageEngine {
         let source = self.source.clone();
         let decoded = self.decoded.clone();
         let ops = self.ops.clone();
-        let keep_icc = self.keep_icc && !self.firewall.reject_metadata;
-        let keep_exif = self.keep_exif && !self.firewall.reject_metadata;
+        let mut policy = self.metadata_policy.clone();
+        policy.apply_firewall(self.firewall.reject_metadata);
         let auto_orient = self.auto_orient;
         let icc_present = self.icc_profile().is_some();
-        let icc_profile = if keep_icc {
+        let icc_profile = if policy.effective_icc() {
             self.icc_profile().cloned()
         } else {
             None
         };
-        let exif_data = if keep_exif {
+        let exif_data = if policy.effective_exif() {
             self.exif_data().cloned()
         } else {
             None
@@ -1128,9 +1168,7 @@ impl ImageEngine {
             icc_present,
             exif_data,
             auto_orient,
-            keep_icc,
-            keep_exif,
-            strip_gps: self.strip_gps,
+            metadata_policy: policy,
             firewall: self.firewall.clone(),
             output_path: path,
             #[cfg(feature = "napi")]
@@ -1166,16 +1204,16 @@ impl ImageEngine {
         let source = self.source.clone();
         let decoded = self.decoded.clone();
         let ops = self.ops.clone();
-        let keep_icc = self.keep_icc && !self.firewall.reject_metadata;
-        let keep_exif = self.keep_exif && !self.firewall.reject_metadata;
+        let mut policy = self.metadata_policy.clone();
+        policy.apply_firewall(self.firewall.reject_metadata);
         let auto_orient = self.auto_orient;
         let icc_present = self.icc_profile().is_some();
-        let icc_profile = if keep_icc {
+        let icc_profile = if policy.effective_icc() {
             self.icc_profile().cloned()
         } else {
             None
         };
-        let exif_data = if keep_exif {
+        let exif_data = if policy.effective_exif() {
             self.exif_data().cloned()
         } else {
             None
@@ -1190,9 +1228,7 @@ impl ImageEngine {
             icc_present,
             exif_data,
             auto_orient,
-            keep_icc,
-            keep_exif,
-            strip_gps: self.strip_gps,
+            metadata_policy: policy,
             firewall: self.firewall.clone(),
             output_path: path,
             #[cfg(feature = "napi")]
@@ -1379,17 +1415,15 @@ impl ImageEngine {
             }
         };
         let ops = self.ops.clone();
-        let keep_icc = self.keep_icc && !self.firewall.reject_metadata;
-        let keep_exif = self.keep_exif && !self.firewall.reject_metadata;
+        let mut policy = self.metadata_policy.clone();
+        policy.apply_firewall(self.firewall.reject_metadata);
         Ok(AsyncTask::new(BatchTask {
             inputs,
             output_dir,
             ops,
             format: output_format,
             concurrency,
-            keep_icc,
-            keep_exif,
-            strip_gps: self.strip_gps,
+            metadata_policy: policy,
             auto_orient: self.auto_orient,
             firewall: self.firewall.clone(),
             #[cfg(feature = "napi")]
@@ -1445,8 +1479,8 @@ impl ImageEngine {
             }
         };
         let ops = self.ops.clone();
-        let keep_icc = self.keep_icc && !self.firewall.reject_metadata;
-        let keep_exif = self.keep_exif && !self.firewall.reject_metadata;
+        let mut policy = self.metadata_policy.clone();
+        policy.apply_firewall(self.firewall.reject_metadata);
 
         Ok(AsyncTask::new(BatchWithMetricsTask {
             inputs,
@@ -1454,9 +1488,7 @@ impl ImageEngine {
             ops,
             format: output_format,
             concurrency,
-            keep_icc,
-            keep_exif,
-            strip_gps: self.strip_gps,
+            metadata_policy: policy,
             auto_orient: self.auto_orient,
             firewall: self.firewall.clone(),
             #[cfg(feature = "napi")]

--- a/src/engine/tasks.rs
+++ b/src/engine/tasks.rs
@@ -5,6 +5,7 @@
 // Async task implementations for NAPI.
 // These tasks run in background threads and don't block Node.js main thread.
 
+use super::api::MetadataPolicy;
 use super::firewall::FirewallConfig;
 use crate::engine::decoder::{
     check_dimensions, decode_image, detect_format, ensure_dimensions_safe,
@@ -177,12 +178,8 @@ pub struct EncodeTask {
     /// Raw EXIF data extracted from source image (for preservation)
     pub exif_data: Option<Arc<Vec<u8>>>,
     pub auto_orient: bool,
-    /// Whether to preserve ICC profile in output (default: false for security & smaller files)
-    pub keep_icc: bool,
-    /// Whether to preserve EXIF metadata in output (default: false for security)
-    pub keep_exif: bool,
-    /// Whether to strip GPS tags from EXIF (default: true for privacy protection)
-    pub strip_gps: bool,
+    /// Single source of truth for metadata preservation decisions
+    pub metadata_policy: MetadataPolicy,
     pub firewall: FirewallConfig,
     /// Last error that occurred during compute (for use in reject)
     #[cfg(feature = "napi")]
@@ -253,12 +250,13 @@ fn process_and_encode_from_parts(
     icc_present: bool,
     exif_data: Option<&Arc<Vec<u8>>>,
     auto_orient: bool,
-    keep_icc: bool,
-    keep_exif: bool,
-    strip_gps: bool,
+    policy: &MetadataPolicy,
     firewall: &FirewallConfig,
     metrics: Option<&mut crate::ProcessingMetrics>,
 ) -> std::result::Result<Vec<u8>, LazyImageError> {
+    let keep_icc = policy.effective_icc();
+    let keep_exif = policy.effective_exif();
+    let strip_gps = policy.strip_gps();
     // Get input size from source
     // Use len() method which works for both Memory and Mapped sources
     let input_size = source.map(|s| s.len() as u64).unwrap_or(0);
@@ -422,9 +420,7 @@ impl EncodeTask {
             self.icc_present,
             self.exif_data.as_ref(),
             self.auto_orient,
-            self.keep_icc,
-            self.keep_exif,
-            self.strip_gps,
+            &self.metadata_policy,
             &self.firewall,
             metrics,
         )
@@ -515,9 +511,7 @@ mod non_napi_tests {
             icc_present: false,
             exif_data: None,
             auto_orient: true,
-            keep_icc: false,
-            keep_exif: false,
-            strip_gps: true,
+            metadata_policy: MetadataPolicy::default_policy(),
             firewall: FirewallConfig::disabled(),
         }
     }
@@ -542,9 +536,7 @@ mod non_napi_tests {
             icc_present: false,
             exif_data: None,
             auto_orient: true,
-            keep_icc: false,
-            keep_exif: false,
-            strip_gps: true,
+            metadata_policy: MetadataPolicy::default_policy(),
             firewall: FirewallConfig::disabled(),
         };
         let err = task.decode().unwrap_err();
@@ -600,9 +592,7 @@ mod non_napi_tests {
             icc_present: false,
             exif_data: None,
             auto_orient: true,
-            keep_icc: false,
-            keep_exif: false,
-            strip_gps: true,
+            metadata_policy: MetadataPolicy::default_policy(),
             firewall,
         };
         let err = task.decode().unwrap_err();
@@ -625,9 +615,7 @@ mod non_napi_tests {
             icc_present: false,
             exif_data: None,
             auto_orient: false,
-            keep_icc: false,
-            keep_exif: false,
-            strip_gps: true,
+            metadata_policy: MetadataPolicy::default_policy(),
             firewall: FirewallConfig::disabled(),
         };
         assert!(!task.auto_orient);
@@ -702,12 +690,8 @@ pub struct EncodeWithMetricsTask {
     /// Raw EXIF data extracted from source image (for preservation)
     pub exif_data: Option<Arc<Vec<u8>>>,
     pub auto_orient: bool,
-    /// Whether to preserve ICC profile in output
-    pub keep_icc: bool,
-    /// Whether to preserve EXIF metadata in output
-    pub keep_exif: bool,
-    /// Whether to strip GPS tags from EXIF
-    pub strip_gps: bool,
+    /// Single source of truth for metadata preservation decisions
+    pub metadata_policy: MetadataPolicy,
     pub firewall: FirewallConfig,
     /// Last error that occurred during compute (for use in reject)
     #[cfg(feature = "napi")]
@@ -732,9 +716,7 @@ impl Task for EncodeWithMetricsTask {
             self.icc_present,
             self.exif_data.as_ref(),
             self.auto_orient,
-            self.keep_icc,
-            self.keep_exif,
-            self.strip_gps,
+            &self.metadata_policy,
             &self.firewall,
             Some(&mut metrics),
         ) {
@@ -854,12 +836,8 @@ pub struct WriteFileTask {
     /// Raw EXIF data extracted from source image (for preservation)
     pub exif_data: Option<Arc<Vec<u8>>>,
     pub auto_orient: bool,
-    /// Whether to preserve ICC profile in output
-    pub keep_icc: bool,
-    /// Whether to preserve EXIF metadata in output
-    pub keep_exif: bool,
-    /// Whether to strip GPS tags from EXIF
-    pub strip_gps: bool,
+    /// Single source of truth for metadata preservation decisions
+    pub metadata_policy: MetadataPolicy,
     pub firewall: FirewallConfig,
     pub output_path: String,
     /// Last error that occurred during compute (for use in reject)
@@ -876,9 +854,8 @@ pub struct WriteFileWithMetricsTask {
     pub icc_present: bool,
     pub exif_data: Option<Arc<Vec<u8>>>,
     pub auto_orient: bool,
-    pub keep_icc: bool,
-    pub keep_exif: bool,
-    pub strip_gps: bool,
+    /// Single source of truth for metadata preservation decisions
+    pub metadata_policy: MetadataPolicy,
     pub firewall: FirewallConfig,
     pub output_path: String,
     #[cfg(feature = "napi")]
@@ -901,9 +878,7 @@ impl Task for WriteFileTask {
             self.icc_present,
             self.exif_data.as_ref(),
             self.auto_orient,
-            self.keep_icc,
-            self.keep_exif,
-            self.strip_gps,
+            &self.metadata_policy,
             &self.firewall,
             None,
         ) {
@@ -958,9 +933,7 @@ impl Task for WriteFileWithMetricsTask {
             self.icc_present,
             self.exif_data.as_ref(),
             self.auto_orient,
-            self.keep_icc,
-            self.keep_exif,
-            self.strip_gps,
+            &self.metadata_policy,
             &self.firewall,
             Some(&mut metrics),
         ) {
@@ -1010,12 +983,12 @@ fn process_batch_file(
     ops: &[Operation],
     format: &OutputFormat,
     auto_orient: bool,
-    keep_icc: bool,
-    keep_exif: bool,
-    strip_gps: bool,
+    policy: &MetadataPolicy,
     firewall: &FirewallConfig,
     collect_metrics: bool,
 ) -> std::result::Result<BatchFileSuccess, LazyImageError> {
+    let keep_icc = policy.effective_icc();
+    let keep_exif = policy.effective_exif();
     use std::path::Path;
     use std::sync::Arc;
 
@@ -1058,9 +1031,7 @@ fn process_batch_file(
         icc_present,
         exif_data.as_ref(),
         auto_orient,
-        keep_icc,
-        keep_exif,
-        strip_gps,
+        policy,
         firewall,
         metrics.as_mut(),
     )?;
@@ -1091,12 +1062,8 @@ pub struct BatchTask {
     pub format: OutputFormat,
     pub concurrency: u32,
     pub auto_orient: bool,
-    /// Whether to preserve ICC profile in output
-    pub keep_icc: bool,
-    /// Whether to preserve EXIF metadata in output
-    pub keep_exif: bool,
-    /// Whether to strip GPS tags from EXIF
-    pub strip_gps: bool,
+    /// Single source of truth for metadata preservation decisions
+    pub metadata_policy: MetadataPolicy,
     pub firewall: FirewallConfig,
     /// Last error that occurred during compute (for use in reject)
     #[cfg(feature = "napi")]
@@ -1110,9 +1077,8 @@ pub struct BatchWithMetricsTask {
     pub format: OutputFormat,
     pub concurrency: u32,
     pub auto_orient: bool,
-    pub keep_icc: bool,
-    pub keep_exif: bool,
-    pub strip_gps: bool,
+    /// Single source of truth for metadata preservation decisions
+    pub metadata_policy: MetadataPolicy,
     pub firewall: FirewallConfig,
     #[cfg(feature = "napi")]
     pub(crate) last_error: Option<LazyImageError>,
@@ -1156,9 +1122,7 @@ impl Task for BatchTask {
         let ops = &self.ops;
         let format = &self.format;
         let output_dir = &self.output_dir;
-        let keep_icc = self.keep_icc;
-        let keep_exif = self.keep_exif;
-        let strip_gps = self.strip_gps;
+        let policy = &self.metadata_policy;
         let firewall = self.firewall.clone();
         let process_one = |input_path: &String| -> BatchResult {
             let result = process_batch_file(
@@ -1167,9 +1131,7 @@ impl Task for BatchTask {
                 ops,
                 format,
                 self.auto_orient,
-                keep_icc,
-                keep_exif,
-                strip_gps,
+                policy,
                 &firewall,
                 false,
             );
@@ -1309,9 +1271,7 @@ impl Task for BatchWithMetricsTask {
         let ops = &self.ops;
         let format = &self.format;
         let output_dir = &self.output_dir;
-        let keep_icc = self.keep_icc;
-        let keep_exif = self.keep_exif;
-        let strip_gps = self.strip_gps;
+        let policy = &self.metadata_policy;
         let firewall = self.firewall.clone();
 
         let process_one = |input_path: &String| -> crate::BatchResultWithMetrics {
@@ -1321,9 +1281,7 @@ impl Task for BatchWithMetricsTask {
                 ops,
                 format,
                 self.auto_orient,
-                keep_icc,
-                keep_exif,
-                strip_gps,
+                policy,
                 &firewall,
                 true,
             ) {


### PR DESCRIPTION
## Summary
- Replace three separate boolean fields (`keep_icc`, `keep_exif`, `strip_gps`) on `ImageEngine` and all task structs with a single `MetadataPolicy` struct
- Centralize firewall-override logic in `MetadataPolicy::apply_firewall()` so every output path reads a single source of truth instead of resolving ad-hoc `self.keep_icc && !self.firewall.reject_metadata` combinations
- Reduce field count across 6 task structs (EncodeTask, EncodeWithMetricsTask, WriteFileTask, WriteFileWithMetricsTask, BatchTask, BatchWithMetricsTask) from 3 booleans to 1 policy struct

Closes #493

## Test plan
- [x] `cargo test --no-default-features` -- all Rust tests pass
- [x] `cargo clippy --no-default-features -- -D warnings` -- no warnings
- [x] `npm run build` -- clean build, no warnings
- [x] `npm test` -- all JS integration, type-safety, and pack-contract tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)