### PR TITLE
refactor(tasks): unify atomic file-write helpers (#543)

### DIFF
--- a/src/engine/tasks.rs
+++ b/src/engine/tasks.rs
@@ -813,7 +813,18 @@ impl EncodeTargetBytesTask {
     }
 }
 
-fn write_encoded_output_with_count(
+/// Write `data` to `output_path` atomically (temp-file + fsync + rename).
+///
+/// All file outputs go through this single helper to guarantee crash-safe
+/// writes: a power loss or process kill mid-write leaves the destination
+/// either untouched or fully written, never half-populated. The temp file
+/// lives in the destination's parent directory so the final `persist()`
+/// is a same-filesystem rename (atomic per POSIX).
+///
+/// Returns the number of bytes written as `u32`. The check fails for files
+/// larger than 4 GiB, but no realistic image encode produces that much
+/// output; callers that don't need the count simply discard the return value.
+fn write_encoded_output(
     output_path: &str,
     data: &[u8],
 ) -> std::result::Result<u32, LazyImageError> {
@@ -853,39 +864,6 @@ fn write_encoded_output_with_count(
     Ok(bytes_written)
 }
 
-fn write_encoded_output(output_path: &str, data: &[u8]) -> std::result::Result<(), LazyImageError> {
-    use std::io::Write;
-    use tempfile::NamedTempFile;
-
-    let output_dir = std::path::Path::new(output_path).parent().ok_or_else(|| {
-        LazyImageError::invalid_argument(
-            "path",
-            output_path.to_string(),
-            "output path must include a parent directory",
-        )
-    })?;
-
-    let mut temp_file = NamedTempFile::new_in(output_dir).map_err(|e| {
-        LazyImageError::file_write_failed(output_dir.to_string_lossy().to_string(), e)
-    })?;
-
-    let temp_path = temp_file.path().to_path_buf();
-    temp_file
-        .write_all(data)
-        .map_err(|e| LazyImageError::file_write_failed(temp_path.display().to_string(), e))?;
-    temp_file
-        .as_file_mut()
-        .sync_all()
-        .map_err(|e| LazyImageError::file_write_failed(temp_path.display().to_string(), e))?;
-
-    temp_file.persist(output_path).map_err(|e| {
-        let io_error = std::io::Error::other(format!("failed to persist file: {e}"));
-        LazyImageError::file_write_failed(output_path.to_string(), io_error)
-    })?;
-
-    Ok(())
-}
-
 define_encode_task! {
     pub struct WriteFileTask {
         pub output_path: String,
@@ -901,7 +879,7 @@ define_encode_task! {
                 }
             };
 
-            match write_encoded_output_with_count(&self.output_path, &data) {
+            match write_encoded_output(&self.output_path, &data) {
                 Ok(bytes_written) => Ok(bytes_written),
                 Err(lazy_err) => {
                     Err(self.ctx.store_and_convert_error(lazy_err))
@@ -930,7 +908,7 @@ define_encode_task! {
                 }
             };
 
-            match write_encoded_output_with_count(&self.output_path, &data) {
+            match write_encoded_output(&self.output_path, &data) {
                 Ok(bytes_written) => Ok((bytes_written, metrics)),
                 Err(lazy_err) => {
                     Err(self.ctx.store_and_convert_error(lazy_err))
@@ -1011,7 +989,7 @@ define_encode_task! {
                 }
             };
 
-            match write_encoded_output_with_count(&self.output_path, &data) {
+            match write_encoded_output(&self.output_path, &data) {
                 Ok(bytes_written) => {
                     #[cfg(feature = "napi")]
                     { self.ctx.last_error = None; }


### PR DESCRIPTION
## Summary

Closes one of three sub-items in #543. The other two are already complete in current code:

- ✅ **ICC/EXIF extraction dedup** — already centralized via `io::extract_icc_profile` and `io::extract_exif_raw`. `tasks.rs` has only 2 callsites, both delegating to the canonical helpers.
- ✅ **Error-to-Result conversion** — already shared via `TaskContext::store_and_convert_error()`. 11 callsites all use it.
- 🔧 **Atomic file write duplication** — fixed in this PR.

## What changed

`write_encoded_output_with_count` (39 lines) and `write_encoded_output` (32 lines) were functionally identical temp-file + fsync + rename sequences, differing only in whether they returned `u32` or `()`. Two implementations of crash-safety-critical code are a drift-risk: any future bugfix that touches one but forgets the other silently weakens atomicity guarantees.

Unified into a single helper returning `Result<u32, _>`:
- The 3 single-file callers that need the byte count use it.
- The 1 batch caller (`process_batch_file`) discards via `?;` — idiomatic Rust, no wrapper needed.
- Added a doc comment explaining the atomicity contract (same-filesystem rename, fsync before persist).

## Behavior change scope

The size-overflow check (`data.len().try_into::<u32>()`) now applies to the batch path too. It only triggers when an individual encoded image exceeds 4 GiB — no realistic codec output does that. Strictly an additional safety check, never a regression on normal inputs.

## Verification

- 1 file changed, +15/-37
- `cargo fmt --check` ✓
- `cargo clippy --no-default-features [--tests] -- -D warnings` ✓
- `cargo build` (default features) ✓
- `cargo build --no-default-features` ✓
- `cargo test --no-default-features --no-fail-fast` ✓ — 437 passed
- `npm run build` ✓
- `npm test` ✓ — full JS integration suite, type-safety, pack-contract, types, Rust tests, property tests

## Test plan

- [x] Atomic write code paths exercised by existing `toFile()` / `processBatch()` tests
- [x] No new public surface
- [x] No new dependencies