### PR TITLE
chore: fix Clippy warnings and adopt idiomatic Rust patterns

### DIFF
--- a/src/codecs/avif_safe.rs
+++ b/src/codecs/avif_safe.rs
@@ -15,10 +15,10 @@ use std::{cell::Cell, thread_local};
 
 #[cfg(test)]
 thread_local! {
-    static TRACK_DROPS: Cell<bool> = Cell::new(false);
-    static LIVE_IMAGES: Cell<usize> = Cell::new(0);
-    static LIVE_ENCODERS: Cell<usize> = Cell::new(0);
-    static LIVE_RWDATA: Cell<usize> = Cell::new(0);
+    static TRACK_DROPS: Cell<bool> = const { Cell::new(false) };
+    static LIVE_IMAGES: Cell<usize> = const { Cell::new(0) };
+    static LIVE_ENCODERS: Cell<usize> = const { Cell::new(0) };
+    static LIVE_RWDATA: Cell<usize> = const { Cell::new(0) };
 }
 
 /// Safe wrapper for avifImage that manages its lifetime using RAII.

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1191,8 +1191,8 @@ mod tests {
             let low_quality = encode_jpeg(&img, 50, None).unwrap();
             // Higher quality is usually larger (though content may reverse this)
             // At least verify both are valid JPEGs
-            assert!(high_quality.len() > 0);
-            assert!(low_quality.len() > 0);
+            assert!(!high_quality.is_empty());
+            assert!(!low_quality.is_empty());
             assert_eq!(&high_quality[0..2], &[0xFF, 0xD8]);
             assert_eq!(&low_quality[0..2], &[0xFF, 0xD8]);
         }
@@ -1331,8 +1331,8 @@ mod tests {
             let high_quality = encode_avif(&img, 80, None).unwrap();
             let low_quality = encode_avif(&img, 40, None).unwrap();
             // Verify both are valid AVIF
-            assert!(high_quality.len() > 0);
-            assert!(low_quality.len() > 0);
+            assert!(!high_quality.is_empty());
+            assert!(!low_quality.is_empty());
         }
 
         #[test]

--- a/src/engine/api.rs
+++ b/src/engine/api.rs
@@ -797,7 +797,7 @@ impl ImageEngine {
     ) -> Result<Reference<ImageEngine>> {
         let value = validation::ensure_finite_integer("brightness", value)
             .and_then(|int| {
-                if int < -100 || int > 100 {
+                if !(-100..=100).contains(&int) {
                     Err(LazyImageError::invalid_argument(
                         "brightness",
                         int.to_string(),
@@ -823,7 +823,7 @@ impl ImageEngine {
     ) -> Result<Reference<ImageEngine>> {
         let value = validation::ensure_finite_integer("contrast", value)
             .and_then(|int| {
-                if int < -100 || int > 100 {
+                if !(-100..=100).contains(&int) {
                     Err(LazyImageError::invalid_argument(
                         "contrast",
                         int.to_string(),

--- a/src/engine/memory.rs
+++ b/src/engine/memory.rs
@@ -984,7 +984,7 @@ mod tests {
         );
         // 2GB -> 5% = 102.4MB -> within bounds
         let reserved = compute_reserved_memory(2 * 1024 * 1024 * 1024);
-        assert!(reserved >= 100 * 1024 * 1024 && reserved <= 110 * 1024 * 1024);
+        assert!((100 * 1024 * 1024..=110 * 1024 * 1024).contains(&reserved));
     }
 
     #[test]
@@ -1066,7 +1066,7 @@ mod tests {
     fn test_calculate_memory_based_concurrency_constrained() {
         // 512MB container: can fit ~3 operations (512MB - 128MB reserve = 384MB / 100MB = 3)
         let result = calculate_memory_based_concurrency(Some(512 * 1024 * 1024), 8);
-        assert!(result >= MIN_SAFE_CONCURRENCY && result <= 4);
+        assert!((MIN_SAFE_CONCURRENCY..=4).contains(&result));
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1172,7 +1172,7 @@ mod tests {
 
     #[test]
     fn test_e102_mmap_failed() {
-        let io_err = std::io::Error::new(std::io::ErrorKind::Other, "mmap error");
+        let io_err = std::io::Error::other("mmap error");
         let err = LazyImageError::mmap_failed("/big/file.jpg", io_err);
         assert_error_variant(
             &err,
@@ -1372,7 +1372,7 @@ mod tests {
 
     #[test]
     fn test_e301_file_write_failed() {
-        let io_err = std::io::Error::new(std::io::ErrorKind::Other, "disk full");
+        let io_err = std::io::Error::other("disk full");
         let err = LazyImageError::file_write_failed("/out/image.webp", io_err);
         assert_error_variant(
             &err,
@@ -1596,7 +1596,7 @@ mod tests {
     #[test]
     fn test_recovery_hint_non_empty_for_all_variants() {
         // Build one instance of every LazyImageError variant and verify its hint
-        let io_err = || std::io::Error::new(std::io::ErrorKind::Other, "test");
+        let io_err = || std::io::Error::other("test");
         let all_errors: Vec<LazyImageError> = vec![
             LazyImageError::file_not_found("x"),
             LazyImageError::file_read_failed("x", io_err()),
@@ -1637,7 +1637,7 @@ mod tests {
     fn test_error_code_consistency_with_error_variant() {
         // Verify that LazyImageError.code().category() matches LazyImageError.category()
         // for every variant (ensures the two parallel match arms stay in sync).
-        let io_err = || std::io::Error::new(std::io::ErrorKind::Other, "test");
+        let io_err = || std::io::Error::other("test");
         let all_errors: Vec<LazyImageError> = vec![
             LazyImageError::file_not_found("x"),
             LazyImageError::file_read_failed("x", io_err()),


### PR DESCRIPTION
## Summary
Closes #479

Fixes all actionable Clippy warnings across the codebase:

| File | Change |
|------|--------|
| `src/engine/api.rs` | Manual range → `(-100..=100).contains()` |
| `src/engine/memory.rs` | Manual range → `.contains()` |
| `src/error.rs` | `io::Error::new(Other, msg)` → `io::Error::other(msg)` |
| `src/engine.rs` | `.len() > 0` → `!is_empty()` |
| `src/codecs/avif_safe.rs` | Thread-local init → `const { Cell::new() }` |

The "8 function parameters" warning (api.rs) is skipped — it's a larger refactor.

## Test plan
- [x] `cargo clippy --no-default-features -- -D warnings` — zero warnings
- [x] `cargo test --no-default-features` — all 370 tests pass
- [x] `cargo fmt --check` — clean