### PR TITLE
chore: add .editorconfig, CODEOWNERS, FUNDING.yml, MSRV

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# https://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.rs]
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for all files
+* @albert-einshutoin

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: albert-einshutoin

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.13.0"
 edition = "2021"
 description = "Web image optimization engine - smaller outputs than sharp, powered by Rust + mozjpeg"
 license = "MIT"
+rust-version = "1.88"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ lazy-image reduces image file sizes by 20-30% compared to sharp in its target we
 [![Node.js CI](https://github.com/albert-einshutoin/lazy-image/actions/workflows/CI.yml/badge.svg)](https://github.com/albert-einshutoin/lazy-image/actions/workflows/CI.yml)
 [![codecov](https://codecov.io/gh/albert-einshutoin/lazy-image/branch/main/graph/badge.svg)](https://codecov.io/gh/albert-einshutoin/lazy-image)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Rust](https://img.shields.io/badge/rust-1.70+-orange.svg)](https://www.rust-lang.org/)
+[![Rust](https://img.shields.io/badge/rust-1.88+-orange.svg)](https://www.rust-lang.org/)
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `.editorconfig` for cross-IDE consistency (2-space JS/TS/JSON, 4-space Rust, LF)
- Add `CODEOWNERS` for automatic review assignment
- Add `FUNDING.yml` to enable GitHub Sponsors button
- Declare `rust-version = "1.88"` in Cargo.toml (matches CI toolchain)
- Update README Rust badge from 1.70+ to 1.88+

## Test plan
- [ ] `npm run build` passes
- [ ] `npm test` passes
- [ ] `cargo clippy --no-default-features -- -D warnings` clean (MSRV check)