### PR TITLE
fix: update SECURITY.md supported versions to 0.13.x

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,9 +4,9 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.9.x   | :white_check_mark: |
-| 0.8.x   | :white_check_mark: |
-| < 0.8   | :x:                |
+| 0.13.x  | :white_check_mark: |
+| 0.12.x  | :white_check_mark: |
+| < 0.12  | :x:                |
 
 ## Reporting a Vulnerability
 
@@ -60,7 +60,7 @@ lazy-image implements several security measures to protect against common vulner
   - Critical/High: security patch release within 14 days of confirmation.
   - Medium: patch in the next scheduled minor/patch release (target ≤ 30 days).
   - Low: fixed opportunistically in a regular release.
-- **Backports**: Security fixes are backported to all supported lines (0.9.x and 0.8.x). Unsupported versions (<0.8) are not patched; users must upgrade.
+- **Backports**: Security fixes are backported to all supported lines (0.13.x and 0.12.x). Unsupported versions (<0.12) are not patched; users must upgrade.
 - **Disclosure**: Public disclosure occurs after a fix is released and packages are available. If coordinated disclosure is requested, we honor reasonable embargoes up to 90 days.
 - **Credit**: We credit reporters in the advisory unless anonymity is requested.
 


### PR DESCRIPTION
## Summary
- Update supported versions table: 0.13.x and 0.12.x (was 0.9.x and 0.8.x)
- Update backport policy text to match

The project is at v0.13.0 — the old version references were stale.

## Test plan
- [ ] Verify version numbers are consistent throughout SECURITY.md