### PR TITLE
refactor: move encodeWithinByteBudget from JS to Rust (#489)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -130,6 +130,18 @@ export declare class ImageEngine {
    */
   toBufferWithMetricsPreset(presetName: PresetName): Promise<OutputWithMetrics>
   /**
+   * Encode to buffer with a byte-budget constraint.
+   *
+   * Performs a binary search over quality (entirely in Rust) to find the
+   * highest quality that keeps the output within `target_bytes`. This
+   * eliminates ~7 JS↔NAPI round-trips per call compared to the previous
+   * JS-side implementation.
+   *
+   * Returns `TargetBytesResult` with the encoded data, chosen quality,
+   * actual size, and whether the budget was met.
+   */
+  toBufferTargetBytesNative(format: string, targetBytes: number, minQuality?: number | undefined | null, maxQuality?: number | undefined | null, fastMode?: boolean | undefined | null, strict?: boolean | undefined | null): Promise<TargetBytesResult>
+  /**
    * Encode and write directly to a file asynchronously.
    * **Memory-efficient**: Combined with fromPath(), this enables
    * full file-to-file processing without touching Node.js heap.
@@ -429,6 +441,27 @@ export declare function supportedInputFormats(): Array<CanonicalInputFormat>
 
 /** Get supported output formats */
 export declare function supportedOutputFormats(): Array<CanonicalOutputFormat>
+
+/**
+ * Result of byte-budget encoding (binary search over quality).
+ *
+ * The binary search runs entirely in Rust, eliminating JS↔NAPI round-trips
+ * that the previous JS-side implementation required (~7 per call).
+ */
+export interface TargetBytesResult {
+  /** Encoded image data at the chosen quality */
+  data: Buffer
+  /** Quality level that was selected */
+  quality: number
+  /** Actual output size in bytes */
+  bytesOut: number
+  /** Whether the byte budget was met */
+  budgetMet: boolean
+  /** Requested target bytes */
+  targetBytes: number
+  /** Processing metrics from the final encode iteration */
+  metrics: ProcessingMetrics
+}
 
 /** Get library version */
 export declare function version(): string

--- a/index.js
+++ b/index.js
@@ -836,6 +836,28 @@ if (nativeBinding && nativeBinding.ImageEngine && nativeBinding.ImageEngine.prot
   }
 
   p.toBufferTargetBytes = async function toBufferTargetBytes(format, options) {
+    // Use Rust-native binary search when available (eliminates ~7 JS↔NAPI round-trips)
+    if (typeof this.toBufferTargetBytesNative === 'function') {
+      const config = normalizeTargetBytesOptions(format, options)
+      const result = await this.toBufferTargetBytesNative(
+        config.format,
+        config.targetBytes,
+        config.minQuality,
+        config.maxQuality,
+        config.fastMode,
+        config.qualityFloorPolicy === 'strict',
+      )
+      return {
+        data: result.data,
+        quality: result.quality,
+        bytesOut: result.bytesOut,
+        budgetMet: result.budgetMet,
+        targetBytes: result.targetBytes,
+        metrics: result.metrics,
+      }
+    }
+
+    // Fallback: JS-side binary search (for older native bindings)
     const result = await encodeWithinByteBudget(this, format, options)
     return {
       data: result.data,
@@ -848,6 +870,28 @@ if (nativeBinding && nativeBinding.ImageEngine && nativeBinding.ImageEngine.prot
   }
 
   p.toFileTargetBytes = async function toFileTargetBytes(path, format, options) {
+    // Use Rust-native binary search when available
+    if (typeof this.toBufferTargetBytesNative === 'function') {
+      const config = normalizeTargetBytesOptions(format, options)
+      const result = await this.toBufferTargetBytesNative(
+        config.format,
+        config.targetBytes,
+        config.minQuality,
+        config.maxQuality,
+        config.fastMode,
+        config.qualityFloorPolicy === 'strict',
+      )
+      const written = await this.toFileWithMetrics(path, config.format, result.quality, config.fastMode)
+      return {
+        bytesWritten: written.bytesWritten,
+        quality: result.quality,
+        budgetMet: written.bytesWritten <= config.targetBytes,
+        targetBytes: config.targetBytes,
+        metrics: written.metrics,
+      }
+    }
+
+    // Fallback: JS-side binary search
     const result = await encodeWithinByteBudget(this, format, options)
     const written = await this.toFileWithMetrics(path, result.format, result.quality, result.fastMode)
     return {

--- a/scripts/postbuild-fixup.js
+++ b/scripts/postbuild-fixup.js
@@ -257,6 +257,28 @@ if (nativeBinding && nativeBinding.ImageEngine && nativeBinding.ImageEngine.prot
   }
 
   p.toBufferTargetBytes = async function toBufferTargetBytes(format, options) {
+    // Use Rust-native binary search when available (eliminates ~7 JS↔NAPI round-trips)
+    if (typeof this.toBufferTargetBytesNative === 'function') {
+      const config = normalizeTargetBytesOptions(format, options)
+      const result = await this.toBufferTargetBytesNative(
+        config.format,
+        config.targetBytes,
+        config.minQuality,
+        config.maxQuality,
+        config.fastMode,
+        config.qualityFloorPolicy === 'strict',
+      )
+      return {
+        data: result.data,
+        quality: result.quality,
+        bytesOut: result.bytesOut,
+        budgetMet: result.budgetMet,
+        targetBytes: result.targetBytes,
+        metrics: result.metrics,
+      }
+    }
+
+    // Fallback: JS-side binary search (for older native bindings)
     const result = await encodeWithinByteBudget(this, format, options)
     return {
       data: result.data,
@@ -269,6 +291,28 @@ if (nativeBinding && nativeBinding.ImageEngine && nativeBinding.ImageEngine.prot
   }
 
   p.toFileTargetBytes = async function toFileTargetBytes(path, format, options) {
+    // Use Rust-native binary search when available
+    if (typeof this.toBufferTargetBytesNative === 'function') {
+      const config = normalizeTargetBytesOptions(format, options)
+      const result = await this.toBufferTargetBytesNative(
+        config.format,
+        config.targetBytes,
+        config.minQuality,
+        config.maxQuality,
+        config.fastMode,
+        config.qualityFloorPolicy === 'strict',
+      )
+      const written = await this.toFileWithMetrics(path, config.format, result.quality, config.fastMode)
+      return {
+        bytesWritten: written.bytesWritten,
+        quality: result.quality,
+        budgetMet: written.bytesWritten <= config.targetBytes,
+        targetBytes: config.targetBytes,
+        metrics: written.metrics,
+      }
+    }
+
+    // Fallback: JS-side binary search
     const result = await encodeWithinByteBudget(this, format, options)
     const written = await this.toFileWithMetrics(path, result.format, result.quality, result.fastMode)
     return {

--- a/src/engine/api.rs
+++ b/src/engine/api.rs
@@ -15,8 +15,8 @@ use crate::engine::io::{extract_exif_raw, extract_icc_profile_lossy, load_file_s
 #[cfg(feature = "napi")]
 #[allow(unused_imports)]
 use crate::engine::tasks::{
-    BatchResult, BatchTask, BatchWithMetricsTask, EncodeTask, EncodeWithMetricsTask, WriteFileTask,
-    WriteFileWithMetricsTask,
+    BatchResult, BatchTask, BatchWithMetricsTask, EncodeTargetBytesTask, EncodeTask,
+    EncodeWithMetricsTask, WriteFileTask, WriteFileWithMetricsTask,
 };
 #[cfg(feature = "napi")]
 use crate::error::LazyImageError;
@@ -1063,6 +1063,107 @@ impl ImageEngine {
             quality.map(|q| q as f64),
             fast_mode,
         )
+    }
+
+    /// Encode to buffer with a byte-budget constraint.
+    ///
+    /// Performs a binary search over quality (entirely in Rust) to find the
+    /// highest quality that keeps the output within `target_bytes`. This
+    /// eliminates ~7 JS↔NAPI round-trips per call compared to the previous
+    /// JS-side implementation.
+    ///
+    /// Returns `TargetBytesResult` with the encoded data, chosen quality,
+    /// actual size, and whether the budget was met.
+    #[napi(
+        js_name = "toBufferTargetBytesNative",
+        ts_return_type = "Promise<TargetBytesResult>"
+    )]
+    pub fn to_buffer_target_bytes_native(
+        &mut self,
+        env: Env,
+        format: String,
+        target_bytes: u32,
+        min_quality: Option<u32>,
+        max_quality: Option<u32>,
+        fast_mode: Option<bool>,
+        strict: Option<bool>,
+    ) -> Result<AsyncTask<EncodeTargetBytesTask>> {
+        let fast_mode = fast_mode.unwrap_or(false);
+
+        // Validate and clamp quality range
+        let min_q = min_quality.unwrap_or(30).min(100) as u8;
+        let max_q = max_quality.unwrap_or(100).min(100) as u8;
+        if min_q > max_q {
+            return Err(napi_err(
+                &env,
+                LazyImageError::invalid_argument(
+                    "minQuality",
+                    min_q.to_string(),
+                    "must be less than or equal to maxQuality",
+                ),
+            ));
+        }
+        if min_q == 0 {
+            return Err(napi_err(
+                &env,
+                LazyImageError::invalid_argument("minQuality", "0", "must be between 1 and 100"),
+            ));
+        }
+        if target_bytes == 0 {
+            return Err(napi_err(
+                &env,
+                LazyImageError::invalid_argument("targetBytes", "0", "must be a positive number"),
+            ));
+        }
+
+        // Parse format (quality is irrelevant here, will be overridden per iteration)
+        let output_format =
+            match OutputFormat::from_str_with_options(&format, Some(max_q), fast_mode) {
+                Ok(f) => f,
+                Err(_) => {
+                    let lazy_err = LazyImageError::unsupported_format(format.clone());
+                    return Err(crate::error::napi_error_with_code(&env, lazy_err)?);
+                }
+            };
+
+        let source = self.source.clone();
+        let decoded = self.decoded.clone();
+        let ops = self.ops.clone();
+        let keep_icc = self.keep_icc && !self.firewall.reject_metadata;
+        let keep_exif = self.keep_exif && !self.firewall.reject_metadata;
+        let auto_orient = self.auto_orient;
+        let icc_present = self.icc_profile.is_some();
+        let icc_profile = if keep_icc {
+            self.icc_profile.clone()
+        } else {
+            None
+        };
+        let exif_data = if keep_exif {
+            self.exif_data.clone()
+        } else {
+            None
+        };
+
+        Ok(AsyncTask::new(EncodeTargetBytesTask {
+            source,
+            decoded,
+            ops,
+            format: output_format,
+            icc_profile,
+            icc_present,
+            exif_data,
+            auto_orient,
+            keep_icc,
+            keep_exif,
+            strip_gps: self.strip_gps,
+            firewall: self.firewall.clone(),
+            target_bytes,
+            min_quality: min_q,
+            max_quality: max_q,
+            quality_floor_policy_strict: strict.unwrap_or(false),
+            #[cfg(feature = "napi")]
+            last_error: None,
+        }))
     }
 
     /// Encode and write directly to a file asynchronously.

--- a/src/engine/tasks.rs
+++ b/src/engine/tasks.rs
@@ -648,6 +648,123 @@ mod non_napi_tests {
         assert!(!fast_result.is_empty());
         assert!(!normal_result.is_empty());
     }
+
+    #[test]
+    fn target_bytes_search_finds_best_quality_under_budget() {
+        let img: ImageBuffer<Rgba<u8>, Vec<u8>> =
+            ImageBuffer::from_pixel(64, 64, Rgba([10, 20, 30, 255]));
+        let dyn_img = DynamicImage::ImageRgba8(img);
+
+        // Encode at max quality to get a reference size
+        let task_max = EncodeTask {
+            source: None,
+            decoded: Some(Arc::new(dyn_img.clone())),
+            ops: vec![],
+            format: OutputFormat::Jpeg {
+                quality: 100,
+                fast_mode: false,
+            },
+            icc_profile: None,
+            icc_present: false,
+            exif_data: None,
+            auto_orient: false,
+            keep_icc: false,
+            keep_exif: false,
+            strip_gps: true,
+            firewall: FirewallConfig::disabled(),
+        };
+        let max_size = task_max.process_and_encode(None).unwrap().len();
+
+        // Set a budget larger than any output (should pick max quality)
+        let search_task = EncodeTargetBytesTask {
+            source: None,
+            decoded: Some(Arc::new(dyn_img.clone())),
+            ops: vec![],
+            format: OutputFormat::Jpeg {
+                quality: 100,
+                fast_mode: false,
+            },
+            icc_profile: None,
+            icc_present: false,
+            exif_data: None,
+            auto_orient: false,
+            keep_icc: false,
+            keep_exif: false,
+            strip_gps: true,
+            firewall: FirewallConfig::disabled(),
+            target_bytes: (max_size + 10000) as u32,
+            min_quality: 1,
+            max_quality: 100,
+            quality_floor_policy_strict: false,
+        };
+        let result = search_task.search().expect("search should succeed");
+        assert!(result.budget_met);
+        assert_eq!(result.quality, 100);
+
+        // Set a tight budget (should pick a lower quality)
+        let tight_task = EncodeTargetBytesTask {
+            source: None,
+            decoded: Some(Arc::new(dyn_img)),
+            ops: vec![],
+            format: OutputFormat::Jpeg {
+                quality: 100,
+                fast_mode: false,
+            },
+            icc_profile: None,
+            icc_present: false,
+            exif_data: None,
+            auto_orient: false,
+            keep_icc: false,
+            keep_exif: false,
+            strip_gps: true,
+            firewall: FirewallConfig::disabled(),
+            target_bytes: 500,
+            min_quality: 1,
+            max_quality: 100,
+            quality_floor_policy_strict: false,
+        };
+        let tight_result = tight_task.search().expect("search should succeed");
+        // Quality should be lower than max since budget is tight
+        assert!(tight_result.quality <= 100);
+        // The result should be the best effort (either under budget or closest over)
+        assert!(tight_result.data.len() > 0);
+    }
+
+    #[test]
+    fn target_bytes_strict_policy_fails_when_budget_unmet() {
+        let img: ImageBuffer<Rgba<u8>, Vec<u8>> =
+            ImageBuffer::from_pixel(64, 64, Rgba([10, 20, 30, 255]));
+        let dyn_img = DynamicImage::ImageRgba8(img);
+
+        let task = EncodeTargetBytesTask {
+            source: None,
+            decoded: Some(Arc::new(dyn_img)),
+            ops: vec![],
+            format: OutputFormat::Jpeg {
+                quality: 100,
+                fast_mode: false,
+            },
+            icc_profile: None,
+            icc_present: false,
+            exif_data: None,
+            auto_orient: false,
+            keep_icc: false,
+            keep_exif: false,
+            strip_gps: true,
+            firewall: FirewallConfig::disabled(),
+            // Impossibly small budget
+            target_bytes: 1,
+            min_quality: 80,
+            max_quality: 100,
+            quality_floor_policy_strict: true,
+        };
+        let err = task.search().unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Unable to meet targetBytes"),
+            "expected strict policy error, got: {msg}"
+        );
+    }
 }
 
 pub struct EncodeWithMetricsTask {
@@ -724,6 +841,169 @@ impl Task for EncodeWithMetricsTask {
             // This should not happen if all error paths properly preserve LazyImageError
             LazyImageError::generic(err.to_string())
         });
+        let napi_err = crate::error::napi_error_with_code(&env, lazy_err)?;
+        Err(napi_err)
+    }
+}
+
+/// Result payload for the byte-budget binary search (before NAPI conversion).
+#[derive(Debug)]
+pub struct TargetBytesOutput {
+    pub data: Vec<u8>,
+    pub quality: u8,
+    pub bytes_out: u32,
+    pub budget_met: bool,
+    pub target_bytes: u32,
+    pub metrics: crate::ProcessingMetrics,
+}
+
+/// Async task that performs byte-budget binary search entirely in Rust.
+///
+/// Previous implementation did this in JS, requiring ~7 NAPI round-trips per
+/// call (one per binary-search iteration). Moving the loop to Rust eliminates
+/// all intermediate JS↔NAPI boundary crossings.
+pub struct EncodeTargetBytesTask {
+    pub source: Option<Source>,
+    pub decoded: Option<Arc<DynamicImage>>,
+    pub ops: Vec<Operation>,
+    pub format: OutputFormat,
+    pub icc_profile: Option<Arc<Vec<u8>>>,
+    pub icc_present: bool,
+    pub exif_data: Option<Arc<Vec<u8>>>,
+    pub auto_orient: bool,
+    pub keep_icc: bool,
+    pub keep_exif: bool,
+    pub strip_gps: bool,
+    pub firewall: FirewallConfig,
+    pub target_bytes: u32,
+    pub min_quality: u8,
+    pub max_quality: u8,
+    pub quality_floor_policy_strict: bool,
+    #[cfg(feature = "napi")]
+    pub(crate) last_error: Option<LazyImageError>,
+}
+
+impl EncodeTargetBytesTask {
+    /// Run binary search over quality to find the best encode within byte budget.
+    fn search(&self) -> std::result::Result<TargetBytesOutput, LazyImageError> {
+        let mut low = self.min_quality;
+        let mut high = self.max_quality;
+        let mut best_under: Option<(Vec<u8>, u8, u32, crate::ProcessingMetrics)> = None;
+        let mut best_over: Option<(Vec<u8>, u8, u32, crate::ProcessingMetrics)> = None;
+
+        while low <= high {
+            let quality = low + (high - low) / 2;
+            let format_at_q = self.format.with_quality(quality);
+
+            let mut metrics = crate::ProcessingMetrics::default();
+            let encoded = process_and_encode_from_parts(
+                self.source.as_ref(),
+                self.decoded.as_ref(),
+                &self.ops,
+                &format_at_q,
+                self.icc_profile.as_ref(),
+                self.icc_present,
+                self.exif_data.as_ref(),
+                self.auto_orient,
+                self.keep_icc,
+                self.keep_exif,
+                self.strip_gps,
+                &self.firewall,
+                Some(&mut metrics),
+            )?;
+
+            let size = encoded.len() as u32;
+
+            if size <= self.target_bytes {
+                best_under = Some((encoded, quality, size, metrics));
+                if quality == u8::MAX {
+                    break;
+                }
+                low = quality + 1;
+            } else {
+                let dominated = best_over.as_ref().is_some_and(|(_, _, prev_size, _)| {
+                    size > *prev_size
+                        || (size == *prev_size && quality <= best_over.as_ref().unwrap().1)
+                });
+                if best_over.is_none() || !dominated {
+                    best_over = Some((encoded, quality, size, metrics));
+                }
+                high = quality.saturating_sub(1);
+                if quality == 0 {
+                    break;
+                }
+            }
+        }
+
+        let (data, quality, bytes_out, metrics) = match (best_under, best_over) {
+            (Some(under), _) => under,
+            (None, Some(over)) => over,
+            (None, None) => {
+                return Err(LazyImageError::encode_failed(
+                    self.format.as_str(),
+                    "Failed to encode any candidate while searching for target bytes",
+                ));
+            }
+        };
+
+        let budget_met = bytes_out <= self.target_bytes;
+        if !budget_met && self.quality_floor_policy_strict {
+            return Err(LazyImageError::encode_failed(
+                self.format.as_str(),
+                format!(
+                    "Unable to meet targetBytes={} within quality range {}-{}",
+                    self.target_bytes, self.min_quality, self.max_quality,
+                ),
+            ));
+        }
+
+        Ok(TargetBytesOutput {
+            data,
+            quality,
+            bytes_out,
+            budget_met,
+            target_bytes: self.target_bytes,
+            metrics,
+        })
+    }
+}
+
+#[cfg(feature = "napi")]
+#[napi]
+impl Task for EncodeTargetBytesTask {
+    type Output = TargetBytesOutput;
+    type JsValue = crate::TargetBytesResult;
+
+    fn compute(&mut self) -> Result<Self::Output> {
+        match self.search() {
+            Ok(result) => {
+                self.last_error = None;
+                Ok(result)
+            }
+            Err(lazy_err) => {
+                self.last_error = Some(lazy_err.clone());
+                Err(napi::Error::from(lazy_err))
+            }
+        }
+    }
+
+    fn resolve(&mut self, env: Env, output: Self::Output) -> Result<Self::JsValue> {
+        let js_buffer = BufferSlice::from_data(&env, output.data)?.into_buffer(&env)?;
+        Ok(crate::TargetBytesResult {
+            data: js_buffer,
+            quality: output.quality as u32,
+            bytes_out: output.bytes_out,
+            budget_met: output.budget_met,
+            target_bytes: output.target_bytes,
+            metrics: output.metrics,
+        })
+    }
+
+    fn reject(&mut self, env: Env, err: napi::Error) -> Result<Self::JsValue> {
+        let lazy_err = self
+            .last_error
+            .take()
+            .unwrap_or_else(|| LazyImageError::generic(err.to_string()));
         let napi_err = crate::error::napi_error_with_code(&env, lazy_err)?;
         Err(napi_err)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -385,6 +385,27 @@ pub struct BatchOutputWithMetrics {
     pub summary: BatchMetricsSummary,
 }
 
+/// Result of byte-budget encoding (binary search over quality).
+///
+/// The binary search runs entirely in Rust, eliminating JS↔NAPI round-trips
+/// that the previous JS-side implementation required (~7 per call).
+#[cfg(feature = "napi")]
+#[napi(object)]
+pub struct TargetBytesResult {
+    /// Encoded image data at the chosen quality
+    pub data: napi::bindgen_prelude::Buffer,
+    /// Quality level that was selected
+    pub quality: u32,
+    /// Actual output size in bytes
+    pub bytes_out: u32,
+    /// Whether the byte budget was met
+    pub budget_met: bool,
+    /// Requested target bytes
+    pub target_bytes: u32,
+    /// Processing metrics from the final encode iteration
+    pub metrics: ProcessingMetrics,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -294,6 +294,20 @@ impl OutputFormat {
             OutputFormat::Avif { .. } => "avif",
         }
     }
+
+    /// Create a copy of this format with a different quality value.
+    /// For PNG (lossless), the format is returned unchanged.
+    pub fn with_quality(&self, quality: u8) -> Self {
+        match self {
+            OutputFormat::Jpeg { fast_mode, .. } => OutputFormat::Jpeg {
+                quality,
+                fast_mode: *fast_mode,
+            },
+            OutputFormat::Png => OutputFormat::Png,
+            OutputFormat::WebP { .. } => OutputFormat::WebP { quality },
+            OutputFormat::Avif { .. } => OutputFormat::Avif { quality },
+        }
+    }
 }
 
 // =============================================================================
@@ -602,6 +616,43 @@ mod tests {
             assert_eq!(OutputFormat::Png.as_str(), "png");
             assert_eq!(OutputFormat::WebP { quality: 80 }.as_str(), "webp");
             assert_eq!(OutputFormat::Avif { quality: 60 }.as_str(), "avif");
+        }
+
+        #[test]
+        fn test_with_quality_jpeg() {
+            let original = OutputFormat::Jpeg {
+                quality: 85,
+                fast_mode: true,
+            };
+            let changed = original.with_quality(50);
+            match changed {
+                OutputFormat::Jpeg { quality, fast_mode } => {
+                    assert_eq!(quality, 50);
+                    assert!(fast_mode, "fast_mode should be preserved");
+                }
+                _ => panic!("expected Jpeg variant"),
+            }
+        }
+
+        #[test]
+        fn test_with_quality_webp() {
+            let original = OutputFormat::WebP { quality: 80 };
+            let changed = original.with_quality(30);
+            assert!(matches!(changed, OutputFormat::WebP { quality: 30 }));
+        }
+
+        #[test]
+        fn test_with_quality_avif() {
+            let original = OutputFormat::Avif { quality: 60 };
+            let changed = original.with_quality(90);
+            assert!(matches!(changed, OutputFormat::Avif { quality: 90 }));
+        }
+
+        #[test]
+        fn test_with_quality_png_unchanged() {
+            let original = OutputFormat::Png;
+            let changed = original.with_quality(50);
+            assert!(matches!(changed, OutputFormat::Png));
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds `toBufferTargetBytesNative` NAPI method that performs the byte-budget binary search (quality search) entirely in Rust, eliminating ~7 JS-to-NAPI round-trips per `toBufferTargetBytes` call
- Adds `OutputFormat::with_quality()` helper for creating format variants at different quality levels
- JS wrapper (`toBufferTargetBytes` / `toFileTargetBytes`) auto-detects the native method and falls back to the existing JS-side loop for older bindings

## Key changes
- **`src/engine/tasks.rs`**: New `EncodeTargetBytesTask` that calls `process_and_encode_from_parts` in a loop with different quality values, performing binary search over quality while staying in Rust
- **`src/engine/api.rs`**: New `toBufferTargetBytesNative` NAPI export with validation
- **`src/ops.rs`**: `OutputFormat::with_quality()` method + tests
- **`src/lib.rs`**: `TargetBytesResult` NAPI object struct
- **`scripts/postbuild-fixup.js`**: Updated JS wrappers to prefer native path

## Test plan
- [x] `cargo test --no-default-features` -- all pass (including new `target_bytes_search_finds_best_quality_under_budget` and `target_bytes_strict_policy_fails_when_budget_unmet`)
- [x] `cargo clippy --no-default-features -- -D warnings` -- clean
- [x] `cargo fmt --check` -- clean
- [x] `npm run build && npm test` -- all pass
- [x] `npm run test:js` -- all pass (including existing `toBufferTargetBytes` and `toFileTargetBytes` integration tests)
- [x] Manual verification: native method is detected and used, strict policy errors propagate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)