### PR TITLE
refactor: add Copy derive to ResizeFit and MetadataPolicy (#544)

### DIFF
--- a/src/engine/metadata.rs
+++ b/src/engine/metadata.rs
@@ -10,7 +10,7 @@
 /// Centralizes the keep-ICC / keep-EXIF / strip-GPS decision so that every
 /// output path reads a single source of truth instead of resolving ad-hoc
 /// boolean combinations.
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct MetadataPolicy {
     /// Whether to preserve ICC profile in output (default: false)
     pub icc: bool,

--- a/src/engine/pipeline.rs
+++ b/src/engine/pipeline.rs
@@ -227,7 +227,7 @@ pub fn optimize_ops(ops: &[Operation]) -> Vec<Operation> {
         {
             let mut final_width = *w1;
             let mut final_height = *h1;
-            let fit_mode = fit.clone();
+            let fit_mode = *fit;
 
             // Absorb all immediately-following resizes with the same fit mode.
             while i + 1 < ops.len() {

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -179,7 +179,7 @@ pub enum ColorSpace {
     Srgb,
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum ResizeFit {
     /// Maintain aspect ratio while fitting inside the bounding box (default)
     #[default]
@@ -405,10 +405,9 @@ impl PresetConfig {
     /// Looks up the name in `PRESET_TABLE` — the single source of truth for
     /// all built-in presets.
     pub fn get(name: &str) -> Option<Self> {
-        let lower = name.to_lowercase();
         PRESET_TABLE
             .iter()
-            .find(|e| e.name == lower)
+            .find(|e| e.name.eq_ignore_ascii_case(name))
             .map(preset_entry_to_config)
     }
 


### PR DESCRIPTION
## Summary
- Add `Copy` to `ResizeFit` (3-variant enum) and `MetadataPolicy` (3 `bool` fields)
- Replace `fit.clone()` with `*fit` in pipeline.rs
- Replace `.to_lowercase()` with `.eq_ignore_ascii_case()` in preset lookup (avoids heap allocation)

Closes #544

## Test plan
- [x] `cargo clippy --no-default-features -- -D warnings` clean
- [x] `cargo test --no-default-features` passes
- [x] `cargo fmt --check` clean