### PR TITLE
Harden Rust idiom gates

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-android-arm64')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-android-arm-eabi')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-win32-x64-gnu')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-win32-x64-msvc')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-win32-ia32-msvc')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-win32-arm64-msvc')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@alberteinshutoin/lazy-image-darwin-universal')
       const bindingPackageVersion = require('@alberteinshutoin/lazy-image-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-darwin-x64')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-darwin-arm64')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-freebsd-x64')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-freebsd-arm64')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-x64-musl')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-x64-gnu')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-arm64-musl')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-arm64-gnu')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-arm-musleabihf')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-loong64-musl')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-loong64-gnu')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-riscv64-musl')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-riscv64-gnu')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-linux-ppc64-gnu')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-linux-s390x-gnu')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-openharmony-arm64')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-openharmony-x64')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-openharmony-arm')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -40,11 +40,18 @@ const ENCODE_PROFILE_CONFIG = {
 // Pure helpers (no dependency on nativeBinding)
 // ---------------------------------------------------------------------------
 
-/** Clamp a value to a valid quality integer (0–100), or return undefined. */
+/** Clamp a value to a valid quality integer (1-100), or return undefined. */
 function clampQuality(v) {
   const n = Number(v);
   if (!Number.isFinite(n)) return undefined;
-  return Math.max(0, Math.min(100, Math.round(n)));
+  return Math.max(1, Math.min(100, Math.round(n)));
+}
+
+/** Parse a target-bytes quality integer without silently clamping invalid ranges. */
+function parseTargetQuality(v) {
+  const n = Number(v);
+  if (!Number.isFinite(n)) return undefined;
+  return Math.round(n);
 }
 
 /** Validate and normalize target-bytes options for binary-search encoding. */
@@ -60,9 +67,16 @@ function normalizeTargetBytesOptions(format, options = {}) {
     throw new Error('targetBytes must be a positive number');
   }
 
-  const minQuality = clampQuality(options.minQuality ?? DEFAULT_TARGET_BYTES_MIN_QUALITY);
-  const maxQuality = clampQuality(options.maxQuality ?? 100);
-  if (minQuality == null || maxQuality == null || minQuality <= 0 || maxQuality <= 0) {
+  const minQuality = parseTargetQuality(options.minQuality ?? DEFAULT_TARGET_BYTES_MIN_QUALITY);
+  const maxQuality = parseTargetQuality(options.maxQuality ?? 100);
+  if (
+    minQuality == null ||
+    maxQuality == null ||
+    minQuality <= 0 ||
+    maxQuality <= 0 ||
+    minQuality > 100 ||
+    maxQuality > 100
+  ) {
     throw new Error('minQuality/maxQuality must be integers between 1 and 100');
   }
   if (minQuality > maxQuality) {
@@ -344,6 +358,7 @@ module.exports = {
   TARGET_BYTES_SUPPORTED_FORMATS,
   ENCODE_PROFILE_CONFIG,
   clampQuality,
+  parseTargetQuality,
   normalizeTargetBytesOptions,
   runTargetBytesSearch,
   resolveEncodeProfile,

--- a/src/engine/api/batch_ops.rs
+++ b/src/engine/api/batch_ops.rs
@@ -128,6 +128,9 @@ impl ImageEngine {
     /// Backward compatibility: the legacy positional signature
     ///   processBatch(inputs, outputDir, format, quality?, fastMode?, concurrency?)
     /// is still accepted for now but will be removed in a future major release.
+    // The exported N-API signature intentionally keeps legacy positional
+    // arguments alongside the options object for JS compatibility.
+    #[allow(clippy::too_many_arguments)]
     #[napi(js_name = "processBatch", ts_return_type = "Promise<BatchResult[]>")]
     pub fn process_batch(
         &self,
@@ -173,7 +176,7 @@ impl ImageEngine {
             }
         };
         let ops = self.ops.clone();
-        let mut policy = self.metadata_policy.clone();
+        let mut policy = self.metadata_policy;
         policy.apply_firewall(self.firewall.reject_metadata);
         Ok(AsyncTask::new(BatchTask {
             inputs,
@@ -189,6 +192,9 @@ impl ImageEngine {
         }))
     }
 
+    // The exported N-API signature intentionally keeps legacy positional
+    // arguments alongside the options object for JS compatibility.
+    #[allow(clippy::too_many_arguments)]
     #[napi(
         js_name = "processBatchWithMetrics",
         ts_return_type = "Promise<BatchOutputWithMetrics>"
@@ -237,7 +243,7 @@ impl ImageEngine {
             }
         };
         let ops = self.ops.clone();
-        let mut policy = self.metadata_policy.clone();
+        let mut policy = self.metadata_policy;
         policy.apply_firewall(self.firewall.reject_metadata);
 
         Ok(AsyncTask::new(BatchWithMetricsTask {

--- a/src/engine/api/engine.rs
+++ b/src/engine/api/engine.rs
@@ -164,7 +164,7 @@ impl ImageEngine {
             icc_profile,
             exif_data,
             auto_orient: self.auto_orient,
-            metadata_policy: self.metadata_policy.clone(),
+            metadata_policy: self.metadata_policy,
             xmp_warning_emitted: self.xmp_warning_emitted,
             firewall: self.firewall.clone(),
         })

--- a/src/engine/api/output_ops.rs
+++ b/src/engine/api/output_ops.rs
@@ -63,7 +63,7 @@ impl ImageEngine {
         let source = self.source.clone();
         let decoded = self.decoded.clone();
         let ops = self.ops.clone();
-        let mut policy = self.metadata_policy.clone();
+        let mut policy = self.metadata_policy;
         policy.apply_firewall(self.firewall.reject_metadata);
         let auto_orient = self.auto_orient;
         let icc_present = self.icc_profile().is_some();
@@ -163,7 +163,7 @@ impl ImageEngine {
         let source = self.source.clone();
         let decoded = self.decoded.clone();
         let ops = self.ops.clone();
-        let mut policy = self.metadata_policy.clone();
+        let mut policy = self.metadata_policy;
         policy.apply_firewall(self.firewall.reject_metadata);
         let auto_orient = self.auto_orient;
         let icc_present = self.icc_profile().is_some();
@@ -251,6 +251,9 @@ impl ImageEngine {
         js_name = "toBufferTargetBytesNative",
         ts_return_type = "Promise<TargetBytesResult>"
     )]
+    // This is an internal N-API compatibility bridge used by the JS helper;
+    // the public JS API accepts a structured options object.
+    #[allow(clippy::too_many_arguments)]
     pub fn to_buffer_target_bytes_native(
         &mut self,
         env: Env,
@@ -263,9 +266,32 @@ impl ImageEngine {
     ) -> Result<AsyncTask<EncodeTargetBytesTask>> {
         let fast_mode = fast_mode.unwrap_or(false);
 
-        // Validate and clamp quality range
-        let min_q = min_quality.unwrap_or(30).min(100) as u8;
-        let max_q = max_quality.unwrap_or(100).min(100) as u8;
+        // Validate quality range without silently clamping so direct native
+        // callers get the same 1-100 contract as the rest of the API.
+        let min_q_raw = min_quality.unwrap_or(30);
+        let max_q_raw = max_quality.unwrap_or(100);
+        if !(1..=100).contains(&min_q_raw) {
+            return Err(napi_err(
+                &env,
+                LazyImageError::invalid_argument(
+                    "minQuality",
+                    min_q_raw.to_string(),
+                    "must be between 1 and 100",
+                ),
+            ));
+        }
+        if !(1..=100).contains(&max_q_raw) {
+            return Err(napi_err(
+                &env,
+                LazyImageError::invalid_argument(
+                    "maxQuality",
+                    max_q_raw.to_string(),
+                    "must be between 1 and 100",
+                ),
+            ));
+        }
+        let min_q = min_q_raw as u8;
+        let max_q = max_q_raw as u8;
         if min_q > max_q {
             return Err(napi_err(
                 &env,
@@ -274,12 +300,6 @@ impl ImageEngine {
                     min_q.to_string(),
                     "must be less than or equal to maxQuality",
                 ),
-            ));
-        }
-        if min_q == 0 {
-            return Err(napi_err(
-                &env,
-                LazyImageError::invalid_argument("minQuality", "0", "must be between 1 and 100"),
             ));
         }
         if target_bytes == 0 {
@@ -302,7 +322,7 @@ impl ImageEngine {
         let source = self.source.clone();
         let decoded = self.decoded.clone();
         let ops = self.ops.clone();
-        let mut policy = self.metadata_policy.clone();
+        let mut policy = self.metadata_policy;
         policy.apply_firewall(self.firewall.reject_metadata);
         let auto_orient = self.auto_orient;
         let icc_present = self.icc_profile().is_some();
@@ -372,7 +392,7 @@ impl ImageEngine {
         let source = self.source.clone();
         let decoded = self.decoded.clone();
         let ops = self.ops.clone();
-        let mut policy = self.metadata_policy.clone();
+        let mut policy = self.metadata_policy;
         policy.apply_firewall(self.firewall.reject_metadata);
         let auto_orient = self.auto_orient;
         let icc_present = self.icc_profile().is_some();
@@ -434,7 +454,7 @@ impl ImageEngine {
         let source = self.source.clone();
         let decoded = self.decoded.clone();
         let ops = self.ops.clone();
-        let mut policy = self.metadata_policy.clone();
+        let mut policy = self.metadata_policy;
         policy.apply_firewall(self.firewall.reject_metadata);
         let auto_orient = self.auto_orient;
         let icc_present = self.icc_profile().is_some();
@@ -536,7 +556,7 @@ impl ImageEngine {
         let source = self.source.clone();
         let decoded = self.decoded.clone();
         let ops = self.ops.clone();
-        let mut policy = self.metadata_policy.clone();
+        let mut policy = self.metadata_policy;
         policy.apply_firewall(self.firewall.reject_metadata);
         let auto_orient = self.auto_orient;
         let icc_present = self.icc_profile().is_some();
@@ -627,7 +647,7 @@ impl ImageEngine {
         let source = self.source.clone();
         let decoded = self.decoded.clone();
         let ops = self.ops.clone();
-        let mut policy = self.metadata_policy.clone();
+        let mut policy = self.metadata_policy;
         policy.apply_firewall(self.firewall.reject_metadata);
         let auto_orient = self.auto_orient;
         let icc_present = self.icc_profile().is_some();

--- a/src/engine/memory/cgroup.rs
+++ b/src/engine/memory/cgroup.rs
@@ -5,8 +5,6 @@
 // All functions in this module are NAPI-only because the only consumer
 // (`detect_available_memory` in the parent module) is itself NAPI-gated.
 
-#![cfg(feature = "napi")]
-
 use std::fs;
 
 /// Parsed cgroup mount entry: the on-disk mount point and the relative root

--- a/src/engine/memory/mod.rs
+++ b/src/engine/memory/mod.rs
@@ -71,9 +71,7 @@ pub fn memory_semaphore() -> Arc<WeightedSemaphore> {
 fn compute_reserved_memory(total_bytes: u64) -> u64 {
     // reserve 5% of total, clamped to [64MB, 512MB]
     let five_percent = total_bytes / 20;
-    five_percent
-        .max(MIN_RESERVED_MEMORY)
-        .min(MAX_RESERVED_MEMORY)
+    five_percent.clamp(MIN_RESERVED_MEMORY, MAX_RESERVED_MEMORY)
 }
 
 #[cfg(not(feature = "napi"))]

--- a/src/engine/memory/semaphore.rs
+++ b/src/engine/memory/semaphore.rs
@@ -98,8 +98,10 @@ impl WeightedSemaphore {
         let ready_flag = {
             let mut state = self.state.lock();
 
-            // Fast path: if capacity available, acquire immediately
-            if state.available >= need {
+            // Fast path: acquire immediately only when no older waiter is queued.
+            // Once a waiter exists, every new request must join the queue to
+            // preserve FIFO fairness and avoid starving large operations.
+            if state.waiters.is_empty() && state.available >= need {
                 state.available -= need;
                 return MemoryPermit {
                     sem: Arc::clone(self),
@@ -162,6 +164,11 @@ impl WeightedSemaphore {
     #[cfg(test)]
     pub(super) fn available_for_test(&self) -> u64 {
         self.state.lock().available
+    }
+
+    #[cfg(test)]
+    pub(super) fn waiters_for_test(&self) -> usize {
+        self.state.lock().waiters.len()
     }
 }
 
@@ -243,6 +250,53 @@ mod tests {
             .recv_timeout(Duration::from_secs(1))
             .expect("waiter should acquire after release");
         handle.join().unwrap();
+    }
+
+    #[test]
+    fn queued_waiter_blocks_later_fast_path() {
+        let sem = Arc::new(WeightedSemaphore::new(100));
+        let permit = sem.acquire(80);
+
+        let sem_large = Arc::clone(&sem);
+        let (large_acquired_tx, large_acquired_rx) = std::sync::mpsc::channel();
+        let large = thread::spawn(move || {
+            let _permit = sem_large.acquire(100);
+            large_acquired_tx.send(()).unwrap();
+        });
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(1);
+        while sem.waiters_for_test() == 0 {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "large waiter should enqueue"
+            );
+            thread::yield_now();
+        }
+
+        let sem_small = Arc::clone(&sem);
+        let (small_acquired_tx, small_acquired_rx) = std::sync::mpsc::channel();
+        let small = thread::spawn(move || {
+            let _permit = sem_small.acquire(10);
+            small_acquired_tx.send(()).unwrap();
+        });
+
+        assert!(
+            small_acquired_rx
+                .recv_timeout(Duration::from_millis(50))
+                .is_err(),
+            "later small waiter must not bypass an older queued waiter"
+        );
+
+        drop(permit);
+        large_acquired_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("large waiter should acquire first after release");
+        small_acquired_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("small waiter should acquire after large permit drops");
+
+        large.join().unwrap();
+        small.join().unwrap();
     }
 
     #[test]

--- a/src/engine/pool.rs
+++ b/src/engine/pool.rs
@@ -174,12 +174,9 @@ pub fn calculate_optimal_concurrency() -> usize {
 
     // 2. Detect memory limits and calculate memory-based concurrency
     let available_memory = memory::detect_available_memory();
-    let memory_based =
-        memory::calculate_memory_based_concurrency(available_memory, cpu_concurrency);
-
     // 3. Use the minimum of CPU and memory constraints
     // This ensures we don't exceed either CPU or memory limits
-    memory_based
+    memory::calculate_memory_based_concurrency(available_memory, cpu_concurrency)
 }
 
 #[cfg(feature = "napi")]

--- a/test/integration/basic.test.js
+++ b/test/integration/basic.test.js
@@ -311,6 +311,58 @@ async function runTests() {
         assert(result.bytesOut === result.data.length, 'bytesOut should match buffer length');
     });
 
+    await asyncTest('toBufferTargetBytes() rejects invalid native quality ranges', async () => {
+        await assert.rejects(
+            () => ImageEngine.fromPath(TEST_IMAGE)
+                .resize(400)
+                .toBufferTargetBytes('jpeg', {
+                    targetBytes: 2000,
+                    minQuality: 0,
+                    maxQuality: 90,
+                }),
+            /minQuality\/maxQuality/,
+            'public helper should reject minQuality=0 instead of silently clamping'
+        );
+
+        await assert.rejects(
+            () => ImageEngine.fromPath(TEST_IMAGE)
+                .resize(400)
+                .toBufferTargetBytes('jpeg', {
+                    targetBytes: 2000,
+                    minQuality: 40,
+                    maxQuality: 101,
+                }),
+            /minQuality\/maxQuality/,
+            'public helper should reject maxQuality=101 instead of silently clamping'
+        );
+
+        try {
+            await ImageEngine.fromPath(TEST_IMAGE)
+                .resize(400)
+                .toBufferTargetBytesNative('jpeg', 2000, 0, 90);
+            assert.fail('minQuality=0 should be rejected instead of silently clamped');
+        } catch (err) {
+            assert(/\[E400\].*minQuality/.test(err.message), `unexpected minQuality error: ${err.message}`);
+        }
+
+        try {
+            await ImageEngine.fromPath(TEST_IMAGE)
+                .resize(400)
+                .toBufferTargetBytesNative('jpeg', 2000, 40, 101);
+            assert.fail('maxQuality=101 should be rejected instead of silently clamped');
+        } catch (err) {
+            assert(/\[E400\].*maxQuality/.test(err.message), `unexpected maxQuality error: ${err.message}`);
+        }
+    });
+
+    await asyncTest('profile quality never resolves below native minimum', async () => {
+        const result = await ImageEngine.fromPath(TEST_IMAGE)
+            .resize(100)
+            .toBufferWithMetricsProfile('jpeg', 'speed-first', 1);
+        assert(result.data.length > 0, 'output should have content');
+        assert.strictEqual(result.metrics.formatOut, 'jpeg', 'profile output should be jpeg');
+    });
+
     await asyncTest('toFileTargetBytes() writes a budgeted file result', async () => {
         const outPath = resolveTemp('target_bytes.jpg');
         try {


### PR DESCRIPTION
## Summary
- make the shipping default-feature clippy gate pass by cleaning small lint debt and documenting N-API compatibility exceptions
- preserve FIFO fairness in the weighted memory semaphore so queued large operations cannot be bypassed by later small requests
- align target-bytes/profile quality handling with the native 1-100 quality contract
- regenerate the NAPI JS binding wrapper for the current 0.15.0 package version

## Verification
- npm run build
- npm test
- cargo fmt --check
- cargo clippy -- -D warnings
- cargo clippy --no-default-features --tests -- -D warnings
- cargo test --no-default-features
- cargo audit (passes with existing allowed warnings: core2, paste, rand)
- git diff --check