### PR TITLE
refactor: deduplicate calc_cover_resize_dimensions (#559)

### DIFF
--- a/src/engine/memory.rs
+++ b/src/engine/memory.rs
@@ -7,7 +7,7 @@
 // This module detects container memory limits from cgroup v1/v2 to automatically
 // adjust thread pool size and prevent OOM kills in constrained environments.
 
-use crate::engine::resize::calc_resize_dimensions;
+use crate::engine::resize::{calc_cover_resize_dimensions, calc_resize_dimensions};
 use crate::ops::{Operation, OutputFormat, ResizeFit};
 use image::ImageFormat;
 use parking_lot::{Condvar, Mutex};
@@ -468,23 +468,6 @@ fn compute_reserved_memory(total_bytes: u64) -> u64 {
     let _ = total_bytes;
     let _ = MAX_RESERVED_MEMORY; // keep constant used in non-NAPI builds
     MIN_RESERVED_MEMORY
-}
-
-fn calc_cover_resize_dimensions(
-    orig_w: u32,
-    orig_h: u32,
-    target_w: u32,
-    target_h: u32,
-) -> (u32, u32) {
-    if orig_w == 0 || orig_h == 0 {
-        return (target_w.max(1), target_h.max(1));
-    }
-    let scale_w = target_w as f64 / orig_w as f64;
-    let scale_h = target_h as f64 / orig_h as f64;
-    let scale = scale_w.max(scale_h);
-    let resize_w = ((orig_w as f64 * scale).ceil() as u32).max(1);
-    let resize_h = ((orig_h as f64 * scale).ceil() as u32).max(1);
-    (resize_w, resize_h)
 }
 
 fn project_operation(dims: (u32, u32), current_bpp: u64, op: &Operation) -> ((u32, u32), u64, u64) {


### PR DESCRIPTION
## Summary

Closes #559.

`calc_cover_resize_dimensions` was duplicated byte-for-byte between two modules:

- `src/engine/resize.rs:80` — \`pub(crate) fn\` (the runtime cover-resize math used by the actual resize pipeline)
- `src/engine/memory.rs:473` — private \`fn\` (used in \`project_operation\` to *project* the post-resize dimensions for memory accounting)

Both implementations need to agree exactly: the memory projection's job is to predict what the resize pipeline will actually do. A drift between the two would silently misreport peak memory budgets for cover-resize ops.

## Change

- Drop the local copy in \`memory.rs\`.
- Add \`calc_cover_resize_dimensions\` to the existing \`use crate::engine::resize::*\` import.
- No call-site changes — the function signature and semantics are identical.

\`\`\`diff
-use crate::engine::resize::calc_resize_dimensions;
+use crate::engine::resize::{calc_cover_resize_dimensions, calc_resize_dimensions};
\`\`\`

Net diff: **+1 / −18**.

## Test plan

- [x] \`cargo build --no-default-features\` — clean
- [x] \`cargo clippy --no-default-features -- -D warnings\` — no warnings
- [x] \`cargo fmt --check\` — clean
- [x] \`npm run build\` — NAPI build green
- [x] \`npm test\` — full suite passes (Rust + JS), including \`project_operation\`-related memory tests