### PR TITLE
chore: fix remaining Clippy warnings in test code (#479)

### DIFF
--- a/src/engine/decoder.rs
+++ b/src/engine/decoder.rs
@@ -475,8 +475,7 @@ mod tests {
     use image::{ImageFormat, Rgb, RgbImage};
 
     fn encode_webp(width: u32, height: u32) -> Vec<u8> {
-        let rgb: Vec<u8> = std::iter::repeat([10u8, 20u8, 30u8])
-            .take((width * height) as usize)
+        let rgb: Vec<u8> = std::iter::repeat_n([10u8, 20u8, 30u8], (width * height) as usize)
             .flatten()
             .collect();
         let encoder = webp::Encoder::from_rgb(&rgb, width, height);
@@ -600,8 +599,10 @@ mod tests {
 
     #[test]
     fn test_zune_png_limit_lte_max_dimension() {
-        // Runtime sanity check matching the compile-time assertion
-        assert!(super::ZUNE_PNG_MAX_DIM <= crate::engine::MAX_DIMENSION);
+        // Compile-time check that ZUNE_PNG_MAX_DIM never exceeds MAX_DIMENSION.
+        // A const assertion is preferred over `assert!` here because both operands
+        // are constants and clippy would flag the runtime form.
+        const _: () = assert!(super::ZUNE_PNG_MAX_DIM <= crate::engine::MAX_DIMENSION);
     }
 
     /// Crafted PNG with huge declared dimensions in the IHDR header but minimal pixel data.

--- a/src/engine/encoder.rs
+++ b/src/engine/encoder.rs
@@ -805,8 +805,8 @@ mod tests {
             let high_quality = encode_jpeg(&img, 95, None).unwrap();
             let low_quality = encode_jpeg(&img, 50, None).unwrap();
             // High quality is usually larger (content can flip this); both should be valid JPEGs
-            assert!(high_quality.len() > 0);
-            assert!(low_quality.len() > 0);
+            assert!(!high_quality.is_empty());
+            assert!(!low_quality.is_empty());
             assert_eq!(&high_quality[0..2], &[0xFF, 0xD8]);
             assert_eq!(&low_quality[0..2], &[0xFF, 0xD8]);
         }
@@ -864,8 +864,8 @@ mod tests {
 
             // Fast mode typically produces slightly larger files (5-10% increase)
             // but should still be reasonable
-            assert!(fast_result.len() > 0);
-            assert!(default_result.len() > 0);
+            assert!(!fast_result.is_empty());
+            assert!(!default_result.is_empty());
             // Fast mode file size should be within reasonable range (not 10x larger)
             assert!(fast_result.len() < default_result.len() * 2);
         }
@@ -907,7 +907,7 @@ mod tests {
             for quality in [50, 75, 90] {
                 let result = encode_jpeg_with_settings(&img, quality, None, true).unwrap();
                 assert_eq!(&result[0..2], &[0xFF, 0xD8]);
-                assert!(result.len() > 0);
+                assert!(!result.is_empty());
             }
         }
 

--- a/src/engine/firewall.rs
+++ b/src/engine/firewall.rs
@@ -405,7 +405,7 @@ mod tests {
         result.push(0xE1);
         result.extend_from_slice(&seg_len.to_be_bytes());
         result.extend_from_slice(exif_header);
-        result.extend(std::iter::repeat(0xAA).take(exif_payload_size));
+        result.extend(std::iter::repeat_n(0xAA, exif_payload_size));
         result.extend_from_slice(&jpeg_data[2..]);
         result
     }

--- a/src/engine/tasks.rs
+++ b/src/engine/tasks.rs
@@ -1775,7 +1775,7 @@ mod non_napi_tests {
         // Quality should be lower than max since budget is tight
         assert!(tight_result.quality <= 100);
         // The result should be the best effort (either under budget or closest over)
-        assert!(tight_result.data.len() > 0);
+        assert!(!tight_result.data.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Brings `cargo clippy --no-default-features --tests -- -D warnings` to zero warnings.

The production-code warnings listed in #479's table were already fixed in earlier commits. The remaining 9 warnings were all in `#[cfg(test)]` modules — this PR cleans them up so CI's clippy gate stays sharp even when tests are included.

## Changes

| File | Site(s) | Fix |
|------|---------|-----|
| `src/engine/decoder.rs:478` | `repeat([10,20,30]).take(n)` | `repeat_n([10,20,30], n)` |
| `src/engine/decoder.rs:604` | runtime `assert!` on constants | `const _: () = assert!(...)` (compile-time) |
| `src/engine/encoder.rs:808,809,867,868,910` | `.len() > 0` | `!is_empty()` |
| `src/engine/firewall.rs:408` | `repeat(0xAA).take(n)` | `repeat_n(0xAA, n)` |
| `src/engine/tasks.rs:1778` | `.len() > 0` | `!is_empty()` |

## Test plan

- [x] `cargo clippy --no-default-features --tests -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)
- [x] `cargo test --no-default-features --lib` (276 passed, 0 failed)
- [x] `npm run build` (release build OK)
- [x] `npm test` (full JS + Rust suite passes)
- [ ] CI matrix: macOS x64/arm64, Windows x64, Linux x64/arm64 gnu, Linux x64 musl

## Risk

Zero behavior change. All edits are test-code idiom swaps with identical semantics (or, for the `assert!` → `const _: () = assert!`, a strict upgrade from runtime to compile-time enforcement).

Closes #479