### PR TITLE
refactor: restrict pub re-exports in engine.rs to public API only (#557)

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -60,33 +60,36 @@ pub use firewall::FirewallConfig;
 pub use io::Source;
 
 // -----------------------------------------------------------------------------
-// Internal items exposed to integration tests
+// Internal items exposed to integration tests and fuzz targets
 // -----------------------------------------------------------------------------
-// Integration tests in `tests/` compile as a separate crate and therefore can
-// only see `pub` items. The codec/pipeline helpers below are NOT part of the
-// supported public API — they are exposed to enable test coverage of internal
-// behavior, and may change at any time without a semver bump.
+// Integration tests in `tests/` and fuzz targets in `fuzz/` compile as
+// separate crates and can only see `pub` items. The codec/pipeline helpers
+// below are NOT part of the supported public API — they are exposed to enable
+// coverage of internal behavior, and may change at any time without a semver
+// bump.
 //
 // `#[doc(hidden)]` keeps them out of rustdoc and signals to downstream users
 // that depending on them is unsupported.
 #[doc(hidden)]
-pub use decoder::{check_dimensions, decode_jpeg_mozjpeg, decode_with_image_crate};
+pub use decoder::{
+    check_dimensions, decode_image, decode_jpeg_mozjpeg, decode_with_image_crate,
+    detect_exif_orientation, detect_format, ensure_dimensions_safe,
+};
 #[doc(hidden)]
 pub use encoder::{encode_avif, encode_jpeg, encode_png, encode_webp};
+#[doc(hidden)]
+pub use io::{extract_exif_raw, extract_icc_profile};
 #[doc(hidden)]
 pub use pipeline::{apply_ops, optimize_ops};
 #[doc(hidden)]
 pub use resize::{calc_resize_dimensions, fast_resize, fast_resize_owned};
 
-// Note: the remaining decoder/encoder/io/resize helpers used elsewhere inside
-// the crate (decode_image, detect_format, embed_icc_*, extract_icc_profile,
-// etc.) intentionally have no re-export here. They are reached via their
-// module-relative paths (`decoder::decode_image`, `super::io::...`) from
-// sibling modules within `engine`, and the surrounding `mod` declarations are
-// private so the items cannot leak through the rlib's public API.
-//
-// `pool::get_pool` and `pool::MAX_CONCURRENCY` are likewise consumed only via
-// module-relative paths from `tasks.rs`, `validation.rs`, and `pool::*` tests.
+// Note: the remaining helpers used elsewhere inside the crate (e.g.
+// `embed_icc_*`, `extract_icc_profile_lossy`, `ResizeError`, pool helpers)
+// intentionally have no re-export here. They are reached via module-relative
+// paths from sibling modules within `engine`, and the surrounding `mod`
+// declarations are private so the items cannot leak through the rlib's
+// public API.
 
 // Re-export types from api.rs and tasks.rs
 #[cfg(feature = "napi")]
@@ -117,10 +120,6 @@ mod tests {
     use super::*;
     use crate::engine::api::MetadataPolicy;
     use crate::engine::firewall::FirewallConfig;
-    // `extract_icc_profile` was previously reached via a now-removed `pub use`
-    // in this module. Import it directly from `io` to keep inline tests building
-    // without re-introducing a crate-public re-export.
-    use crate::engine::io::extract_icc_profile;
     use crate::engine::tasks::{EncodeTask, TaskContext};
     use crate::error::LazyImageError;
     use crate::ops::OutputFormat;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -49,26 +49,44 @@ mod stress;
 mod tasks;
 pub(crate) mod validation;
 
-// Re-export commonly used types and functions
+// -----------------------------------------------------------------------------
+// Public API surface
+// -----------------------------------------------------------------------------
+// These items form the intentional public API of lazy-image as an `rlib`.
+// External consumers may rely on these — they are subject to semver.
 pub use api::ImageEngine;
-pub use decoder::{
-    check_dimensions, decode_image, decode_jpeg_mozjpeg, decode_with_image_crate,
-    detect_exif_orientation, detect_format, ensure_dimensions_safe,
-};
-pub use encoder::{
-    embed_icc_jpeg, embed_icc_png, embed_icc_webp, encode_avif, encode_jpeg, encode_png,
-    encode_webp, QualitySettings,
-};
+pub use encoder::QualitySettings;
 pub use firewall::FirewallConfig;
-pub use io::{extract_exif_raw, extract_icc_profile, extract_icc_profile_lossy, Source};
-pub use pipeline::{apply_ops, optimize_ops};
-pub use resize::{
-    calc_resize_dimensions, fast_resize, fast_resize_internal, fast_resize_owned, ResizeError,
-};
+pub use io::Source;
 
-// Re-export pool constants for tasks.rs
-#[cfg(feature = "napi")]
-pub use pool::{get_pool, MAX_CONCURRENCY};
+// -----------------------------------------------------------------------------
+// Internal items exposed to integration tests
+// -----------------------------------------------------------------------------
+// Integration tests in `tests/` compile as a separate crate and therefore can
+// only see `pub` items. The codec/pipeline helpers below are NOT part of the
+// supported public API — they are exposed to enable test coverage of internal
+// behavior, and may change at any time without a semver bump.
+//
+// `#[doc(hidden)]` keeps them out of rustdoc and signals to downstream users
+// that depending on them is unsupported.
+#[doc(hidden)]
+pub use decoder::{check_dimensions, decode_jpeg_mozjpeg, decode_with_image_crate};
+#[doc(hidden)]
+pub use encoder::{encode_avif, encode_jpeg, encode_png, encode_webp};
+#[doc(hidden)]
+pub use pipeline::{apply_ops, optimize_ops};
+#[doc(hidden)]
+pub use resize::{calc_resize_dimensions, fast_resize, fast_resize_owned};
+
+// Note: the remaining decoder/encoder/io/resize helpers used elsewhere inside
+// the crate (decode_image, detect_format, embed_icc_*, extract_icc_profile,
+// etc.) intentionally have no re-export here. They are reached via their
+// module-relative paths (`decoder::decode_image`, `super::io::...`) from
+// sibling modules within `engine`, and the surrounding `mod` declarations are
+// private so the items cannot leak through the rlib's public API.
+//
+// `pool::get_pool` and `pool::MAX_CONCURRENCY` are likewise consumed only via
+// module-relative paths from `tasks.rs`, `validation.rs`, and `pool::*` tests.
 
 // Re-export types from api.rs and tasks.rs
 #[cfg(feature = "napi")]
@@ -99,6 +117,10 @@ mod tests {
     use super::*;
     use crate::engine::api::MetadataPolicy;
     use crate::engine::firewall::FirewallConfig;
+    // `extract_icc_profile` was previously reached via a now-removed `pub use`
+    // in this module. Import it directly from `io` to keep inline tests building
+    // without re-introducing a crate-public re-export.
+    use crate::engine::io::extract_icc_profile;
     use crate::engine::tasks::{EncodeTask, TaskContext};
     use crate::error::LazyImageError;
     use crate::ops::OutputFormat;

--- a/src/engine/resize.rs
+++ b/src/engine/resize.rs
@@ -177,26 +177,6 @@ pub fn fast_resize_internal_with_options(
     )
 }
 
-/// Backward-compatible helper preserving the legacy signature without options.
-pub fn fast_resize_internal(
-    src_width: u32,
-    src_height: u32,
-    src_pixels: Vec<u8>,
-    pixel_type: PixelType,
-    dst_width: u32,
-    dst_height: u32,
-) -> std::result::Result<DynamicImage, String> {
-    fast_resize_internal_with_options(
-        src_width,
-        src_height,
-        src_pixels,
-        pixel_type,
-        dst_width,
-        dst_height,
-        default_resize_options(),
-    )
-}
-
 pub(crate) fn fast_resize_owned_impl(
     img: DynamicImage,
     dst_width: u32,

--- a/src/engine/validation.rs
+++ b/src/engine/validation.rs
@@ -191,11 +191,11 @@ pub fn sanitize_concurrency(concurrency: Option<f64>) -> std::result::Result<u32
                 )
             })?;
 
-            if value > crate::engine::MAX_CONCURRENCY as u32 {
+            if value > crate::engine::pool::MAX_CONCURRENCY as u32 {
                 return Err(LazyImageError::invalid_argument(
                     "concurrency",
                     value.to_string(),
-                    format!("must be 0 or 1-{}", crate::engine::MAX_CONCURRENCY),
+                    format!("must be 0 or 1-{}", crate::engine::pool::MAX_CONCURRENCY),
                 ));
             }
 


### PR DESCRIPTION
## Summary

- Restrict `src/engine.rs` re-exports so only the intentional public API (`ImageEngine`, `Source`, `FirewallConfig`, `QualitySettings`) stays `pub` on the rlib surface.
- Hide codec/pipeline/resize helpers consumed by integration tests **and fuzz targets** behind `#[doc(hidden)] pub use` — they remain reachable from `tests/` and `fuzz/` but are signaled as unsupported and removed from rustdoc.
- Drop the unused re-exports `embed_icc_*`, `extract_icc_profile_lossy`, `fast_resize_internal`, `ResizeError`, `get_pool`, `MAX_CONCURRENCY`; sibling modules reach those via module-relative paths.

## Why

Per #557: `crate-type = ["cdylib", "rlib"]` means every `pub use` in `engine.rs` is part of the crate's downstream public API. Functions like `decode_jpeg_mozjpeg` and `embed_icc_jpeg` are implementation details — leaking them constrains future refactors and risks accidental external dependence.

## Self-review finding (fixed in second commit)

The first pass missed that `fuzz/` is a separate crate (excluded from the Cargo package but still built in CI) and therefore can only see `pub` items, just like `tests/`. As initially proposed it broke 4 fuzz CI jobs (`decode_avif`, `decode_from_buffer`, `exif_parse`, `icc_profile`) with unresolved-import errors. The follow-up commit re-adds `decode_image`, `detect_format`, `ensure_dimensions_safe`, `detect_exif_orientation`, `extract_exif_raw`, and `extract_icc_profile` under the same `#[doc(hidden)] pub use` block, and drops the now-redundant explicit import in inline tests.

## Side cleanups

- `fast_resize_internal` (the no-options legacy wrapper) had no remaining callers once its re-export was removed — dropped.
- `src/engine/validation.rs` updated from `crate::engine::MAX_CONCURRENCY` → `crate::engine::pool::MAX_CONCURRENCY` (module-relative path).

## Verification

- [x] `cargo test --no-default-features --no-fail-fast` — **437 passed, 0 failed**
- [x] `cargo clippy --no-default-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo check` inside `fuzz/` — compiles (regression covered)
- [x] `npm run build` — release build OK, postbuild fixup applied
- [x] `npm test` — all JS integration tests, type-safety, pack-contract, streaming, golden, EXIF roundtrip, etc. green

## Test plan

- [ ] CI green on `develop`-target PR (no-default-features cargo lint/test, build matrix across macOS/Linux/Windows, NAPI integration tests, leak detection, fuzz targets)
- [ ] No downstream consumer relies on the now-removed helpers (these were never documented as supported)

Closes #557