### PR TITLE
docs: add JavaScript usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ More: batch processing, presets, metrics, streaming — [docs/API.md](./docs/API
 
 | Topic | Link |
 |-------|------|
+| **Examples** | [examples/](./examples/) |
 | **Full API reference** | [docs/API.md](./docs/API.md) |
 | **Migration from sharp** | [docs/MIGRATION_FROM_SHARP.md](./docs/MIGRATION_FROM_SHARP.md) |
 | **Performance & when to use** | [docs/PERFORMANCE.md](./docs/PERFORMANCE.md) |

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,30 @@
+# Examples
+
+Runnable examples demonstrating lazy-image usage patterns.
+
+## Prerequisites
+
+```bash
+npm install @alberteinshutoin/lazy-image
+# or build from source:
+git clone https://github.com/albert-einshutoin/lazy-image.git
+cd lazy-image && npm install && npm run build
+```
+
+## Examples
+
+| File | Description |
+|------|-------------|
+| [basic.mjs](./basic.mjs) | Resize, convert, crop, rotate, presets, metrics |
+| [batch-processing.mjs](./batch-processing.mjs) | Batch processing with auto/manual concurrency |
+| [error-handling.mjs](./error-handling.mjs) | 4-tier error taxonomy, validation, Image Firewall |
+
+## Running
+
+```bash
+node examples/basic.mjs
+node examples/batch-processing.mjs
+node examples/error-handling.mjs
+```
+
+These examples use ESM (`import`). For CommonJS, replace `import` with `require()`.

--- a/examples/basic.mjs
+++ b/examples/basic.mjs
@@ -1,0 +1,64 @@
+/**
+ * Basic usage examples for lazy-image.
+ *
+ * Prerequisites:
+ *   npm install @alberteinshutoin/lazy-image
+ *   (or run from the repo root after `npm run build`)
+ *
+ * Run:
+ *   node examples/basic.mjs
+ */
+
+import { ImageEngine, inspectFile } from '@alberteinshutoin/lazy-image';
+
+// ── 1. Resize and save (file-to-file, recommended) ─────────────────
+const bytesWritten = await ImageEngine.fromPath('input.jpg')
+  .resize(800)
+  .toFile('output.jpg', 'jpeg', 85);
+
+console.log(`Wrote ${bytesWritten} bytes`);
+
+// ── 2. Convert PNG to WebP with quality control ────────────────────
+const webpBuffer = await ImageEngine.fromPath('photo.png')
+  .resize({ width: 1200, fit: 'inside' })
+  .toBuffer('webp', 80);
+
+console.log(`WebP buffer: ${webpBuffer.length} bytes`);
+
+// ── 3. Multiple outputs from one source (clone) ────────────────────
+const engine = ImageEngine.fromPath('hero.jpg').resize(1920);
+
+const [jpegBytes, avifBytes] = await Promise.all([
+  engine.clone().toFile('hero.jpg', 'jpeg', 85),
+  engine.clone().toFile('hero.avif', 'avif', 60),
+]);
+
+console.log(`JPEG: ${jpegBytes} bytes, AVIF: ${avifBytes} bytes`);
+
+// ── 4. Inspect metadata without decoding ───────────────────────────
+const meta = inspectFile('input.jpg');
+console.log(`${meta.width}x${meta.height} ${meta.format}`);
+
+// ── 5. Presets for common use cases ────────────────────────────────
+const thumbnail = await ImageEngine.fromPath('photo.jpg')
+  .toBufferWithPreset('thumbnail');
+
+console.log(`Thumbnail: ${thumbnail.length} bytes`);
+
+// ── 6. Crop, rotate, and grayscale ─────────────────────────────────
+const processed = await ImageEngine.fromPath('photo.jpg')
+  .crop(100, 100, 400, 400)
+  .rotate(90)
+  .grayscale()
+  .toBuffer('jpeg', 80);
+
+console.log(`Processed: ${processed.length} bytes`);
+
+// ── 7. Encode with metrics ─────────────────────────────────────────
+const { data, metrics } = await ImageEngine.fromPath('photo.jpg')
+  .resize(600)
+  .toBufferWithMetrics('webp', 80);
+
+console.log(`Output: ${data.length} bytes`);
+console.log(`Decode: ${metrics.decodeMs}ms, Encode: ${metrics.encodeMs}ms`);
+console.log(`Compression ratio: ${metrics.compressionRatio.toFixed(2)}`);

--- a/examples/batch-processing.mjs
+++ b/examples/batch-processing.mjs
@@ -1,0 +1,50 @@
+/**
+ * Batch processing examples for lazy-image.
+ *
+ * Run:
+ *   node examples/batch-processing.mjs
+ */
+
+import { ImageEngine } from '@alberteinshutoin/lazy-image';
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const inputDir = './images';
+const outputDir = './optimized';
+
+// ── 1. Simple batch with auto concurrency ──────────────────────────
+const files = readdirSync(inputDir)
+  .filter((f) => /\.(jpe?g|png|webp)$/i.test(f))
+  .map((f) => join(inputDir, f));
+
+const results = await ImageEngine.fromPath(files[0])
+  .resize(1200)
+  .processBatch(files, outputDir, {
+    format: 'webp',
+    quality: 80,
+    // concurrency: 0 = auto-detect based on CPU cores and memory
+  });
+
+for (const r of results) {
+  if (r.success) {
+    console.log(`OK: ${r.source} -> ${r.outputPath}`);
+  } else {
+    console.error(`FAIL: ${r.source} — ${r.error} [${r.errorCode}]`);
+  }
+}
+
+// ── 2. Batch with metrics and manual concurrency ───────────────────
+const { items, summary } = await ImageEngine.fromPath(files[0])
+  .resize(800)
+  .processBatchWithMetrics(files, outputDir, {
+    format: 'jpeg',
+    quality: 85,
+    concurrency: 4,
+  });
+
+console.log(`\nBatch summary:`);
+console.log(`  Success: ${summary.successfulItems}/${summary.totalItems}`);
+console.log(`  Concurrency: ${summary.effectiveConcurrency} (auto: ${summary.autoConcurrency})`);
+console.log(`  Total in: ${(summary.totalBytesIn / 1024).toFixed(0)} KB`);
+console.log(`  Total out: ${(summary.totalBytesOut / 1024).toFixed(0)} KB`);
+console.log(`  Wall time: ${summary.totalWallMs.toFixed(0)} ms`);

--- a/examples/error-handling.mjs
+++ b/examples/error-handling.mjs
@@ -1,0 +1,77 @@
+/**
+ * Error handling examples for lazy-image.
+ *
+ * lazy-image uses a 4-tier error taxonomy:
+ *   - UserError: invalid input, recoverable by the caller
+ *   - CodecError: format/encoding issues
+ *   - ResourceLimit: memory/dimension limits
+ *   - InternalBug: library bugs (please report)
+ *
+ * Run:
+ *   node examples/error-handling.mjs
+ */
+
+import {
+  ImageEngine,
+  ErrorCategory,
+  getErrorCategory,
+  inspectFile,
+} from '@alberteinshutoin/lazy-image';
+
+// ── 1. Category-based error recovery ───────────────────────────────
+try {
+  await ImageEngine.fromPath('missing.jpg')
+    .resize(800)
+    .toBuffer('jpeg', 85);
+} catch (err) {
+  const category = getErrorCategory(err);
+
+  switch (category) {
+    case ErrorCategory.UserError:
+      console.log('Fix your input:', err.message);
+      break;
+    case ErrorCategory.CodecError:
+      console.log('Image format issue:', err.message);
+      break;
+    case ErrorCategory.ResourceLimit:
+      console.log('Resource limit hit:', err.message);
+      break;
+    case ErrorCategory.InternalBug:
+      console.error('Please report this bug:', err.message);
+      break;
+    default:
+      console.log('Unknown error:', err.message);
+  }
+
+  // Fine-grained code and recovery hint are also available
+  console.log('Error code:', err.errorCode);
+  console.log('Recovery hint:', err.recoveryHint);
+}
+
+// ── 2. Validate before processing ──────────────────────────────────
+function safeProcess(inputPath, outputPath) {
+  const MAX_DIMENSION = 10000;
+
+  const meta = inspectFile(inputPath);
+
+  if (meta.width > MAX_DIMENSION || meta.height > MAX_DIMENSION) {
+    throw new Error(`Image too large: ${meta.width}x${meta.height}`);
+  }
+
+  return ImageEngine.fromPath(inputPath)
+    .resize(800)
+    .toFile(outputPath, 'webp', 80);
+}
+
+// ── 3. Image Firewall for untrusted uploads ────────────────────────
+try {
+  await ImageEngine.fromPath('untrusted-upload.jpg')
+    .sanitize({ policy: 'strict' })
+    .resize(1200)
+    .toBuffer('webp', 80);
+} catch (err) {
+  const category = getErrorCategory(err);
+  if (category === ErrorCategory.ResourceLimit) {
+    console.log('Upload rejected by firewall:', err.message);
+  }
+}


### PR DESCRIPTION
## Summary
- Add `examples/basic.mjs` — resize, convert, crop, rotate, presets, metrics
- Add `examples/batch-processing.mjs` — batch with auto/manual concurrency
- Add `examples/error-handling.mjs` — 4-tier error taxonomy, validation, firewall
- Add `examples/README.md` — index with descriptions and prerequisites
- Add "Examples" link to README.md documentation table

The `examples/` directory previously only contained a Rust stress test. A Node.js library with zero JS examples is a significant adoption barrier.

## Test plan
- [ ] Examples are syntactically valid ESM (`node --check examples/*.mjs`)
- [ ] API usage matches current index.d.ts signatures
- [ ] README link resolves correctly