### PR TITLE
refactor: improve helpers.js type safety and remove unused export (#550)

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -40,12 +40,14 @@ const ENCODE_PROFILE_CONFIG = {
 // Pure helpers (no dependency on nativeBinding)
 // ---------------------------------------------------------------------------
 
+/** Clamp a value to a valid quality integer (0–100), or return undefined. */
 function clampQuality(v) {
   const n = Number(v);
   if (!Number.isFinite(n)) return undefined;
   return Math.max(0, Math.min(100, Math.round(n)));
 }
 
+/** Validate and normalize target-bytes options for binary-search encoding. */
 function normalizeTargetBytesOptions(format, options = {}) {
   const normalizedFormat = String(format || '').toLowerCase();
   if (!TARGET_BYTES_SUPPORTED_FORMATS.has(normalizedFormat)) {
@@ -179,6 +181,7 @@ async function runTargetBytesSearch(engine, format, options) {
   };
 }
 
+/** Resolve an encode-profile name into concrete quality/fastMode settings. */
 function resolveEncodeProfile(format, profile = 'balanced', quality) {
   const normalizedFormat = String(format || '').toLowerCase();
   if (!['jpeg', 'jpg', 'png', 'webp', 'avif'].includes(normalizedFormat)) {
@@ -186,7 +189,7 @@ function resolveEncodeProfile(format, profile = 'balanced', quality) {
   }
 
   const normalizedProfile = String(profile || 'balanced').toLowerCase();
-  if (!Object.prototype.hasOwnProperty.call(ENCODE_PROFILE_CONFIG, normalizedProfile)) {
+  if (!Object.hasOwn(ENCODE_PROFILE_CONFIG, normalizedProfile)) {
     throw new Error(`Unsupported encode profile: ${profile}`);
   }
 
@@ -286,6 +289,7 @@ function createGetErrorCategory(ErrorCategory, ErrorCode) {
 // Prototype method attachment — called with the ImageEngine class
 // ---------------------------------------------------------------------------
 
+/** Attach profile and target-bytes convenience methods to ImageEngine.prototype. */
 function attachPrototypeMethods(ImageEngine) {
   if (!ImageEngine || !ImageEngine.prototype) return;
   const p = ImageEngine.prototype;
@@ -341,7 +345,6 @@ module.exports = {
   ENCODE_PROFILE_CONFIG,
   clampQuality,
   normalizeTargetBytesOptions,
-  encodeWithinByteBudget,
   runTargetBytesSearch,
   resolveEncodeProfile,
   createGetErrorCategory,


### PR DESCRIPTION
## Summary
- Remove `encodeWithinByteBudget` from `module.exports` (internal-only function)
- Replace `Object.prototype.hasOwnProperty.call()` with `Object.hasOwn()` (ES2022)
- Add JSDoc to `clampQuality`, `normalizeTargetBytesOptions`, `resolveEncodeProfile`, `attachPrototypeMethods`

Closes #550

## Test plan
- [x] `npm run test:js` passes