### PR TITLE
[codex] fix high-priority reliability issues

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -577,6 +577,7 @@ export declare function createStreamingPipeline(options: {
   }>
   ImageEngine?: typeof ImageEngine
   onMetrics?: (metrics: ProcessingMetrics) => void
+  onCleanupError?: (err: Error, target: string) => void
 }): {
   writable: NodeJS.WritableStream
   readable: NodeJS.ReadableStream

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "test": "npm run test:js && npm run test:rust",
     "test:js": "npm run test:js:specs && npm run test:js:type-safety && npm run test:pack-contract && npm run test:types",
     "test:js:specs": "node test/integration/run.js",
-    "test:js:type-safety": "node test/type-safety/runtime-type-safety.test.js",
+    "test:js:type-safety": "node test/type-safety/runtime-type-safety-exit.test.js && node test/type-safety/runtime-type-safety.test.js",
     "test:pack-contract": "node scripts/verify-pack.js",
     "test:types": "tsc --noEmit",
     "test:bench": "npm run test:bench:compare && npm run test:bench:verify && npm run test:bench:smoke",

--- a/scripts/postbuild-fixup.js
+++ b/scripts/postbuild-fixup.js
@@ -65,6 +65,7 @@ export declare function createStreamingPipeline(options: {
   }>
   ImageEngine?: typeof ImageEngine
   onMetrics?: (metrics: ProcessingMetrics) => void
+  onCleanupError?: (err: Error, target: string) => void
 }): {
   writable: NodeJS.WritableStream
   readable: NodeJS.ReadableStream

--- a/src/engine/pool.rs
+++ b/src/engine/pool.rs
@@ -25,6 +25,8 @@
 
 #[cfg(feature = "napi")]
 use crate::engine::memory;
+#[cfg(feature = "napi")]
+use crate::error::LazyImageError;
 #[cfg(all(test, feature = "napi"))]
 use parking_lot::RwLock;
 #[cfg(feature = "napi")]
@@ -47,18 +49,21 @@ const MIN_RAYON_THREADS: usize = 1;
 // Production: Use OnceLock directly for lock-free access after initialization
 // Test: Keep RwLock variant for shutdown_global_pool() functionality
 #[cfg(all(not(test), feature = "napi"))]
-pub(crate) static GLOBAL_THREAD_POOL: OnceLock<Arc<ThreadPool>> = OnceLock::new();
+pub(crate) static GLOBAL_THREAD_POOL: OnceLock<std::result::Result<Arc<ThreadPool>, String>> =
+    OnceLock::new();
 
 #[cfg(all(test, feature = "napi"))]
-pub(crate) static GLOBAL_THREAD_POOL: OnceLock<RwLock<Option<Arc<ThreadPool>>>> = OnceLock::new();
+pub(crate) static GLOBAL_THREAD_POOL: OnceLock<
+    RwLock<Option<std::result::Result<Arc<ThreadPool>, String>>>,
+> = OnceLock::new();
 
 #[cfg(all(test, feature = "napi"))]
-fn pool_cell() -> &'static RwLock<Option<Arc<ThreadPool>>> {
+fn pool_cell() -> &'static RwLock<Option<std::result::Result<Arc<ThreadPool>, String>>> {
     GLOBAL_THREAD_POOL.get_or_init(|| RwLock::new(None))
 }
 
 #[cfg(feature = "napi")]
-fn build_pool() -> Arc<ThreadPool> {
+fn build_pool() -> std::result::Result<Arc<ThreadPool>, String> {
     let detected_parallelism = std::thread::available_parallelism()
         .map(|n| n.get())
         .unwrap_or(MIN_RAYON_THREADS);
@@ -68,47 +73,67 @@ fn build_pool() -> Arc<ThreadPool> {
         .saturating_sub(uv_reserve)
         .max(MIN_RAYON_THREADS);
 
-    Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_threads)
+    match rayon::ThreadPoolBuilder::new()
+        .num_threads(num_threads)
+        .build()
+    {
+        Ok(pool) => Ok(Arc::new(pool)),
+        Err(primary_err) => rayon::ThreadPoolBuilder::new()
+            .num_threads(MIN_RAYON_THREADS)
             .build()
-            .unwrap_or_else(|e| {
-                // Fallback: create a minimal thread pool if the preferred configuration fails
-                rayon::ThreadPoolBuilder::new()
-                    .num_threads(MIN_RAYON_THREADS)
-                    .build()
-                    .expect(&format!(
-                        "Failed to create fallback thread pool with {} threads: {}",
-                        MIN_RAYON_THREADS, e
-                    ))
+            .map(Arc::new)
+            .map_err(|fallback_err| {
+                format!(
+                    "preferred pool ({num_threads} threads) failed: {primary_err}; \
+                     fallback pool ({MIN_RAYON_THREADS} thread) failed: {fallback_err}"
+                )
             }),
-    )
+    }
+}
+
+#[cfg(feature = "napi")]
+fn pool_init_error(message: &str) -> LazyImageError {
+    LazyImageError::internal_panic(format!("failed to initialize rayon thread pool: {message}"))
 }
 
 // Production: Lock-free access via OnceLock::get_or_init()
 #[cfg(all(not(test), feature = "napi"))]
-pub fn get_pool() -> Arc<ThreadPool> {
-    Arc::clone(GLOBAL_THREAD_POOL.get_or_init(build_pool))
+pub fn get_pool() -> std::result::Result<Arc<ThreadPool>, LazyImageError> {
+    match GLOBAL_THREAD_POOL.get_or_init(build_pool) {
+        Ok(pool) => Ok(Arc::clone(pool)),
+        Err(message) => Err(pool_init_error(message)),
+    }
 }
 
 // Test: Keep double-check locking for shutdown_global_pool() compatibility
 #[cfg(all(test, feature = "napi"))]
-pub fn get_pool() -> Arc<ThreadPool> {
+pub fn get_pool() -> std::result::Result<Arc<ThreadPool>, LazyImageError> {
     {
         let guard = pool_cell().read();
         if let Some(pool) = guard.as_ref() {
-            return Arc::clone(pool);
+            return pool
+                .as_ref()
+                .map(Arc::clone)
+                .map_err(|message| pool_init_error(message));
         }
     }
 
     let mut guard = pool_cell().write();
     if let Some(pool) = guard.as_ref() {
-        return Arc::clone(pool);
+        return pool
+            .as_ref()
+            .map(Arc::clone)
+            .map_err(|message| pool_init_error(message));
     }
 
     let pool = build_pool();
-    *guard = Some(Arc::clone(&pool));
-    pool
+    *guard = Some(pool);
+    guard
+        .as_ref()
+        .expect("pool cell was initialized")
+        .as_ref()
+        .map(Arc::clone)
+        .map_err(|message| pool_init_error(message))
 }
 
 /// Explicitly drop the global thread pool so it can be re-created.
@@ -124,7 +149,7 @@ pub(crate) fn shutdown_global_pool() {
 /// Useful for scenarios where environment variables (like UV_THREADPOOL_SIZE)
 /// change at runtime and need to be respected by a fresh pool instance.
 #[cfg(all(test, feature = "napi"))]
-pub(crate) fn reinitialize_global_pool() -> Arc<ThreadPool> {
+pub(crate) fn reinitialize_global_pool() -> std::result::Result<Arc<ThreadPool>, LazyImageError> {
     shutdown_global_pool();
     get_pool()
 }
@@ -233,12 +258,12 @@ mod tests {
     fn pool_reinitializes_with_new_uv_reservation() {
         let guard = EnvGuard::set("UV_THREADPOOL_SIZE", "8");
 
-        let pool = reinitialize_global_pool();
+        let pool = reinitialize_global_pool().expect("pool should initialize");
         let expected = expected_threads(8);
         assert_eq!(thread_count(&pool), expected);
 
         drop(guard);
-        let pool_after_reset = reinitialize_global_pool();
+        let pool_after_reset = reinitialize_global_pool().expect("pool should reinitialize");
         let expected_default = expected_threads(DEFAULT_LIBUV_THREADPOOL_SIZE);
         assert_eq!(thread_count(&pool_after_reset), expected_default);
     }
@@ -251,7 +276,7 @@ mod tests {
     #[test]
     fn pool_handles_real_workloads_and_stays_usable() {
         shutdown_global_pool();
-        let pool = get_pool();
+        let pool = get_pool().expect("pool should initialize");
         let images = make_workload();
 
         let resized: Vec<Vec<u8>> = pool.install(|| {

--- a/src/engine/tasks.rs
+++ b/src/engine/tasks.rs
@@ -1166,8 +1166,16 @@ impl Task for BatchTask {
         // When effective_concurrency < inputs.len(), run exactly that many worker
         // tasks on the global pool and pull work dynamically via an atomic index.
         // This preserves the concurrency cap while avoiding chunk-induced tail latency.
+        let pool = match pool::get_pool() {
+            Ok(pool) => pool,
+            Err(err) => {
+                self.last_error = Some(err.clone());
+                return Err(napi::Error::from(err));
+            }
+        };
+
         let results: Vec<BatchResult> = if effective_concurrency >= self.inputs.len() {
-            pool::get_pool().install(|| self.inputs.par_iter().map(process_one).collect())
+            pool.install(|| self.inputs.par_iter().map(process_one).collect())
         } else {
             use std::sync::atomic::{AtomicUsize, Ordering};
             use std::sync::{Arc, Mutex};
@@ -1177,7 +1185,7 @@ impl Task for BatchTask {
                 self.inputs.len(),
             )));
 
-            pool::get_pool().install(|| {
+            pool.install(|| {
                 rayon::scope(|scope| {
                     for _ in 0..effective_concurrency {
                         let next_index = Arc::clone(&next_index);
@@ -1310,9 +1318,17 @@ impl Task for BatchWithMetricsTask {
             }
         };
 
+        let pool = match pool::get_pool() {
+            Ok(pool) => pool,
+            Err(err) => {
+                self.last_error = Some(err.clone());
+                return Err(napi::Error::from(err));
+            }
+        };
+
         let items: Vec<crate::BatchResultWithMetrics> =
             if effective_concurrency >= self.inputs.len() {
-                pool::get_pool().install(|| self.inputs.par_iter().map(process_one).collect())
+                pool.install(|| self.inputs.par_iter().map(process_one).collect())
             } else {
                 use std::sync::atomic::{AtomicUsize, Ordering};
                 use std::sync::{Arc, Mutex};
@@ -1321,7 +1337,7 @@ impl Task for BatchWithMetricsTask {
                 let out = Arc::new(Mutex::new(Vec::with_capacity(self.inputs.len())));
                 let next = AtomicUsize::new(0);
 
-                pool::get_pool().install(|| {
+                pool.install(|| {
                     rayon::scope(|s| {
                         for _ in 0..effective_concurrency {
                             let inputs = Arc::clone(&inputs);

--- a/streaming/pipeline.js
+++ b/streaming/pipeline.js
@@ -18,7 +18,14 @@ const { PassThrough } = require('stream');
  * - ops: array of operations (same schema as core API)
  */
 function createStreamingPipeline(options) {
-    const { format = 'jpeg', quality, ops = [], ImageEngine, onMetrics } = options ?? {};
+    const {
+        format = 'jpeg',
+        quality,
+        ops = [],
+        ImageEngine,
+        onMetrics,
+        onCleanupError,
+    } = options ?? {};
     const Engine = ImageEngine || require('../index').ImageEngine;
     if (!Engine) {
         throw new Error('ImageEngine must be provided to createStreamingPipeline');
@@ -31,7 +38,7 @@ function createStreamingPipeline(options) {
     const writable = fs.createWriteStream(inputPath);
     const readable = new PassThrough();
 
-    async function process() {
+    async function processImage() {
         try {
             let engine = Engine.fromPath(inputPath);
             for (const op of ops) {
@@ -85,13 +92,29 @@ function createStreamingPipeline(options) {
     function cleanup() {
         if (cleaned) return;
         cleaned = true;
-        fs.rm(inputPath, { force: true }, () => {});
-        fs.rm(outputPath, { force: true }, () => {});
-        fs.rm(tempBase, { force: true, recursive: true }, () => {});
+        const reportCleanupError = (target) => (err) => {
+            if (!err) return;
+            if (typeof onCleanupError === 'function') {
+                onCleanupError(err, target);
+                return;
+            }
+            // Cleanup failures should not mask the image processing result, but
+            // they should be visible during operation and tests.
+            process.emitWarning(err, {
+                code: 'LAZY_IMAGE_STREAM_CLEANUP_FAILED',
+            });
+        };
+
+        fs.rm(inputPath, { force: true }, reportCleanupError(inputPath));
+        fs.rm(outputPath, { force: true }, reportCleanupError(outputPath));
+        fs.rm(tempBase, { force: true, recursive: true }, reportCleanupError(tempBase));
     }
 
     writable.on('finish', () => {
-        process();
+        processImage().catch((err) => {
+            readable.destroy(err);
+            cleanup();
+        });
     });
     writable.on('error', (err) => {
         readable.destroy(err);

--- a/test/integration/format-matrix.test.js
+++ b/test/integration/format-matrix.test.js
@@ -76,6 +76,7 @@ async function runTests() {
     console.log('=== Format Conversion Matrix Tests ===\n');
 
     const { jpegBuf, pngBuf, webpBuf } = await generateFixtures();
+    const avifPath = resolveFixture('test_92kb_input.avif');
 
     // --- Format conversion matrix -------------------------------------------
     // Each entry: [label, sourceBuf, targetFormat, quality]
@@ -121,6 +122,19 @@ async function runTests() {
             }
         });
     }
+
+    await asyncTest('format: AVIF input fails with a decode error until AVIF decode is supported', async () => {
+        await assert.rejects(
+            ImageEngine.fromPath(avifPath).resize(100).toBuffer('jpeg', 80),
+            (err) => {
+                assert(
+                    err.message.includes('[E131]') || err.message.includes('Failed to decode image'),
+                    `unexpected error for unsupported AVIF input: ${err.message}`,
+                );
+                return true;
+            },
+        );
+    });
 
     // --- Resize fit mode tests ----------------------------------------------
 

--- a/test/integration/streaming.test.js
+++ b/test/integration/streaming.test.js
@@ -42,6 +42,7 @@ async function run() {
     await test_avif_output();
     await test_destroy_mid_stream();
     await test_empty_input();
+    await test_cleanup_error_reporting();
 }
 
 async function test_basic_resize() {
@@ -293,6 +294,41 @@ async function test_empty_input() {
     );
 
     console.log('✅ streaming empty input error passed');
+}
+
+async function test_cleanup_error_reporting() {
+    const originalRm = fs.rm;
+    const cleanupErrors = [];
+    fs.rm = function patchedRm(target, options, callback) {
+        const cb = typeof options === 'function' ? options : callback;
+        process.nextTick(() => cb(new Error(`forced cleanup failure: ${target}`)));
+    };
+
+    try {
+        const { writable, readable } = createStreamingPipeline({
+            format: 'jpeg',
+            quality: 80,
+            onCleanupError(err) {
+                cleanupErrors.push(err);
+            },
+        });
+
+        writable.end(Buffer.from([0, 1, 2, 3]));
+
+        await new Promise((resolve) => {
+            readable.on('error', resolve);
+            readable.resume();
+        });
+    } finally {
+        fs.rm = originalRm;
+    }
+
+    assert(
+        cleanupErrors.length > 0,
+        'cleanup failures should be reported instead of silently swallowed',
+    );
+
+    console.log('✅ streaming cleanup error reporting passed');
 }
 
 run().catch((err) => {

--- a/test/integration/type-improvements.test.js
+++ b/test/integration/type-improvements.test.js
@@ -31,7 +31,7 @@ async function testTypeImprovements() {
     console.log('  The zero-copy conversion now provides contextual error messages:');
     console.log('  - "pixel count overflow: X * 3 (image too large for zero-copy conversion)"');
     console.log('  - "capacity overflow: X * 3 (memory allocation too large for zero-copy conversion)"');
-    console.log('  - "Failed to create fallback thread pool with 1 threads: ..."');
+    console.log('  - "failed to initialize rayon thread pool: preferred pool (...) failed: ..."');
     
     console.log('\n📋 Type Safety Improvements Summary:');
     console.log('1. ✅ ImageMetadata.format: canonical input format | undefined');

--- a/test/type-safety/runtime-type-safety-exit.test.js
+++ b/test/type-safety/runtime-type-safety-exit.test.js
@@ -1,0 +1,28 @@
+/**
+ * Verifies that the runtime type-safety test exits non-zero on unexpected
+ * rejection so CI catches regressions.
+ */
+
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+const { resolveRoot } = require('../helpers/paths');
+
+const result = spawnSync(
+    process.execPath,
+    [resolveRoot('test/type-safety/runtime-type-safety.test.js')],
+    {
+        env: {
+            ...process.env,
+            LAZY_IMAGE_FORCE_RUNTIME_TYPE_SAFETY_FAILURE: '1',
+        },
+        encoding: 'utf8',
+    },
+);
+
+assert.notStrictEqual(
+    result.status,
+    0,
+    `forced runtime type-safety failure should exit non-zero; stdout=${result.stdout} stderr=${result.stderr}`,
+);
+
+console.log('runtime-type-safety-exit.test.js passed');

--- a/test/type-safety/runtime-type-safety.test.js
+++ b/test/type-safety/runtime-type-safety.test.js
@@ -6,6 +6,10 @@ const { resolveFixture, resolveRoot } = require('../helpers/paths');
 const { ImageEngine } = require(resolveRoot('index'));
 
 async function testTypeSafetyInPractice() {
+    if (process.env.LAZY_IMAGE_FORCE_RUNTIME_TYPE_SAFETY_FAILURE === '1') {
+        throw new Error('forced runtime type-safety failure');
+    }
+
     console.log('🔒 Type Safety Verification Test');
     console.log('=================================\n');
     
@@ -83,5 +87,10 @@ async function testTypeSafetyInPractice() {
 }
 
 if (require.main === module) {
-    testTypeSafetyInPractice().catch(console.error);
+    testTypeSafetyInPractice().catch((err) => {
+        console.error(err);
+        process.exit(1);
+    });
 }
+
+module.exports = { testTypeSafetyInPractice };


### PR DESCRIPTION
## Summary

Implements the high-priority issue sequence requested from `develop`:

- Closes #475: strengthen format matrix coverage by explicitly covering current AVIF input behavior, while preserving existing JPEG/PNG/WebP -> JPEG/PNG/WebP/AVIF coverage, `fit: fill`, and `normalizePixelFormat()` tests
- Closes #561: make runtime type-safety test failures exit non-zero, with a regression test that forces an unexpected rejection
- Closes #560: make Rayon pool initialization fallible and propagate initialization failure as `LazyImageError` instead of panicking from fallback `expect()`
- Closes #540: harden streaming pipeline async error handling and report cleanup failures via `onCleanupError` / warning instead of silently swallowing them

## Notes

AVIF decode is still unsupported in the native binding, so this PR does not pretend to add AVIF input support. It adds explicit regression coverage that AVIF input currently fails with a structured decode error until a real AVIF decoder is added.

## Validation

- `npm run build`
- `npm test`
