### PR TITLE
chore: sync v0.14.0 release back to develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.14.0] - 2026-05-10
+
+### Added
+- **TypeScript guide**: added `docs/TYPESCRIPT.md` with CommonJS, ESM, and type-safety usage patterns.
+- **Runnable JavaScript examples**: added example scripts and an examples README for common lazy-image workflows.
+- **Project governance metadata**: added CODEOWNERS, funding metadata, editor configuration, Cargo package metadata, and a Contributor Covenant code of conduct.
+
+### Changed
+- **Engine internals**: split validation, metadata, resize, and task logic into smaller modules while preserving the public API.
+- **Preset model**: replaced preset format strings with a typed `PresetFormat` enum and a data-driven preset table.
+- **Metadata helpers**: deduplicated ICC and EXIF extraction/embedding paths behind shared traits.
+- **Test organization**: moved large error and PNG helper coverage into focused test modules/utilities.
+- **Documentation**: refreshed README architecture/MSRV details and removed stale ICC version wording.
+- **CI**: added Rust dependency caching and pinned the fuzzing nightly toolchain.
+
+### Fixed
+- Removed a stale test import introduced during branch synchronization.
+- Documented the current cargo audit exceptions so unresolved upstream advisories are explicit instead of hidden.
+
+---
+
 ## [0.13.0] - 2026-04-02
 
 ### Added
@@ -451,7 +472,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[Unreleased]: https://github.com/albert-einshutoin/lazy-image/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/albert-einshutoin/lazy-image/compare/v0.14.0...HEAD
+[0.14.0]: https://github.com/albert-einshutoin/lazy-image/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/albert-einshutoin/lazy-image/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/albert-einshutoin/lazy-image/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/albert-einshutoin/lazy-image/compare/v0.10.2...v0.11.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "lazy-image"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "bitflags",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lazy-image"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "Web image optimization engine - smaller outputs than sharp, powered by Rust + mozjpeg"
 license = "MIT"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,9 +4,9 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 0.14.x  | :white_check_mark: |
 | 0.13.x  | :white_check_mark: |
-| 0.12.x  | :white_check_mark: |
-| < 0.12  | :x:                |
+| < 0.13  | :x:                |
 
 ## Reporting a Vulnerability
 
@@ -60,7 +60,7 @@ lazy-image implements several security measures to protect against common vulner
   - Critical/High: security patch release within 14 days of confirmation.
   - Medium: patch in the next scheduled minor/patch release (target ≤ 30 days).
   - Low: fixed opportunistically in a regular release.
-- **Backports**: Security fixes are backported to all supported lines (0.13.x and 0.12.x). Unsupported versions (<0.12) are not patched; users must upgrade.
+- **Backports**: Security fixes are backported to all supported lines (0.14.x and 0.13.x). Unsupported versions (<0.13) are not patched; users must upgrade.
 - **Disclosure**: Public disclosure occurs after a fix is released and packages are available. If coordinated disclosure is requested, we honor reasonable embargoes up to 90 days.
 - **Credit**: We credit reporters in the advisory unless anonymity is requested.
 

--- a/index.js
+++ b/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-android-arm64')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-android-arm-eabi')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-win32-x64-gnu')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-win32-x64-msvc')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-win32-ia32-msvc')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-win32-arm64-msvc')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@alberteinshutoin/lazy-image-darwin-universal')
       const bindingPackageVersion = require('@alberteinshutoin/lazy-image-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-darwin-x64')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-darwin-arm64')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-freebsd-x64')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-freebsd-arm64')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-x64-musl')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-x64-gnu')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-arm64-musl')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-arm64-gnu')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-arm-musleabihf')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-loong64-musl')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-loong64-gnu')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-riscv64-musl')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-riscv64-gnu')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-linux-ppc64-gnu')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-linux-s390x-gnu')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-openharmony-arm64')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-openharmony-x64')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-openharmony-arm')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alberteinshutoin/lazy-image",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@alberteinshutoin/lazy-image",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^3.5.1",
@@ -19,17 +19,17 @@
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "@alberteinshutoin/lazy-image-darwin-arm64": "0.13.0",
-        "@alberteinshutoin/lazy-image-darwin-x64": "0.13.0",
-        "@alberteinshutoin/lazy-image-linux-arm64-gnu": "0.13.0",
-        "@alberteinshutoin/lazy-image-linux-x64-gnu": "0.13.0",
-        "@alberteinshutoin/lazy-image-linux-x64-musl": "0.13.0",
-        "@alberteinshutoin/lazy-image-win32-x64-msvc": "0.13.0"
+        "@alberteinshutoin/lazy-image-darwin-arm64": "0.14.0",
+        "@alberteinshutoin/lazy-image-darwin-x64": "0.14.0",
+        "@alberteinshutoin/lazy-image-linux-arm64-gnu": "0.14.0",
+        "@alberteinshutoin/lazy-image-linux-x64-gnu": "0.14.0",
+        "@alberteinshutoin/lazy-image-linux-x64-musl": "0.14.0",
+        "@alberteinshutoin/lazy-image-win32-x64-msvc": "0.14.0"
       }
     },
     "node_modules/@alberteinshutoin/lazy-image-darwin-arm64": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-darwin-arm64/-/lazy-image-darwin-arm64-0.13.0.tgz",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-darwin-arm64/-/lazy-image-darwin-arm64-0.14.0.tgz",
       "cpu": [
         "arm64"
       ],
@@ -43,8 +43,8 @@
       }
     },
     "node_modules/@alberteinshutoin/lazy-image-darwin-x64": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-darwin-x64/-/lazy-image-darwin-x64-0.13.0.tgz",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-darwin-x64/-/lazy-image-darwin-x64-0.14.0.tgz",
       "cpu": [
         "x64"
       ],
@@ -58,8 +58,8 @@
       }
     },
     "node_modules/@alberteinshutoin/lazy-image-linux-arm64-gnu": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-linux-arm64-gnu/-/lazy-image-linux-arm64-gnu-0.13.0.tgz",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-linux-arm64-gnu/-/lazy-image-linux-arm64-gnu-0.14.0.tgz",
       "cpu": [
         "arm64"
       ],
@@ -73,8 +73,8 @@
       }
     },
     "node_modules/@alberteinshutoin/lazy-image-linux-x64-gnu": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-linux-x64-gnu/-/lazy-image-linux-x64-gnu-0.13.0.tgz",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-linux-x64-gnu/-/lazy-image-linux-x64-gnu-0.14.0.tgz",
       "cpu": [
         "x64"
       ],
@@ -88,8 +88,8 @@
       }
     },
     "node_modules/@alberteinshutoin/lazy-image-linux-x64-musl": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-linux-x64-musl/-/lazy-image-linux-x64-musl-0.13.0.tgz",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-linux-x64-musl/-/lazy-image-linux-x64-musl-0.14.0.tgz",
       "cpu": [
         "x64"
       ],
@@ -103,8 +103,8 @@
       }
     },
     "node_modules/@alberteinshutoin/lazy-image-win32-x64-msvc": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-win32-x64-msvc/-/lazy-image-win32-x64-msvc-0.13.0.tgz",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-win32-x64-msvc/-/lazy-image-win32-x64-msvc-0.14.0.tgz",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alberteinshutoin/lazy-image",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Web image optimization engine for Node.js - smaller files than sharp, powered by Rust + mozjpeg",
   "main": "index.js",
   "exports": {
@@ -81,12 +81,12 @@
     ]
   },
   "optionalDependencies": {
-    "@alberteinshutoin/lazy-image-darwin-arm64": "0.13.0",
-    "@alberteinshutoin/lazy-image-darwin-x64": "0.13.0",
-    "@alberteinshutoin/lazy-image-linux-x64-gnu": "0.13.0",
-    "@alberteinshutoin/lazy-image-linux-x64-musl": "0.13.0",
-    "@alberteinshutoin/lazy-image-linux-arm64-gnu": "0.13.0",
-    "@alberteinshutoin/lazy-image-win32-x64-msvc": "0.13.0"
+    "@alberteinshutoin/lazy-image-darwin-arm64": "0.14.0",
+    "@alberteinshutoin/lazy-image-darwin-x64": "0.14.0",
+    "@alberteinshutoin/lazy-image-linux-x64-gnu": "0.14.0",
+    "@alberteinshutoin/lazy-image-linux-x64-musl": "0.14.0",
+    "@alberteinshutoin/lazy-image-linux-arm64-gnu": "0.14.0",
+    "@alberteinshutoin/lazy-image-win32-x64-msvc": "0.14.0"
   },
   "engines": {
     "node": ">= 18"


### PR DESCRIPTION
## Summary
- merge the v0.14.0 release state from main back into develop
- keep main and develop aligned after tagging v0.14.0

## Notes
- v0.14.0 tag has already been pushed on the main merge commit.
- No source changes beyond the main release state are introduced by this sync branch.