### PR TITLE
docs: align zero-copy and serverless claims with native implementation (#589)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -6,7 +6,7 @@
 - Web 向け画像最適化に特化した意図的なエンジン
 - まだ sharp のドロップイン代替ではありません（互換 API が必要なら sharp を使用）
 - セキュリティ優先: 全メタデータ（EXIF/XMP/ICC）をデフォルトで削除。`keepMetadata()` で保持可能
-- ゼロコピー入力パス: `fromPath()/processBatch()` → `toFile()` で入力ファイルを JS ヒープへコピーしない
+- V8 ヒープを経由しない入力パス: `fromPath()/processBatch()` → `toFile()` で入力ファイルを JS ヒープへコピーしない（256 MB 以下は Rust 所有バッファに読み込み、256 MB 超は advisory lock 付き mmap）
 - AVIF の ICC は v0.9.x（libavif-sys）で保持。<0.9.0 や ravif のみ構成では破棄
 - `lazy` の意味: [docs/LAZY_SEMANTICS.md](./docs/LAZY_SEMANTICS.md) を参照（constructor は無作業ではない）
 - 思想と非目標: [docs/PROJECT_PHILOSOPHY.md](./docs/PROJECT_PHILOSOPHY.md)

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 lazy-image reduces image file sizes by 20-30% compared to sharp in its target web-delivery scenarios, trading encoding speed for smaller outputs. Ideal for CDN-heavy workloads where bandwidth costs matter more than CPU costs.
 
 - **Not** a drop-in replacement for sharp — use sharp if you need its full API or maximum throughput.
-- **Security-first**: Metadata stripped by default; `keepMetadata()` to preserve. Zero-copy path: `fromPath()`/`processBatch()` → `toFile()`.
-- Japanese: [README.ja.md](./README.ja.md). **mmap**: Do not modify/delete source files while processing; use a copy or `from(Buffer)` for mutable inputs.
+- **Security-first**: Metadata stripped by default; `keepMetadata()` to preserve. File-path inputs (`fromPath()`/`processBatch()` → `toFile()`) bypass the V8 heap — small/medium files (≤ 256 MB) are read into Rust-owned memory for SIGBUS safety; only files larger than 256 MB use mmap with advisory locks. See [docs/ZERO_COPY.md](./docs/ZERO_COPY.md).
+- Japanese: [README.ja.md](./README.ja.md). **mmap (files > 256 MB)**: do not modify or delete source files while processing; use a copy or `from(Buffer)` for mutable inputs.
 - Lazy contract: [docs/LAZY_SEMANTICS.md](./docs/LAZY_SEMANTICS.md) explains what is deferred vs eager.
 - Metadata matrix: [docs/METADATA_SUPPORT.md](./docs/METADATA_SUPPORT.md).
 - Philosophy and non-goals: [docs/PROJECT_PHILOSOPHY.md](./docs/PROJECT_PHILOSOPHY.md).
@@ -58,7 +58,7 @@ lib/helpers.js              # Encoding profiles, target-bytes binary search
 streaming/pipeline.js       # Disk-backed bounded-memory streaming
 ```
 
-**Key design decisions:** lazy execution (ops queue until output), zero-copy file I/O via mmap, memory-bounded concurrency via weighted semaphore, panic guards on all codec entry points. See [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) for details.
+**Key design decisions:** lazy execution (ops queue until output), file-path inputs bypass the V8 heap (read-into-memory for ≤ 256 MB, mmap with advisory locks for > 256 MB), memory-bounded concurrency via weighted semaphore, panic guards on all codec entry points. See [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) for details.
 
 ---
 
@@ -74,7 +74,7 @@ streaming/pipeline.js       # Disk-backed bounded-memory streaming
 **Key differentiators:**
 
 1. **File size optimization** — mozjpeg + libwebp + ravif produce 20-30% smaller outputs than sharp's defaults
-2. **Memory efficiency** — zero-copy mmap architecture; no pixel data copied to the JS heap
+2. **Memory efficiency** — file-path inputs are not copied into the V8 heap; decoded pixels stay in Rust memory
 3. **Security-first** — GPS auto-strip, Image Firewall, Rust memory safety
 4. **AVIF excellence** — ravif encoder with quality-optimized defaults
 
@@ -192,7 +192,7 @@ More: batch processing, presets, metrics, streaming — [docs/API.md](./docs/API
 
 ## Features (summary)
 
-Smaller JPEG (mozjpeg) · Smaller WebP (libwebp) · AVIF (ravif) · ICC profiles · EXIF auto-orient · Zero-copy file I/O · Disk-backed bounded-memory pipeline (`createStreamingPipeline()`, not true chunked transform streaming) · Image Firewall · GPS auto-strip · Fluent API · Rust core (NAPI-RS) · Cross-platform (macOS, Windows, Linux). Design choices and limits: [docs/ROADMAP.md](./docs/ROADMAP.md) and [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md).
+Smaller JPEG (mozjpeg) · Smaller WebP (libwebp) · AVIF (ravif) · ICC profiles · EXIF auto-orient · Bypass-V8-heap file I/O (read-into-memory ≤ 256 MB, mmap > 256 MB) · Disk-backed bounded-memory pipeline (`createStreamingPipeline()`, not true chunked transform streaming) · Image Firewall · GPS auto-strip · Fluent API · Rust core (NAPI-RS) · Cross-platform (macOS, Windows, Linux). Design choices and limits: [docs/ROADMAP.md](./docs/ROADMAP.md) and [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md).
 
 ---
 

--- a/docs/ADOPTION_GUIDE.md
+++ b/docs/ADOPTION_GUIDE.md
@@ -198,9 +198,11 @@ Key sizing guidance:
 
 Same pattern as Lambda. Use `/tmp` for scratch files. For Cloud Run, set `--memory 512Mi` and `--concurrency 1` per container instance if processing large images. lazy-image's internal memory semaphore prevents concurrent operations from exceeding cgroup limits.
 
-### Vercel / Netlify Edge Functions
+### Vercel / Netlify Edge Functions and Cloudflare Workers
 
-These environments run in V8 isolates with strict execution time and memory limits. Use lazy-image only for small images (< 2 MP) in edge functions. For larger images, process in a background serverless function and serve from a CDN.
+These environments run in V8 isolates and **do not support the native NAPI binary** that lazy-image ships. The published `@alberteinshutoin/lazy-image` package requires a Node.js runtime (Vercel Node Functions, Netlify Node Functions, AWS Lambda, Cloud Run, etc.).
+
+For Edge / Workers, process images in a background Node-runtime function and serve the results from a CDN. Wasm support for V8-isolate runtimes is tracked under [#87](https://github.com/albert-einshutoin/lazy-image/issues/87).
 
 ### Cold start optimization
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -7,7 +7,7 @@ Full API reference for lazy-image. For a quick start, see [README.md](../README.
 | Method | Description |
 |--------|-------------|
 | `ImageEngine.from(buffer)` | Create engine from a Buffer (loads into V8 heap). Full pixel decode is deferred, but constructor-time metadata extraction still runs. |
-| `ImageEngine.fromPath(path)` | **Recommended**: Create engine from file path (bypasses V8 heap). Full pixel decode is deferred, but constructor-time file setup and metadata extraction still run. Uses memory mapping for zero-copy access on large files. **Note**: On Windows, memory-mapped files cannot be deleted while mapped. See [TROUBLESHOOTING.md](./TROUBLESHOOTING.md#windows-file-locking). |
+| `ImageEngine.fromPath(path)` | **Recommended**: Create engine from file path (bypasses V8 heap). Full pixel decode is deferred, but constructor-time file setup and metadata extraction still run. Size-tiered: files ≤ 256 MB are read once into a Rust-owned buffer; files > 256 MB are accessed via `mmap` with an advisory lock and a retained fd. **Note**: On Windows, memory-mapped files (the > 256 MB tier) cannot be deleted while mapped. See [TROUBLESHOOTING.md](./TROUBLESHOOTING.md#windows-file-locking) and [ZERO_COPY.md](./ZERO_COPY.md). |
 
 See [LAZY_SEMANTICS.md](./LAZY_SEMANTICS.md) for the exact deferred vs eager contract.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,16 +8,19 @@
 4. **Chroma subsampling** (4:2:0) for web-optimal output
 5. **Adaptive preprocessing** — JPEG: compression optimization; WebP (v0.8.1+): speed optimization
 
-## Memory Management (Zero-Copy Architecture)
+## Memory Management (V8-heap bypass + Copy-on-Write)
 
-lazy-image uses a **Copy-on-Write (CoW)** design:
+lazy-image uses a **Copy-on-Write (CoW)** design and avoids the V8 (JS) heap on the input path:
 
 1. **Deferred pixel decode** — constructors set up the source and extract lightweight metadata, but full decode waits until `toBuffer()`/`toFile()`.
-2. **Zero-copy mmap** — `fromPath()` and `processBatch()` use memory mapping; no copy into the Node.js heap.
+2. **V8-heap bypass for file inputs** — `fromPath()` and `processBatch()` never copy the source file into the Node.js heap. Implementation is size-tiered to eliminate SIGBUS/SIGSEGV risk:
+   - **Files ≤ 256 MB**: read once into a Rust-owned buffer (no mmap).
+   - **Files > 256 MB**: opened via `mmap` with an advisory lock + fd retained for the engine lifetime.
+   The size threshold (`MMAP_SIZE_THRESHOLD`) lives in [`src/engine/io.rs`](../src/engine/io.rs).
 3. **Zero-copy conversions** — Format conversion without resize/crop reuses the decoded buffer (no extra pixel buffer).
 4. **Clone** — `.clone()` is cheap and does not allocate until a destructive op runs.
 5. **Verification** — See [ZERO_COPY.md](./ZERO_COPY.md). Run `node --expose-gc docs/scripts/measure-zero-copy.js` to check heap/RSS.
-6. **Contract** — Do not modify or delete the source file while it is memory-mapped. On Windows, mapped files cannot be deleted until the engine is dropped.
+6. **mmap contract** — For the > 256 MB tier, do not modify or delete the source file while the engine is alive. On Windows, mapped files cannot be deleted until the engine is dropped. Files in the ≤ 256 MB tier are read once and the disk handle is closed, so concurrent mutation does not affect them.
 
 See [LAZY_SEMANTICS.md](./LAZY_SEMANTICS.md) for the exact boundary between eager constructor work and deferred execution.
 

--- a/docs/MIGRATION_FROM_SHARP.md
+++ b/docs/MIGRATION_FROM_SHARP.md
@@ -22,7 +22,7 @@ This keeps existing editing workflows intact while still gaining lazy-image's we
 | sharp | lazy-image | Notes |
 |-------|-----------|-------|
 | `sharp(inputBuffer)` | `ImageEngine.from(buffer)` | Loads from a JS buffer (copies into V8 heap). |
-| `sharp('input.jpg')` | `ImageEngine.fromPath('input.jpg')` | Zero-copy path; recommended for servers. |
+| `sharp('input.jpg')` | `ImageEngine.fromPath('input.jpg')` | Bypasses the V8 heap (≤ 256 MB read into a Rust-owned buffer; > 256 MB mmap with advisory lock). Recommended for servers. |
 | `.resize(800).jpeg({ quality: 80 }).toBuffer()` | `.resize(800).toBuffer('jpeg', 80)` | Default fit is `inside` in both. |
 | `.resize(800, 600, { fit: 'cover' })` | `.resize(800, 600, 'cover').toBuffer('jpeg')` | `cover` crops to fill. |
 | `.extract({ left: 10, top: 20, width: 300, height: 200 })` | `.crop(10, 20, 300, 200)` | Same origin (top-left). |

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -26,10 +26,10 @@ Full data: [TRUE_BENCHMARKS.md](./TRUE_BENCHMARKS.md).
 
 ## When to Use lazy-image
 
-- **Serverless (Lambda, Cloud Run, Vercel, etc.)** — Avoid OOM and smaller cold-start footprint.
+- **Node-runtime serverless (AWS Lambda, Google Cloud Run, Vercel Node Functions, Google Cloud Functions)** — Avoid OOM and smaller cold-start footprint. V8-isolate runtimes such as Cloudflare Workers and Vercel Edge are **not supported** by the native NAPI build (tracked under [#87](https://github.com/albert-einshutoin/lazy-image/issues/87) for future Wasm support).
 - **Bandwidth-sensitive** — Smaller JPEG/AVIF saves CDN and transfer costs.
 - **AVIF generation** — Strong results in the benchmarked PNG → AVIF format-conversion workloads.
-- **Memory-constrained** — 512MB containers; zero-copy path keeps heap low.
+- **Memory-constrained** — 512MB containers; `fromPath()` bypasses the V8 heap (read-into-memory ≤ 256 MB, mmap with advisory locks > 256 MB).
 - **Safety-first** — Rust memory safety; built-in decompression limits and Image Firewall.
 
 ## When to Use sharp
@@ -88,6 +88,8 @@ await ImageEngine.from(buf).resize(800).toBuffer('jpeg', 80);
 
 - No `LD_LIBRARY_PATH` or system libvips.
 - Single static binary (mozjpeg, libwebp; AVIF via `avif` feature).
-- Main npm package ~15 KB + one platform binary.
+- Main npm package ~29 KB tarball / ~107 KB unpacked + one platform binary (run `npm pack --dry-run --json` for the current numbers).
 
-**Ideal for**: AWS Lambda, Vercel Edge, Cloudflare Workers, Google Cloud Functions.
+**Ideal for Node-runtime serverless**: AWS Lambda, Google Cloud Functions, Google Cloud Run, Vercel Node Functions.
+
+**Not supported**: V8-isolate runtimes such as Cloudflare Workers and Vercel Edge. The published native NAPI module requires a Node.js runtime; Wasm support is tracked under [#87](https://github.com/albert-einshutoin/lazy-image/issues/87).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,7 +9,7 @@ This document reflects the current state of `develop` and focuses on the work th
 The following foundations are already in place on `develop`:
 
 - **Lazy, non-destructive pipeline**: deferred decode, `clone()`, file-based happy path
-- **Zero-copy / mmap path**: `fromPath()` and batch-oriented file processing
+- **V8-heap bypass for file inputs**: `fromPath()` and `processBatch()` keep source bytes out of the Node.js heap (read-into-memory ≤ 256 MB, mmap with advisory locks > 256 MB)
 - **Structured errors and operational limits**: typed error taxonomy and Image Firewall
 - **Metadata-safe defaults**: strip by default, GPS strip, opt-in preservation paths
 - **Benchmark and regression tooling**: benchmark docs, regression workflow, zero-copy measurement
@@ -81,7 +81,7 @@ To maintain focus and stability, the following features are explicitly **out of 
 `develop` にはすでに以下の基盤があります。
 
 - **lazy / 非破壊パイプライン**: deferred decode、`clone()`、file-to-file の主導線
-- **zero-copy / mmap 経路**: `fromPath()` とバッチ処理向けファイル経路
+- **V8 ヒープを経由しないファイル入力**: `fromPath()` と `processBatch()` は入力バイトを Node.js ヒープに載せない（256 MB 以下は Rust 所有バッファに読み込み、256 MB 超は advisory lock 付き mmap）
 - **構造化エラーと制限**: typed error taxonomy と Image Firewall
 - **安全なメタデータデフォルト**: デフォルト strip、GPS strip、必要時のみ opt-in
 - **ベンチマーク運用**: benchmark docs、regression workflow、zero-copy 計測

--- a/docs/VERSION_HISTORY.md
+++ b/docs/VERSION_HISTORY.md
@@ -11,8 +11,8 @@
 | v0.8.7 | Telemetry metrics, Smart concurrency with auto memory cap detection, Performance optimizations |
 | v0.8.6 | Version bump to 0.8.6 |
 | v0.8.5 | Fixed CI compilation errors and improved --no-default-features build support |
-| v0.8.4 | Zero-copy memory mapping implementation: fromPath() and processBatch() use mmap for zero-copy file access |
-| v0.8.3 | Documentation: Updated README.md to document zero-copy memory mapping for processBatch() |
+| v0.8.4 | Zero-copy memory mapping implementation: fromPath() and processBatch() use mmap for zero-copy file access. (Later refined to a size-tiered model — see `docs/ZERO_COPY.md` for current behavior: ≤ 256 MB read into a Rust-owned buffer, > 256 MB mmap with advisory lock.) |
+| v0.8.3 | Documentation: Updated README.md to document zero-copy memory mapping for processBatch(). (See v0.8.4 note above for the current size-tiered implementation.) |
 | v0.8.1 | WebP encoding optimization: ~4x speed improvement (method 4, single pass) to match sharp performance |
 | v0.8.0 | Updated benchmark results, improved test suite |
 | v0.7.7 | CI/CD improvements: skip napi prepublish auto-publish, use manual package generation |

--- a/docs/ZERO_COPY.md
+++ b/docs/ZERO_COPY.md
@@ -1,17 +1,22 @@
 # Zero-Copy definition and validation
 
-This document clarifies the **meaning, scope, and measurement** of lazy-image's zero-copy claims.
+This document clarifies the **meaning, scope, and measurement** of lazy-image's "zero-copy" claims.
+
+> "Zero-copy" in lazy-image refers to the **JS-heap boundary**, not the OS page cache. The source file is never staged through V8 heap memory. Whether the file is then accessed via a Rust-owned in-memory buffer or via `mmap` depends on its size — see "Implementation" below.
 
 ## Meaning
 
-- **Zero-copy**: when using `fromPath()` or `processBatch()` to `toFile()/toBuffer()`, the source file is **not copied into the Node.js heap**.
-- Implementation: input files are accessed via **mmap**, read directly by Rust; JS never holds the raw file bytes.
+- **Zero-copy (JS-heap sense)**: when using `fromPath()` or `processBatch()` to `toFile()/toBuffer()`, the source file is **not copied into the Node.js (V8) heap**. JS never holds the raw file bytes.
+- **Implementation** (size-tiered to eliminate SIGBUS/SIGSEGV risk for typical images):
+  - **Files ≤ 256 MB**: read in full into a Rust-owned buffer. No mmap. No V8 heap copy. (`MMAP_SIZE_THRESHOLD` in [`src/engine/io.rs`](../src/engine/io.rs).)
+  - **Files > 256 MB**: opened via `mmap` with an advisory lock and an fd retained for the engine lifetime. Page-cache backed; still no V8 heap copy.
+- In both tiers, decoded pixel buffers live in Rust memory.
 
 ## Scope (where it applies)
 
 Applies:
-- `ImageEngine.fromPath(...)` → any processing → `toFile()/toBuffer()/toBufferWithMetrics()`
-- `processBatch()` (each input handled via mmap)
+- `ImageEngine.fromPath(...)` → any processing → `toFile()/toBuffer()/toBufferWithMetrics()` (no V8-heap copy of the source bytes)
+- `processBatch()` (per-input, same size-tiered model)
 - Rust-side decode/encode (pixel buffers live in Rust memory)
 
 Not applicable / exceptions:
@@ -51,21 +56,25 @@ These numbers are reproducible via the measurement script; open an issue/PR if y
 ## FAQ
 
 - **なぜ JS ヒープを指標にするのか?**  
-  ゼロコピーの主張は「入力を JS ヒープに載せない」ことにあるため、ヒープ増加が事実上の証拠となる。
+  「ゼロコピー」の主張は「入力を V8 (JS) ヒープに載せない」ことを指すため、ヒープ増加が事実上の証拠となる。
 - **出力バッファはコピーになるのでは?**  
   はい。エンコード結果は必ず `Buffer` として生成されるため、出力サイズ分のメモリは必要。ゼロコピーの対象は「入力経路」である。
+- **mmap は常に使われるのか?**  
+  いいえ。SIGBUS/SIGSEGV を避けるため、256 MB 以下のファイルは Rust 側で全読み込みする。256 MB を超えるファイルだけが advisory lock 付きの mmap を使う。`MMAP_SIZE_THRESHOLD` を参照。
 - **ストリーミング API は?**  
   デフォルトはディスクバッファを使うが、入力ストリームを JS で保持する場合はゼロコピーの対象外。ただし内部処理は同じメモリモデルを使う。
 
 ## まとめ
 
-- **ゼロコピー = 入力ファイルを JS ヒープへコピーしない**（mmap で Rust から直接読む）
+- **ゼロコピー = 入力ファイルを V8 ヒープへコピーしない**（256 MB 以下は Rust 所有メモリ、256 MB 超は mmap）
 - **測定式**で上限を示し、`docs/scripts/measure-zero-copy.js` でいつでも再検証できる
 - 適用範囲と例外を明示し、期待値と境界をドキュメント化
 
 ## Behavior when files are modified or deleted during mmap
 
-- **Contract**: Source files must not be modified or deleted while processing is in progress.
+> This section applies only to the > 256 MB mmap tier. Files ≤ 256 MB are read into a Rust-owned buffer up front and are no longer touched on disk after that read completes, so concurrent mutation does not affect them.
+
+- **Contract**: Source files larger than 256 MB must not be modified or deleted while processing is in progress.
 - **Possible outcomes on Linux/macOS**: decode failure, corrupted images, or a fatal `SIGBUS`/`SIGSEGV` if mapped pages become invalid (for example due to truncation).
 - **Possible outcomes on Windows**: deletion typically fails while the mapping is active; concurrent modification can still cause decode failure or corrupted output.
 - **Recommendations**:
@@ -73,7 +82,7 @@ These numbers are reproducible via the measurement script; open an issue/PR if y
   - To prevent concurrent writes on shared storage, use file locking (for example, `flock`-equivalent OS locks).
   - On Windows, keep source files until processing completes, or switch to `from(Buffer)` when immediate deletion is required.
 
-## Additional mmap safety assumptions (fromPath/processBatch)
+## Additional mmap safety assumptions (fromPath/processBatch, > 256 MB tier)
 
 - Files must stay readable for the engine lifetime; permission changes or truncation after mmap are undefined behavior.
 - File size is assumed stable: truncation/extension after mmap may SIGBUS or corrupt output.


### PR DESCRIPTION
## Summary

Brings the user-facing documentation in line with the actual size-tiered file-ingestion model implemented in `src/engine/io.rs` (`MMAP_SIZE_THRESHOLD = 256 MB`), and removes unsupported serverless claims.

- **Zero-copy reframed as V8-heap bypass.** Files ≤ 256 MB are read into a Rust-owned buffer; only files > 256 MB use `mmap` with an advisory lock + retained fd. This eliminates SIGBUS/SIGSEGV risk on typical-size images while still keeping source bytes out of the Node.js heap.
- **Serverless guidance split** into Node-runtime serverless (Lambda, Google Cloud Functions, Cloud Run, Vercel Node Functions) vs V8-isolate runtimes (Cloudflare Workers, Vercel Edge, Netlify Edge). The native NAPI build does not support the latter; Wasm work is tracked under #87.
- **Package size refreshed** from "~15 KB" to "~29 KB tarball / ~107 KB unpacked" (verified via `npm pack --dry-run --json` on v0.14.0), with guidance to re-run the command for future numbers.
- **VERSION_HISTORY** v0.8.3 / v0.8.4 entries are preserved as historical records and annotated with a pointer to the current size-tiered model in `docs/ZERO_COPY.md`.

## Files touched

- `README.md`, `README.ja.md`
- `docs/ADOPTION_GUIDE.md`, `docs/API.md`, `docs/ARCHITECTURE.md`
- `docs/MIGRATION_FROM_SHARP.md`, `docs/PERFORMANCE.md`
- `docs/ROADMAP.md`, `docs/VERSION_HISTORY.md`, `docs/ZERO_COPY.md`

## Acceptance criteria (from #589)

- [x] Cloudflare Workers / browser claims moved behind #87 / explicitly marked as future Wasm support
- [x] Serverless guidance separates Node runtimes from V8-isolate runtimes
- [x] Zero-copy claims reflect the size-tiered model (≤ 256 MB read-into-memory, > 256 MB mmap)
- [x] Package size numbers refreshed from `npm pack --dry-run --json`
- [x] VERSION_HISTORY entries preserved with current-state annotation

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (JS integration + Rust unit + property tests)
- [x] `node test/benchmarks/readme-verification.bench.js` runs (docs-only — no code paths changed)
- [ ] CI: full matrix (macOS x64 / arm64, Windows x64, Linux x64 gnu/musl, Linux arm64 gnu)
- [ ] Reviewer spot-check that each removed "Cloudflare Workers" / "Vercel Edge" mention now points to #87 instead

Closes #589