### PR TITLE
refactor: clean up exported TypeScript types (#563)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -270,7 +270,14 @@ export interface Dimensions {
   height: number
 }
 
-/** Options object for the unified `encode()` / `encodeToFile()` methods. */
+/**
+ * Options object for the unified `encode()` / `encodeToFile()` methods.
+ *
+ * @deprecated Use `EncodeOptionsInput` instead — this interface uses `format?: string`,
+ * whereas `EncodeOptionsInput` is strongly typed (`format?: OutputFormat`). The class
+ * methods on `ImageEngine` accept `EncodeOptionsInput`; this type is retained only for
+ * the NAPI ABI signature.
+ */
 export interface EncodeOptions {
   /** Output format: "jpeg", "jpg", "png", "webp", "avif" */
   format?: string
@@ -522,7 +529,8 @@ export declare function version(): string
 type CaseInsensitive<T extends string> = T | Uppercase<T> | Capitalize<T>
 type CanonicalSupportedInputFormat = 'jpeg' | 'jpg' | 'png' | 'webp'
 type CanonicalInputFormat = CanonicalSupportedInputFormat
-type CanonicalOutputFormat = CanonicalInputFormat | 'jpg' | 'avif'
+// CanonicalInputFormat already contains 'jpg'; only 'avif' is output-exclusive.
+type CanonicalOutputFormat = CanonicalInputFormat | 'avif'
 type CanonicalPresetName = 'thumbnail' | 'avatar' | 'hero' | 'social'
 
 export type InputFormat = CaseInsensitive<CanonicalSupportedInputFormat> | (string & {})
@@ -545,8 +553,9 @@ export interface ImageEngine {
   toFileProfile(path: string, format: OutputFormat, profile?: EncodeProfile, quality?: number | undefined | null): Promise<number>
   toBufferTargetBytes(format: TargetBytesFormat, options: TargetBytesOptions): Promise<BufferTargetBytesResult>
   toFileTargetBytes(path: string, format: TargetBytesFormat, options: TargetBytesOptions): Promise<FileTargetBytesResult>
-  encode(options: EncodeOptionsInput): Promise<EncodeResult>
-  encodeToFile(path: string, options: EncodeOptionsInput): Promise<FileEncodeResult>
+  // Note: encode() / encodeToFile() are declared on the ImageEngine class
+  // (see patchIndexDts patches that retype them to EncodeOptionsInput) and
+  // are deliberately NOT re-declared here to avoid duplicate signatures.
 }
 
 export interface EncodeOptionsInput {

--- a/scripts/postbuild-fixup.js
+++ b/scripts/postbuild-fixup.js
@@ -10,7 +10,8 @@ const dtsExtraBlock = `
 type CaseInsensitive<T extends string> = T | Uppercase<T> | Capitalize<T>
 type CanonicalSupportedInputFormat = 'jpeg' | 'jpg' | 'png' | 'webp'
 type CanonicalInputFormat = CanonicalSupportedInputFormat
-type CanonicalOutputFormat = CanonicalInputFormat | 'jpg' | 'avif'
+// CanonicalInputFormat already contains 'jpg'; only 'avif' is output-exclusive.
+type CanonicalOutputFormat = CanonicalInputFormat | 'avif'
 type CanonicalPresetName = 'thumbnail' | 'avatar' | 'hero' | 'social'
 
 export type InputFormat = CaseInsensitive<CanonicalSupportedInputFormat> | (string & {})
@@ -33,8 +34,9 @@ export interface ImageEngine {
   toFileProfile(path: string, format: OutputFormat, profile?: EncodeProfile, quality?: number | undefined | null): Promise<number>
   toBufferTargetBytes(format: TargetBytesFormat, options: TargetBytesOptions): Promise<BufferTargetBytesResult>
   toFileTargetBytes(path: string, format: TargetBytesFormat, options: TargetBytesOptions): Promise<FileTargetBytesResult>
-  encode(options: EncodeOptionsInput): Promise<EncodeResult>
-  encodeToFile(path: string, options: EncodeOptionsInput): Promise<FileEncodeResult>
+  // Note: encode() / encodeToFile() are declared on the ImageEngine class
+  // (see patchIndexDts patches that retype them to EncodeOptionsInput) and
+  // are deliberately NOT re-declared here to avoid duplicate signatures.
 }
 
 export interface EncodeOptionsInput {
@@ -172,6 +174,16 @@ function patchIndexDts() {
   content = replaceIfNeeded(content, '  toFileWithMetrics(path: string, format: string,', '  toFileWithMetrics(path: string, format: OutputFormat,');
   content = replaceIfNeeded(content, '  encode(options: EncodeOptions): Promise<EncodeResult>', '  encode(options: EncodeOptionsInput): Promise<EncodeResult>');
   content = replaceIfNeeded(content, '  encodeToFile(path: string, options: EncodeOptions): Promise<FileEncodeResult>', '  encodeToFile(path: string, options: EncodeOptionsInput): Promise<FileEncodeResult>');
+  // Mark the NAPI-generated `EncodeOptions` interface as deprecated.
+  // The exported type uses `format?: string` (weak typing); consumers should
+  // import `EncodeOptionsInput` instead, which uses `format?: OutputFormat`.
+  // We patch the JSDoc rather than removing the export because the interface
+  // is still the NAPI ABI type for `encode()` / `encodeToFile()` at runtime.
+  content = replaceIfNeeded(
+    content,
+    '/** Options object for the unified `encode()` / `encodeToFile()` methods. */\nexport interface EncodeOptions {',
+    '/**\n * Options object for the unified `encode()` / `encodeToFile()` methods.\n *\n * @deprecated Use `EncodeOptionsInput` instead — this interface uses `format?: string`,\n * whereas `EncodeOptionsInput` is strongly typed (`format?: OutputFormat`). The class\n * methods on `ImageEngine` accept `EncodeOptionsInput`; this type is retained only for\n * the NAPI ABI signature.\n */\nexport interface EncodeOptions {',
+  );
   content = replaceIfNeeded(content, '  fit?: string', '  fit?: ResizeFit');
   content = replaceIfNeeded(content, '  policy?: string', '  policy?: FirewallPolicy');
   content = replaceIfNeeded(content, 'export declare function supportedInputFormats(): Array<string>', 'export declare function supportedInputFormats(): Array<CanonicalInputFormat>');


### PR DESCRIPTION
## Summary

Closes #563.

Three corrections to the public TypeScript surface — all type-level only, no runtime behavior changes.

## Changes

### 1. \`EncodeOptions\` marked \`@deprecated\`

The NAPI-generated \`EncodeOptions\` interface uses \`format?: string\` (weak typing), while the class methods \`encode()\` / \`encodeToFile()\` accept the strongly-typed \`EncodeOptionsInput\` (\`format?: OutputFormat\`). Consumers who import \`EncodeOptions\` were getting weaker types than the methods they call. The JSDoc now points them at \`EncodeOptionsInput\` and explains why \`EncodeOptions\` is preserved (still the NAPI ABI shape — removing it would require changing Rust source and the NAPI binding).

### 2. \`CanonicalOutputFormat\` deduped

Was:
\`\`\`ts
type CanonicalOutputFormat = CanonicalInputFormat | 'jpg' | 'avif'
\`\`\`
But \`CanonicalInputFormat\` already includes \`'jpg'\`. Fixed to:
\`\`\`ts
type CanonicalOutputFormat = CanonicalInputFormat | 'avif'
\`\`\`

### 3. Duplicate \`encode\` / \`encodeToFile\` removed from interface augmentation

These methods are already declared on the \`ImageEngine\` class (lines 166/173 of \`index.d.ts\`) with \`EncodeOptionsInput\` after postbuild patching. The interface augmentation block was redundantly re-declaring the same signatures. Replaced with an explanatory comment so the reasoning is discoverable.

## Test plan

- [x] \`npm run build\` — postbuild-fixup runs and patches \`index.d.ts\` correctly
- [x] \`npm run test:types\` — \`tsc --noEmit\` passes
- [x] \`npm test\` — full suite green (Rust + JS)
- [x] Verified \`@deprecated\` JSDoc appears on \`EncodeOptions\` in the regenerated \`index.d.ts\`
- [x] Verified \`CanonicalOutputFormat = CanonicalInputFormat | 'avif'\` in the regenerated \`index.d.ts\`
- [x] Verified \`ImageEngine\` interface no longer re-declares \`encode\` / \`encodeToFile\`

## Notes

- Auto-close won't fire (PR targets \`develop\`, not the default branch \`main\`). Will close #563 manually after merge.