### PR TITLE
refactor: add Send assertions, drop dead code, trim avif allocations (#564)

### DIFF
--- a/src/engine/decoder.rs
+++ b/src/engine/decoder.rs
@@ -65,8 +65,9 @@ pub fn decode_jpeg_mozjpeg(data: &[u8]) -> DecoderResult<DynamicImage> {
             LazyImageError::decode_failed(format!("mozjpeg: failed to read scanlines: {e:?}"))
         })?;
 
-        // Safe conversion from Vec<[u8; 3]> to Vec<u8>
-        let flat_pixels: Vec<u8> = pixels.into_iter().flatten().collect();
+        // Zero-copy reinterpretation of Vec<[u8; 3]> as Vec<u8> — avoids the
+        // intermediate iterator + reallocation that `flatten().collect()` performs.
+        let flat_pixels: Vec<u8> = pixels.into_flattened();
 
         // Create DynamicImage from raw RGB data
         let rgb_image =

--- a/src/engine/encoder.rs
+++ b/src/engine/encoder.rs
@@ -671,7 +671,7 @@ pub fn encode_avif(img: &DynamicImage, quality: u8, icc: Option<&[u8]>) -> Encod
         validate_buffer_len(width, height, 4, pixels.len(), "avif")?;
 
         let mut avif_image = SafeAvifImage::new(width, height, 8, AVIF_PIXEL_FORMAT_YUV420)
-            .map_err(|e| LazyImageError::encode_failed("avif".to_string(), e.to_string()))?;
+            .map_err(|e| LazyImageError::encode_failed("avif", e.to_string()))?;
 
         avif_image.set_color_properties(
             AVIF_COLOR_PRIMARIES_BT709 as u16,
@@ -683,24 +683,24 @@ pub fn encode_avif(img: &DynamicImage, quality: u8, icc: Option<&[u8]>) -> Encod
         if let Some(icc_data) = icc {
             avif_image
                 .set_icc_profile(icc_data)
-                .map_err(|e| LazyImageError::encode_failed("avif".to_string(), e.to_string()))?;
+                .map_err(|e| LazyImageError::encode_failed("avif", e.to_string()))?;
         }
 
         let rgb = create_rgb_image(&mut avif_image, pixels.as_ptr(), width, height)
-            .map_err(|e| LazyImageError::encode_failed("avif".to_string(), e.to_string()))?;
+            .map_err(|e| LazyImageError::encode_failed("avif", e.to_string()))?;
 
         avif_image
             .allocate_planes(AVIF_PLANES_YUV)
-            .map_err(|e| LazyImageError::encode_failed("avif".to_string(), e.to_string()))?;
+            .map_err(|e| LazyImageError::encode_failed("avif", e.to_string()))?;
 
         avif_image
             .rgb_to_yuv(&rgb)
-            .map_err(|e| LazyImageError::encode_failed("avif".to_string(), e.to_string()))?;
+            .map_err(|e| LazyImageError::encode_failed("avif", e.to_string()))?;
 
         if has_alpha {
             avif_image
                 .allocate_planes(AVIF_PLANES_A)
-                .map_err(|e| LazyImageError::encode_failed("avif".to_string(), e.to_string()))?;
+                .map_err(|e| LazyImageError::encode_failed("avif", e.to_string()))?;
 
             unsafe {
                 // SAFETY:
@@ -733,7 +733,7 @@ pub fn encode_avif(img: &DynamicImage, quality: u8, icc: Option<&[u8]>) -> Encod
         }
 
         let mut encoder = SafeAvifEncoder::new()
-            .map_err(|e| LazyImageError::encode_failed("avif".to_string(), e.to_string()))?;
+            .map_err(|e| LazyImageError::encode_failed("avif", e.to_string()))?;
 
         let cpu_threads = std::thread::available_parallelism()
             .map(|n| n.get())
@@ -747,11 +747,11 @@ pub fn encode_avif(img: &DynamicImage, quality: u8, icc: Option<&[u8]>) -> Encod
 
         encoder
             .add_image(&mut avif_image, 1, AVIF_ADD_IMAGE_FLAG_SINGLE)
-            .map_err(|e| LazyImageError::encode_failed("avif".to_string(), e.to_string()))?;
+            .map_err(|e| LazyImageError::encode_failed("avif", e.to_string()))?;
 
         encoder
             .finish(&mut output)
-            .map_err(|e| LazyImageError::encode_failed("avif".to_string(), e.to_string()))?;
+            .map_err(|e| LazyImageError::encode_failed("avif", e.to_string()))?;
 
         Ok(output.to_vec())
     })

--- a/src/engine/io.rs
+++ b/src/engine/io.rs
@@ -782,60 +782,8 @@ fn extract_icc_from_avif_safe(_data: &[u8]) -> Option<Vec<u8>> {
 // - Orientation tag reset after auto-orient (prevents double-rotation bugs)
 // - GPS tag stripping by default (privacy-first, exceeds Sharp's capabilities)
 
-#[allow(unused_imports)]
-use little_exif::filetype::FileExtension;
-
 /// Maximum EXIF data size to process (prevent DoS from malicious inputs)
 const MAX_EXIF_SOURCE_BYTES: usize = 8 * 1024 * 1024;
-
-/// Detect file extension for little_exif from image data magic bytes.
-/// Note: Reserved for future PNG/WebP/AVIF EXIF support.
-#[allow(dead_code)]
-fn detect_file_extension(data: &[u8]) -> Option<FileExtension> {
-    if data.len() < 12 {
-        return None;
-    }
-
-    // JPEG: starts with FF D8
-    if data.starts_with(&[0xFF, 0xD8]) {
-        return Some(FileExtension::JPEG);
-    }
-
-    // PNG: starts with 89 50 4E 47
-    // as_zTXt_chunk: true means EXIF is stored in zTXt chunk (standard for PNG)
-    if data.starts_with(&[0x89, 0x50, 0x4E, 0x47]) {
-        return Some(FileExtension::PNG {
-            as_zTXt_chunk: true,
-        });
-    }
-
-    // WebP: RIFF....WEBP
-    if data.starts_with(b"RIFF") && data.len() >= 12 && &data[8..12] == b"WEBP" {
-        return Some(FileExtension::WEBP);
-    }
-
-    // AVIF/HEIF: ISOBMFF with ftyp box - little_exif uses HEIF for both
-    if &data[4..8] == b"ftyp" {
-        let brand = &data[8..12];
-        if brand == b"avif"
-            || brand == b"avis"
-            || brand == b"heic"
-            || brand == b"heix"
-            || brand == b"mif1"
-        {
-            return Some(FileExtension::HEIF);
-        }
-    }
-
-    // TIFF: II (little-endian) or MM (big-endian)
-    if (data.starts_with(b"II") && data[2] == 0x2A && data[3] == 0x00)
-        || (data.starts_with(b"MM") && data[2] == 0x00 && data[3] == 0x2A)
-    {
-        return Some(FileExtension::TIFF);
-    }
-
-    None
-}
 
 /// Extract raw EXIF bytes from image data.
 /// This is used to store EXIF for later embedding without needing to re-parse.

--- a/src/engine/tasks.rs
+++ b/src/engine/tasks.rs
@@ -565,6 +565,16 @@ macro_rules! define_encode_task {
             $( $( #[$fmeta] )* pub $field : $fty, )*
         }
 
+        // Compile-time `Send` guarantee. NAPI's `AsyncTask` moves task structs
+        // onto a worker thread for `compute()`, so any non-Send field would
+        // surface as a runtime error rather than at build time. This assertion
+        // catches it during compilation, before the napi attribute even
+        // expands.
+        const _: fn() = || {
+            fn assert_send<T: Send>() {}
+            assert_send::<$name>();
+        };
+
         #[cfg(feature = "napi")]
         #[napi]
         impl Task for $name {
@@ -1138,6 +1148,15 @@ pub struct BatchWithMetricsTask {
     #[cfg(feature = "napi")]
     pub(crate) last_error: Option<LazyImageError>,
 }
+
+// Compile-time `Send` assertions for the manually-implemented batch tasks.
+// Matches the assertion the `define_encode_task!` macro emits for the other
+// task types — see the comment near the macro definition.
+const _: fn() = || {
+    fn assert_send<T: Send>() {}
+    assert_send::<BatchTask>();
+    assert_send::<BatchWithMetricsTask>();
+};
 
 #[cfg(feature = "napi")]
 #[napi]


### PR DESCRIPTION
## Summary

Four small wins consolidated per #564:

1. **Compile-time `Send` assertions on every NAPI task struct.** `define_encode_task!` now emits a `const _: fn() = || { assert_send::<$name>(); };` so any non-Send field fails the build rather than surfacing as a runtime error inside `AsyncTask`. `BatchTask` / `BatchWithMetricsTask` are asserted manually in parallel to the macro-generated form.
2. **JPEG decode hot path: `into_flattened()` instead of `flatten().collect()`.** `Vec<[u8; 3]>::into_flattened` (stable since 1.80; MSRV is 1.88) reinterprets the existing buffer as `Vec<u8>` — no iterator, no reallocation. The previous code paid a full allocation on every JPEG decode.
3. **Drop the dead `detect_file_extension` in `io.rs`.** Was marked `#[allow(dead_code)]` with a "Reserved for future" comment and no tracking issue. Grep confirms zero callers across `src/`, `tests/`, `fuzz/`. Function and now-unused `FileExtension` import removed (-52 lines).
4. **Stop allocating `"avif"` on every AVIF error path.** `LazyImageError::encode_failed` accepts `impl Into<Cow<'static, str>>`, so the 9 callsites passing `"avif".to_string()` were paying a needless heap allocation each error. Pass the literal directly; matches the 13 callsites in the same file that already do.

## Why

- Item 1 catches a real class of regression at compile time. Adding a non-Send field today would only surface when the user runs an AsyncTask.
- Items 2 + 4 trim small but real per-call allocations on common paths (every JPEG decode, every AVIF error).
- Item 3 is hygiene — `#[allow(dead_code)]` with no tracking issue is just rot.

## Verification

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --no-default-features -- -D warnings` — clean
- [x] `cargo clippy --no-default-features --tests -- -D warnings` — clean
- [x] `cargo build` (default features) — clean (validates Send assertions hold)
- [x] `cargo build --no-default-features` — clean
- [x] `cargo test --no-default-features --no-fail-fast` — **437 passed, 0 failed**
- [x] `npm run build` — release build OK
- [x] `npm test` — JS suites (48 + 31 + 16 + 21) and Rust suites all green

## Test plan

- [ ] CI green across build matrix, NAPI integration tests, fuzz, ASan leak detection
- [ ] No measurable regression in golden/perf jobs (item 2 should be neutral or slightly favorable)

Closes #564