### PR TITLE
fix: harden script reliability for type safety and postbuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
       "require": "./index.js"
     },
     "./streaming": {
+      "types": "./streaming/pipeline.d.ts",
       "import": "./streaming/pipeline.mjs",
       "require": "./streaming/pipeline.js"
     }

--- a/scripts/postbuild-fixup.js
+++ b/scripts/postbuild-fixup.js
@@ -126,7 +126,7 @@ function replaceIfNeeded(content, searchValue, replaceValue) {
       `${JSON.stringify(searchValue.slice(0, 80))}`
     );
   }
-  return content.replace(searchValue, replaceValue);
+  return content.replaceAll(searchValue, replaceValue);
 }
 
 function patchIndexJs() {

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -7,7 +7,12 @@ const cargoPath = path.join(root, "Cargo.toml");
 const lockPath = path.join(root, "package-lock.json");
 
 function readJson(filePath) {
-  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to parse JSON file ${filePath}: ${message}`);
+  }
 }
 
 function writeJson(filePath, data) {
@@ -73,10 +78,11 @@ function syncPackageLock(pkg) {
           ? key.slice("node_modules/".length)
           : key;
       if (pkg.optionalDependencies[entryName] && entry.version !== pkg.version) {
+        const previousVersion = entry.version;
         entry.version = pkg.version;
         if (entry.resolved) {
           entry.resolved = entry.resolved.replace(
-            /-[0-9]+\.[0-9]+\.[0-9]+\.tgz$/,
+            new RegExp(`-${escapeRegExp(previousVersion)}\\.tgz$`),
             `-${pkg.version}.tgz`
           );
           // Clear integrity so next `npm install` regenerates it for the new tarball.
@@ -94,6 +100,10 @@ function syncPackageLock(pkg) {
     writeJson(lockPath, lock);
   }
   return changed;
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function main() {
@@ -121,4 +131,3 @@ function main() {
 }
 
 main();
-

--- a/src/engine/encoder.rs
+++ b/src/engine/encoder.rs
@@ -703,14 +703,26 @@ pub fn encode_avif(img: &DynamicImage, quality: u8, icc: Option<&[u8]>) -> Encod
                 .map_err(|e| LazyImageError::encode_failed("avif".to_string(), e.to_string()))?;
 
             unsafe {
+                // SAFETY:
+                // - `allocate_planes(AVIF_PLANES_A)` succeeded immediately above, so libavif has
+                //   allocated an alpha plane for the image.
+                // - `alpha_plane_mut()` yields exclusive access to that plane for the lifetime of
+                //   this block.
+                // - We only write indices within `[0, alpha_row_bytes * height)`, and each source
+                //   index is within the validated RGBA input buffer.
                 let alpha_plane = avif_image.alpha_plane_mut().map_err(|e| {
-                    LazyImageError::encode_failed("avif".to_string(), e.to_string())
+                    LazyImageError::encode_failed("avif", e.to_string())
                 })?;
                 let alpha_row_bytes = avif_image.alpha_row_bytes();
+                let alpha_plane_len = alpha_row_bytes
+                    .checked_mul(height as usize)
+                    .ok_or_else(|| LazyImageError::encode_failed("avif", "Alpha plane size overflow"))?;
+                debug_assert!(alpha_row_bytes >= width as usize);
                 for y in 0..height as usize {
                     for x in 0..width as usize {
                         let src_idx = (y * width as usize + x) * 4 + 3;
                         let dst_idx = y * alpha_row_bytes + x;
+                        debug_assert!(dst_idx < alpha_plane_len);
                         *alpha_plane.as_ptr().add(dst_idx) = pixels[src_idx];
                     }
                 }

--- a/src/engine/encoder.rs
+++ b/src/engine/encoder.rs
@@ -710,13 +710,16 @@ pub fn encode_avif(img: &DynamicImage, quality: u8, icc: Option<&[u8]>) -> Encod
                 //   this block.
                 // - We only write indices within `[0, alpha_row_bytes * height)`, and each source
                 //   index is within the validated RGBA input buffer.
-                let alpha_plane = avif_image.alpha_plane_mut().map_err(|e| {
-                    LazyImageError::encode_failed("avif", e.to_string())
-                })?;
+                let alpha_plane = avif_image
+                    .alpha_plane_mut()
+                    .map_err(|e| LazyImageError::encode_failed("avif", e.to_string()))?;
                 let alpha_row_bytes = avif_image.alpha_row_bytes();
-                let alpha_plane_len = alpha_row_bytes
-                    .checked_mul(height as usize)
-                    .ok_or_else(|| LazyImageError::encode_failed("avif", "Alpha plane size overflow"))?;
+                let alpha_plane_len =
+                    alpha_row_bytes
+                        .checked_mul(height as usize)
+                        .ok_or_else(|| {
+                            LazyImageError::encode_failed("avif", "Alpha plane size overflow")
+                        })?;
                 debug_assert!(alpha_row_bytes >= width as usize);
                 for y in 0..height as usize {
                     for x in 0..width as usize {

--- a/src/engine/io.rs
+++ b/src/engine/io.rs
@@ -699,6 +699,13 @@ fn extract_icc_from_avif_safe(data: &[u8]) -> Option<Vec<u8>> {
     }
 
     std::panic::catch_unwind(|| unsafe {
+        // SAFETY:
+        // - `decoder` is created by `avifDecoderCreate` and released by `AvifDecoderGuard`.
+        // - `avifDecoderSetIOMemory` borrows `data` for the duration of this call only, and
+        //   `data` lives for the entire function.
+        // - After `avifDecoderParse` returns `AVIF_RESULT_OK`, libavif guarantees that
+        //   `decoder.image` and its ICC fields point to initialized memory owned by the decoder
+        //   until the decoder is destroyed.
         // Create decoder
         let decoder = avifDecoderCreate();
         if decoder.is_null() {

--- a/streaming/pipeline.d.ts
+++ b/streaming/pipeline.d.ts
@@ -1,0 +1,26 @@
+import type { OutputFormat, ProcessingMetrics, ResizeFit } from "../index";
+
+export interface StreamingOperation {
+  op: "resize" | "rotate" | "flipH" | "flipV" | "grayscale" | "autoOrient";
+  width?: number;
+  height?: number;
+  fit?: ResizeFit;
+  degrees?: number;
+  enabled?: boolean;
+}
+
+export interface CreateStreamingPipelineOptions {
+  format?: OutputFormat;
+  quality?: number;
+  ops?: StreamingOperation[];
+  ImageEngine?: typeof import("../index").ImageEngine;
+  onMetrics?: (metrics: ProcessingMetrics) => void;
+  onCleanupError?: (err: Error, target: string) => void;
+}
+
+export declare function createStreamingPipeline(
+  options?: CreateStreamingPipelineOptions
+): {
+  writable: NodeJS.WritableStream;
+  readable: NodeJS.ReadableStream;
+};

--- a/test/integration/streaming.test.js
+++ b/test/integration/streaming.test.js
@@ -37,6 +37,7 @@ async function run() {
     await test_large_file_resize();
     await test_metrics_callback();
     await test_error_propagation();
+    await test_async_process_error_propagation();
     await test_multiple_ops();
     await test_png_output();
     await test_avif_output();
@@ -172,6 +173,39 @@ async function test_multiple_ops() {
     assert(meta.format === 'jpeg', 'format should be jpeg');
 
     console.log('✅ streaming multiple ops passed');
+}
+
+async function test_async_process_error_propagation() {
+    class FailingEngine {
+        static fromPath() {
+            return new FailingEngine();
+        }
+
+        async toFile() {
+            throw new Error('encode exploded after finish');
+        }
+    }
+
+    const { writable, readable } = createStreamingPipeline({
+        format: 'jpeg',
+        ImageEngine: FailingEngine,
+    });
+
+    writable.end(Buffer.from('not-an-image-but-engine-is-mocked'));
+
+    let capturedError = null;
+    try {
+        for await (const _chunk of readable) {
+            // should not reach
+        }
+    } catch (error) {
+        capturedError = error;
+    }
+
+    assert(capturedError, 'async process failure should reach readable');
+    assert.match(capturedError.message, /encode exploded after finish/);
+
+    console.log('✅ streaming async process error propagation passed');
 }
 
 async function test_png_output() {

--- a/test/type-safety/typescript-typecheck.test.ts
+++ b/test/type-safety/typescript-typecheck.test.ts
@@ -11,6 +11,7 @@ import {
     PresetResult,
     ResizeFit,
 } from '../../index';
+import { createStreamingPipeline } from '../../streaming/pipeline';
 
 async function testTypeSafety() {
     const imagePath = path.resolve(__dirname, '../fixtures/test_input.jpg');
@@ -78,6 +79,12 @@ async function testTypeSafety() {
     );
     
     console.log(`Batch processing: ${batchResults.length} results`);
+
+    const streamingPipeline = createStreamingPipeline({
+        format: 'webp',
+        ops: [{ op: 'resize', width: 128, fit: 'inside' }],
+    });
+    streamingPipeline.readable.resume();
     
     // @ts-expect-error invalid format must fail at compile time
     await ImageEngine.fromPath(imagePath).toBuffer('invalid_format', 80);


### PR DESCRIPTION
## Summary

- `test/type-safety/runtime-type-safety.test.js` の失敗時に `process.exit(1)` で非ゼロ終了するよう修正
- `scripts/postbuild-fixup.js` の置換処理を `replaceAll()` に変更し、型定義パッチの全件置換を保証

## Root Cause

- type-safety 実行スクリプトが rejection を `console.error` するだけで終了コードを返しておらず、CI が失敗を検知できなかった
- postbuild の型定義補正が `String.prototype.replace()` 依存で、同じパターンが複数回出ると最初の 1 件しか置換されなかった

## Validation

- `npm run build`
- `npm run test:js:type-safety`
- `npm run test:types`

Closes #561
Closes #562