### PR TITLE
chore: sync package-lock.json to 0.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alberteinshutoin/lazy-image",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@alberteinshutoin/lazy-image",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^3.5.1",
@@ -19,17 +19,18 @@
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "@alberteinshutoin/lazy-image-darwin-arm64": "0.14.0",
-        "@alberteinshutoin/lazy-image-darwin-x64": "0.14.0",
-        "@alberteinshutoin/lazy-image-linux-arm64-gnu": "0.14.0",
-        "@alberteinshutoin/lazy-image-linux-x64-gnu": "0.14.0",
-        "@alberteinshutoin/lazy-image-linux-x64-musl": "0.14.0",
-        "@alberteinshutoin/lazy-image-win32-x64-msvc": "0.14.0"
+        "@alberteinshutoin/lazy-image-darwin-arm64": "0.15.0",
+        "@alberteinshutoin/lazy-image-darwin-x64": "0.15.0",
+        "@alberteinshutoin/lazy-image-linux-arm64-gnu": "0.15.0",
+        "@alberteinshutoin/lazy-image-linux-x64-gnu": "0.15.0",
+        "@alberteinshutoin/lazy-image-linux-x64-musl": "0.15.0",
+        "@alberteinshutoin/lazy-image-win32-x64-msvc": "0.15.0"
       }
     },
     "node_modules/@alberteinshutoin/lazy-image-darwin-arm64": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-darwin-arm64/-/lazy-image-darwin-arm64-0.14.0.tgz",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-darwin-arm64/-/lazy-image-darwin-arm64-0.15.0.tgz",
+      "integrity": "sha512-xelpffrjY3ALdU/ywEHshhdwrnM6H1PNH1vN3RCpwu/CEdYeNtbIL17uyZcOJ3YYtNsL5dNpgHx6QNvCU7ThHg==",
       "cpu": [
         "arm64"
       ],
@@ -43,8 +44,9 @@
       }
     },
     "node_modules/@alberteinshutoin/lazy-image-darwin-x64": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-darwin-x64/-/lazy-image-darwin-x64-0.14.0.tgz",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-darwin-x64/-/lazy-image-darwin-x64-0.15.0.tgz",
+      "integrity": "sha512-oSHl8iBLMP6PcSLZsCuRdV6se8EDFK8BxMd/MwECekKAs/OfcFuQyQgVVaSq0utozDKdmQapk8t1A6SdzxM5JQ==",
       "cpu": [
         "x64"
       ],
@@ -58,8 +60,9 @@
       }
     },
     "node_modules/@alberteinshutoin/lazy-image-linux-arm64-gnu": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-linux-arm64-gnu/-/lazy-image-linux-arm64-gnu-0.14.0.tgz",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-linux-arm64-gnu/-/lazy-image-linux-arm64-gnu-0.15.0.tgz",
+      "integrity": "sha512-CqKZhwY/9fvRZt+UY8tZz0t8Vrv+bvGiq1TAz/XKDQSg4rLtp8Tm5w+zXKZgVO+eolqgnBlDEqNFyO+C5Yz+6Q==",
       "cpu": [
         "arm64"
       ],
@@ -73,8 +76,9 @@
       }
     },
     "node_modules/@alberteinshutoin/lazy-image-linux-x64-gnu": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-linux-x64-gnu/-/lazy-image-linux-x64-gnu-0.14.0.tgz",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-linux-x64-gnu/-/lazy-image-linux-x64-gnu-0.15.0.tgz",
+      "integrity": "sha512-TBCXBynmLCxXcdKiB1jq0CCc/VXrtS5i79XcxkUgXOADXOVDP5yrer1wOxUJwokVDmqPocQHvztC236kXSpSBg==",
       "cpu": [
         "x64"
       ],
@@ -88,8 +92,9 @@
       }
     },
     "node_modules/@alberteinshutoin/lazy-image-linux-x64-musl": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-linux-x64-musl/-/lazy-image-linux-x64-musl-0.14.0.tgz",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-linux-x64-musl/-/lazy-image-linux-x64-musl-0.15.0.tgz",
+      "integrity": "sha512-vt3TjTDU11CbbV9mrywiY2S+XcdFaKAjvtGEm1ITe/YBOSwi05AvfTJPsdxJF/VaphlQ9NIAbQl4jZArYxyH2Q==",
       "cpu": [
         "x64"
       ],
@@ -103,8 +108,9 @@
       }
     },
     "node_modules/@alberteinshutoin/lazy-image-win32-x64-msvc": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-win32-x64-msvc/-/lazy-image-win32-x64-msvc-0.14.0.tgz",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-win32-x64-msvc/-/lazy-image-win32-x64-msvc-0.15.0.tgz",
+      "integrity": "sha512-tP1mnOlMAUZxQB7mKad98kQ7jXJs/Tw03WPeytONeVr/tdWJjLJ1ttoiasGrv/Mze8xKLLlVuZZdHlZqK3N3ew==",
       "cpu": [
         "x64"
       ],


### PR DESCRIPTION
## Summary

Fixes CI \`npm ci\` failures on every PR opened after the 0.15.0 release. The release bump touched \`package.json\` / \`Cargo.toml\` / \`Cargo.lock\` / \`CHANGELOG.md\` but **not** \`package-lock.json\`.

## Root cause

The release PR ([#612](https://github.com/albert-einshutoin/lazy-image/pull/612)) and sync-back PR ([#613](https://github.com/albert-einshutoin/lazy-image/pull/613)) both passed CI even though \`package-lock.json\` still pinned \`0.14.0\`. This is a **race condition**:

- At the time those PRs ran, \`@alberteinshutoin/lazy-image-*@0.15.0\` had not been published to npm yet
- npm treated the missing 0.15.0 optional deps as \"skip silently\" rather than \"lock file out of sync\"
- \`npm ci\` therefore succeeded

After the publish job ran on the \`v0.15.0\` tag, npm could see that the 0.15.0 platform packages now exist, so every subsequent \`npm ci\` started failing with:

\`\`\`
Invalid: lock file's @alberteinshutoin/lazy-image-darwin-arm64@0.14.0 does not satisfy @alberteinshutoin/lazy-image-darwin-arm64@0.15.0
\`\`\`

This is why PR [#614](https://github.com/albert-einshutoin/lazy-image/pull/614) (docs-only) is currently red.

## Fix

Regenerate \`package-lock.json\` against the published 0.15.0 platform packages via \`npm install --package-lock-only --ignore-scripts\`. Diff is purely version + integrity-hash updates for the six \`@alberteinshutoin/lazy-image-*\` platform packages.

## Follow-ups

I'll also amend [docs/RELEASE.md](https://github.com/albert-einshutoin/lazy-image/pull/614) to add \`package-lock.json\` to the list of files that must be updated every release, with this incident as the pitfall.

## Test plan

- [ ] CI's \`npm ci\` step now succeeds on Build / Test / Coverage / Package Contract / ASan jobs