### PR TITLE
chore(develop): sync 0.15.0 from release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.15.0] - 2026-05-28
+
+### Added
+- **Memory-pressure streaming tests**: Added comprehensive tests for streaming API under memory constraints (#480).
+
+### Changed
+- **Engine module refactoring**: Refactored `engine.rs` and `io.rs` into focused submodules for improved maintainability:
+  - Modularized I/O layer: split `io.rs` into `source/`, `icc/`, and `exif/` submodules (#609)
+  - Modularized API: split `engine/api.rs` into focused submodules (#610)
+  - Modularized pipeline: split `engine/pipeline.rs` into focused submodules (#611)
+  - Modularized memory: split `memory.rs` into submodules (#608)
+  - Modularized tasks: split `tasks.rs` into submodules (#607)
+- **Encode context**: Bundled encode parameters into `EncodeContext` and `BatchFileContext` for cleaner internal APIs (#606).
+- **File I/O helpers**: Unified atomic file-write helpers for code deduplication (#605).
+- **Public API visibility**: Restricted pub re-exports in `engine.rs` to public API surface only (#557).
+- **Code optimization**: Added Send assertions, dropped dead code, and trimmed AVIF allocations (#564).
+- **Resize calculations**: Deduplicated `calc_cover_resize_dimensions` logic (#559).
+- **TypeScript types**: Cleaned up exported TypeScript types for clarity (#563).
+
+### Fixed
+- **Test re-exports**: Include fuzz-target helpers in test-only re-exports (#557).
+
+---
+
 ## [0.14.0] - 2026-05-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "lazy-image"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "bitflags",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lazy-image"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 description = "Web image optimization engine - smaller outputs than sharp, powered by Rust + mozjpeg"
 license = "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alberteinshutoin/lazy-image",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Web image optimization engine for Node.js - smaller files than sharp, powered by Rust + mozjpeg",
   "main": "index.js",
   "exports": {
@@ -82,12 +82,12 @@
     ]
   },
   "optionalDependencies": {
-    "@alberteinshutoin/lazy-image-darwin-arm64": "0.14.0",
-    "@alberteinshutoin/lazy-image-darwin-x64": "0.14.0",
-    "@alberteinshutoin/lazy-image-linux-x64-gnu": "0.14.0",
-    "@alberteinshutoin/lazy-image-linux-x64-musl": "0.14.0",
-    "@alberteinshutoin/lazy-image-linux-arm64-gnu": "0.14.0",
-    "@alberteinshutoin/lazy-image-win32-x64-msvc": "0.14.0"
+    "@alberteinshutoin/lazy-image-darwin-arm64": "0.15.0",
+    "@alberteinshutoin/lazy-image-darwin-x64": "0.15.0",
+    "@alberteinshutoin/lazy-image-linux-x64-gnu": "0.15.0",
+    "@alberteinshutoin/lazy-image-linux-x64-musl": "0.15.0",
+    "@alberteinshutoin/lazy-image-linux-arm64-gnu": "0.15.0",
+    "@alberteinshutoin/lazy-image-win32-x64-msvc": "0.15.0"
   },
   "engines": {
     "node": ">= 18"


### PR DESCRIPTION
## Sync Release 0.15.0 Back to Develop

After merging `release/0.15.0` to `main` and tagging v0.15.0, this PR syncs the version bumps and CHANGELOG entries back to `develop`.

### Changes
- `package.json`: version 0.14.0 → 0.15.0
- `Cargo.toml`: version 0.14.0 → 0.15.0  
- `Cargo.lock`: lock file updated for new version
- `CHANGELOG.md`: added [0.15.0] section

### Notes
- No functional changes; this is purely a sync operation
- Required by git flow to keep develop in sync after release