### PR TITLE
docs: refresh benchmark claims

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lazy-image"
 version = "0.15.0"
 edition = "2021"
-description = "Web image optimization engine - smaller outputs than sharp, powered by Rust + mozjpeg"
+description = "Web image optimization engine - smaller JPEG outputs than sharp in canonical benchmarks, powered by Rust + mozjpeg"
 license = "MIT"
 repository = "https://github.com/albert-einshutoin/lazy-image"
 keywords = ["image", "resize", "jpeg", "webp", "optimization"]
@@ -116,7 +116,7 @@ harness = false
 name = "memory_semaphore"
 harness = false
 
-# 【重要】依存関係（mozjpeg, ravif等）はデバッグビルド時も最適化する
+# 【重要】依存関係（mozjpeg, libavif等）はデバッグビルド時も最適化する
 # これがないと、ASanテスト中の画像処理が激重でタイムアウトする
 [profile.dev.package."*"]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lazy-image"
 version = "0.15.0"
 edition = "2021"
-description = "Web image optimization engine - smaller JPEG outputs than sharp in canonical benchmarks, powered by Rust + mozjpeg"
+description = "Web image optimization engine - smaller JPEG outputs in simple canonical benchmarks, powered by Rust + mozjpeg"
 license = "MIT"
 repository = "https://github.com/albert-einshutoin/lazy-image"
 keywords = ["image", "resize", "jpeg", "webp", "optimization"]

--- a/README.ja.md
+++ b/README.ja.md
@@ -5,29 +5,30 @@
 ## 位置付け
 - Web 向け画像最適化に特化した意図的なエンジン
 - まだ sharp のドロップイン代替ではありません（互換 API が必要なら sharp を使用）
+- 現行の正本ベンチマークでは、PNG → JPEG の測定シナリオで sharp より **17-20% 小さい JPEG** を生成。AVIF/WebP の速度・サイズはワークロード依存で、現行測定では sharp が有利なケースがあります
 - セキュリティ優先: 全メタデータ（EXIF/XMP/ICC）をデフォルトで削除。`keepMetadata()` で保持可能
 - V8 ヒープを経由しない入力パス: `fromPath()/processBatch()` → `toFile()` で入力ファイルを JS ヒープへコピーしない（256 MB 以下は Rust 所有バッファに読み込み、256 MB 超は advisory lock 付き mmap）
-- AVIF の ICC は v0.9.x（libavif-sys）で保持。<0.9.0 や ravif のみ構成では破棄
+- AVIF の ICC は v0.9.x（libavif-sys）で保持。古い/別構成の AVIF backend では破棄される場合があります
 - `lazy` の意味: [docs/LAZY_SEMANTICS.md](./docs/LAZY_SEMANTICS.md) を参照（constructor は無作業ではない）
 - 思想と非目標: [docs/PROJECT_PHILOSOPHY.md](./docs/PROJECT_PHILOSOPHY.md)
 
 ## 計測可能な指標
 - JS ヒープ増加: `fromPath → toBufferWithMetrics` で **2MB 以下**（`node --expose-gc docs/scripts/measure-zero-copy.js` で検証）
 - RSS 目安: `peak_rss ≤ decoded_bytes + 24MB`（decoded_bytes = width × height × bpp; JPEG bpp=3, PNG/WebP/AVIF bpp=4）。例: 6000×4000 PNG (≈96MB) → 目標 RSS ≤ 120MB
-- 品質ゲート: SSIM ≥ 0.995 / PSNR ≥ 40dB （sharp 出力と比較するベンチで検証）
+- 品質比較: `npm run test:bench:compare` は sharp 出力との SSIM/PSNR を出力。公開性能 claim の正本は [docs/TRUE_BENCHMARKS.md](./docs/TRUE_BENCHMARKS.md)
 
 ## 主な特徴
-- AVIF/WebP/JPEG/PNG エンコード（AVIFは高速かつ小サイズ）
+- AVIF/WebP/JPEG/PNG エンコード（AVIF/WebP の速度・サイズ優位はワークロードごとに要検証）
 - ICC/EXIF 保持オプション（AVIFの ICC は v0.9.x 以降、GPS は自動削除）
 - EXIF 自動回転（`autoOrient(false)` で無効化）
 - ディスクバッファ型ストリーミングでメモリを O(1) 近傍に抑制
 - Rust コアによるメモリ安全 & Node.js バインディング (napi-rs)
 
 ## 推奨シナリオ
-- CDN/モバイル向けの帯域削減
+- CDN/モバイル向けの JPEG 帯域削減
 - バッチ処理・静的サイト生成
 - メモリ制約環境（512MB コンテナなど）
-- AVIF 生成・色精度重視ワークフロー
+- AVIF 生成・色精度重視ワークフロー（サイズ/速度は対象画像で検証）
 
 ## セキュリティと互換性
 - 安全策の詳細とサポートバージョン: [SECURITY.md](./SECURITY.md)

--- a/README.ja.md
+++ b/README.ja.md
@@ -5,7 +5,7 @@
 ## 位置付け
 - Web 向け画像最適化に特化した意図的なエンジン
 - まだ sharp のドロップイン代替ではありません（互換 API が必要なら sharp を使用）
-- 現行の正本ベンチマークでは、PNG → JPEG の測定シナリオで sharp より **17-20% 小さい JPEG** を生成。AVIF/WebP の速度・サイズはワークロード依存で、現行測定では sharp が有利なケースがあります
+- 現行の正本ベンチマークでは、PNG → JPEG の単純な 2 シナリオ（no-resize 変換 / 800px resize）で sharp より **17-20% 小さい JPEG** を生成。AVIF/WebP と複合操作 JPEG pipeline の速度・サイズはワークロード依存で、現行測定では sharp が有利なケースがあります
 - セキュリティ優先: 全メタデータ（EXIF/XMP/ICC）をデフォルトで削除。`keepMetadata()` で保持可能
 - V8 ヒープを経由しない入力パス: `fromPath()/processBatch()` → `toFile()` で入力ファイルを JS ヒープへコピーしない（256 MB 以下は Rust 所有バッファに読み込み、256 MB 超は advisory lock 付き mmap）
 - AVIF の ICC は v0.9.x（libavif-sys）で保持。古い/別構成の AVIF backend では破棄される場合があります

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 <img width="256" height="256" alt="image" src="https://github.com/user-attachments/assets/239496c7-ad7f-4649-b130-8ed0a65481f7" />
 
-> **Web image optimization engine for Node.js.** Rust core, smaller outputs than sharp.
+> **Web image optimization engine for Node.js.** Rust core, smaller JPEG outputs, bounded memory.
 
-lazy-image reduces image file sizes by 20-30% compared to sharp in its target web-delivery scenarios, trading encoding speed for smaller outputs. Ideal for CDN-heavy workloads where bandwidth costs matter more than CPU costs.
+In current canonical benchmarks, lazy-image produces **17-20% smaller JPEG outputs** than sharp for tested PNG → JPEG workloads. AVIF/WebP size and speed are workload-specific; benchmark your target image mix before assuming a win.
 
 - **Not** a drop-in replacement for sharp — use sharp if you need its full API or maximum throughput.
 - **Security-first**: Metadata stripped by default; `keepMetadata()` to preserve. File-path inputs (`fromPath()`/`processBatch()` → `toFile()`) bypass the V8 heap — small/medium files (≤ 256 MB) are read into Rust-owned memory for SIGBUS safety; only files larger than 256 MB use mmap with advisory locks. See [docs/ZERO_COPY.md](./docs/ZERO_COPY.md).
@@ -68,15 +68,15 @@ streaming/pipeline.js       # Disk-backed bounded-memory streaming
 |---|---|
 | You pay for bandwidth (CDN, S3, CloudFront) | You need maximum encoding throughput |
 | You run in serverless / memory-constrained envs | You need a broad image editing API |
-| You want AVIF with good defaults | You need drop-in API compatibility |
-| You want smaller outputs over faster encodes | You need GIF, SVG, or TIFF support |
+| You want AVIF with safe defaults | You need drop-in API compatibility |
+| You want smaller JPEG outputs over broader codec throughput | You need GIF, SVG, or TIFF support |
 
 **Key differentiators:**
 
-1. **File size optimization** — mozjpeg + libwebp + ravif produce 20-30% smaller outputs than sharp's defaults
+1. **JPEG file size optimization** — mozjpeg produces 17-20% smaller JPEG outputs in the canonical PNG → JPEG benchmarks
 2. **Memory efficiency** — file-path inputs are not copied into the V8 heap; decoded pixels stay in Rust memory
 3. **Security-first** — GPS auto-strip, Image Firewall, Rust memory safety
-4. **AVIF excellence** — ravif encoder with quality-optimized defaults
+4. **AVIF output support** — libavif encoder with quality-tuned defaults and ICC support; benchmark AVIF workloads for size/speed
 
 **What lazy-image does NOT compete on:** raw encoding speed (sharp/libvips is faster), feature breadth (no drawing, compositing, or GIF), API compatibility with sharp.
 
@@ -103,14 +103,14 @@ Scenario guide: [docs/ADOPTION_GUIDE.md](./docs/ADOPTION_GUIDE.md).
 
 Assume:
 - average image size before optimization: **1.0 MB**
-- average reduction with lazy-image: **25%**
+- average JPEG-oriented reduction with lazy-image: **18%** (example only; not universal across all codecs)
 - CDN transfer rate: **$0.085/GB** (example: CloudFront pay-as-you-go, US/EU next 9TB tier)
 
 | Scenario | Transfer with sharp | Transfer with lazy-image | Monthly savings |
 |---|---:|---:|---:|
-| 1M image deliveries / month | 976.6 GB | 732.4 GB | **$20.75** |
-| 10M image deliveries / month | 9.54 TB | 7.15 TB | **$207.52** |
-| 100M image deliveries / month | 95.37 TB | 71.53 TB | **$2,075.20** |
+| 1M image deliveries / month | 976.6 GB | 800.8 GB | **$14.94** |
+| 10M image deliveries / month | 9.54 TB | 7.82 TB | **$149.41** |
+| 100M image deliveries / month | 95.37 TB | 78.20 TB | **$1,494.14** |
 
 Break-even intuition:
 - Encoding overhead is paid **once per generated image**
@@ -192,7 +192,7 @@ More: batch processing, presets, metrics, streaming — [docs/API.md](./docs/API
 
 ## Features (summary)
 
-Smaller JPEG (mozjpeg) · Smaller WebP (libwebp) · AVIF (ravif) · ICC profiles · EXIF auto-orient · Bypass-V8-heap file I/O (read-into-memory ≤ 256 MB, mmap > 256 MB) · Disk-backed bounded-memory pipeline (`createStreamingPipeline()`, not true chunked transform streaming) · Image Firewall · GPS auto-strip · Fluent API · Rust core (NAPI-RS) · Cross-platform (macOS, Windows, Linux). Design choices and limits: [docs/ROADMAP.md](./docs/ROADMAP.md) and [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md).
+Smaller JPEG (mozjpeg) · WebP (libwebp) · AVIF (libavif) · ICC profiles · EXIF auto-orient · Bypass-V8-heap file I/O (read-into-memory ≤ 256 MB, mmap > 256 MB) · Disk-backed bounded-memory pipeline (`createStreamingPipeline()`, not true chunked transform streaming) · Image Firewall · GPS auto-strip · Fluent API · Rust core (NAPI-RS) · Cross-platform (macOS, Windows, Linux). Design choices and limits: [docs/ROADMAP.md](./docs/ROADMAP.md) and [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md).
 
 ---
 
@@ -215,7 +215,7 @@ MIT
 
 ## Credits
 
-[mozjpeg](https://github.com/mozilla/mozjpeg) · [libwebp](https://chromium.googlesource.com/webm/libwebp) · [ravif](https://github.com/kornelski/ravif) · [fast_image_resize](https://github.com/Cykooz/fast_image_resize) · [img-parts](https://github.com/paolobarbolini/img-parts) · [napi-rs](https://napi.rs/)
+[mozjpeg](https://github.com/mozilla/mozjpeg) · [libwebp](https://chromium.googlesource.com/webm/libwebp) · [libavif](https://github.com/AOMediaCodec/libavif) · [fast_image_resize](https://github.com/Cykooz/fast_image_resize) · [img-parts](https://github.com/paolobarbolini/img-parts) · [napi-rs](https://napi.rs/)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > **Web image optimization engine for Node.js.** Rust core, smaller JPEG outputs, bounded memory.
 
-In current canonical benchmarks, lazy-image produces **17-20% smaller JPEG outputs** than sharp for tested PNG → JPEG workloads. AVIF/WebP size and speed are workload-specific; benchmark your target image mix before assuming a win.
+In current canonical benchmarks, lazy-image produces **17-20% smaller JPEG outputs** than sharp for the two simple PNG → JPEG cases: no-resize conversion and resize-to-800px. AVIF/WebP size and speed, and multi-operation JPEG pipelines, are workload-specific; benchmark your target image mix before assuming a win.
 
 - **Not** a drop-in replacement for sharp — use sharp if you need its full API or maximum throughput.
 - **Security-first**: Metadata stripped by default; `keepMetadata()` to preserve. File-path inputs (`fromPath()`/`processBatch()` → `toFile()`) bypass the V8 heap — small/medium files (≤ 256 MB) are read into Rust-owned memory for SIGBUS safety; only files larger than 256 MB use mmap with advisory locks. See [docs/ZERO_COPY.md](./docs/ZERO_COPY.md).
@@ -73,7 +73,7 @@ streaming/pipeline.js       # Disk-backed bounded-memory streaming
 
 **Key differentiators:**
 
-1. **JPEG file size optimization** — mozjpeg produces 17-20% smaller JPEG outputs in the canonical PNG → JPEG benchmarks
+1. **JPEG file size optimization** — mozjpeg produces 17-20% smaller JPEG outputs in the canonical simple PNG → JPEG no-resize and resize benchmarks
 2. **Memory efficiency** — file-path inputs are not copied into the V8 heap; decoded pixels stay in Rust memory
 3. **Security-first** — GPS auto-strip, Image Firewall, Rust memory safety
 4. **AVIF output support** — libavif encoder with quality-tuned defaults and ICC support; benchmark AVIF workloads for size/speed

--- a/docs/ADOPTION_GUIDE.md
+++ b/docs/ADOPTION_GUIDE.md
@@ -542,4 +542,4 @@ If you are unsure where to start, use:
 ImageEngine.fromPath(input).resize(...).toFile(output, format, quality)
 ```
 
-That path best matches the library's design goals: smaller outputs, bounded memory, and predictable server behavior.
+That path best matches the library's design goals: smaller JPEG outputs in canonical benchmarks, bounded memory, and predictable server behavior.

--- a/docs/ADOPTION_GUIDE.md
+++ b/docs/ADOPTION_GUIDE.md
@@ -542,4 +542,4 @@ If you are unsure where to start, use:
 ImageEngine.fromPath(input).resize(...).toFile(output, format, quality)
 ```
 
-That path best matches the library's design goals: smaller JPEG outputs in canonical benchmarks, bounded memory, and predictable server behavior.
+That path best matches the library's design goals: smaller JPEG outputs in simple canonical benchmarks, bounded memory, and predictable server behavior.

--- a/docs/API.md
+++ b/docs/API.md
@@ -210,7 +210,7 @@ Metrics payloads are versioned. See [metrics-api.md](./metrics-api.md) and [metr
 
 ## Quality Metrics (SSIM/PSNR)
 
-lazy-image enforces quality parity with sharp in CI: SSIM ≥ 0.995, PSNR ≥ 40 dB. These are used in benchmarks only; no public API for them yet.
+Benchmark helpers can report SSIM/PSNR against sharp outputs for local comparison. These metrics are benchmark-only helpers; there is no public API for them yet, and public performance claims should cite the scenario-specific data in [TRUE_BENCHMARKS.md](./TRUE_BENCHMARKS.md).
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 
 1. **mozjpeg** — Progressive mode, optimized Huffman tables, scan optimization, trellis quantization
 2. **libwebp** — Method 4 (balanced), single-pass encoding (v0.8.1+ optimized for speed)
-3. **ravif** — Pure Rust AVIF encoder, AV1-based compression
+3. **libavif** — AVIF encoder backend with safe Rust FFI wrappers
 4. **Chroma subsampling** (4:2:0) for web-optimal output
 5. **Adaptive preprocessing** — JPEG: compression optimization; WebP (v0.8.1+): speed optimization
 
@@ -26,14 +26,14 @@ See [LAZY_SEMANTICS.md](./LAZY_SEMANTICS.md) for the exact boundary between eage
 
 ## Color Management
 
-**AVIF**: ICC preserved in v0.9.0+ (libavif-sys). On &lt;0.9.0 or ravif-only builds, ICC is dropped — convert to sRGB before encoding if needed.
+**AVIF**: ICC preserved in v0.9.0+ (libavif-sys). On older or alternate AVIF backend builds, ICC may be dropped — convert to sRGB before encoding if needed.
 
 | Format | ICC |
 |--------|-----|
 | JPEG   | ✅ Extracted and embedded |
 | PNG    | ✅ iCCP chunk |
 | WebP   | ✅ ICCP chunk |
-| AVIF   | ✅ v0.9.0+ libavif-sys; dropped on ravif-only |
+| AVIF   | ✅ v0.9.0+ libavif-sys; may be dropped on older/alternate backend builds |
 
 ## Platform Notes
 
@@ -59,7 +59,7 @@ On Windows, memory-mapped files **cannot be deleted** while mapped. Keep the `Im
 ├─────────────────────────────────────────────────────────────┤
 │                         Rust Core                           │
 │  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌─────────────┐  │
-│  │ mozjpeg  │  │ libwebp  │  │  ravif   │  │ fast_image  │  │
+│  │ mozjpeg  │  │ libwebp  │  │ libavif  │  │ fast_image  │  │
 │  │ (JPEG)   │  │ (WebP)   │  │ (AVIF)   │  │ _resize     │  │
 │  └──────────┘  └──────────┘  └──────────┘  └─────────────┘  │
 │  ┌──────────┐  ┌──────────┐                                 │

--- a/docs/BENCHMARK_CLAIMS.md
+++ b/docs/BENCHMARK_CLAIMS.md
@@ -18,8 +18,8 @@ These may appear in README, marketing, and migration guides **without qualificat
 
 | Claim | Location | Source Scenario | Notes |
 |-------|----------|----------------|-------|
-| "20-30% smaller outputs than sharp" | README.md | JPEG −17%, AVIF −40.9% | Range covers no-resize codec results; does not apply to resize-heavy pipelines (e.g. AVIF resize shows +9.5%) |
-| "25% file size reduction" | ROI_CALCULATOR.md (example) | Mid-range estimate | Labeled as example, not a guarantee |
+| "17-20% smaller JPEG outputs than sharp" | README.md, PERFORMANCE.md | PNG -> JPEG no-resize -17.0%; PNG -> JPEG resize 800px -20.0% | JPEG-specific; do not generalize to AVIF/WebP |
+| "18% file size reduction" | ROI_CALCULATOR.md (example) | JPEG-oriented worked example | Labeled as example, not a guarantee |
 | Binary size savings (5-9 MB vs 15-21 MB) | PERFORMANCE.md | Measured `.node` binary sizes | Platform-specific, factual |
 
 ### Workload-specific claims
@@ -28,18 +28,18 @@ These **must always include the codec, input format, and scenario** when quoted:
 
 | Claim | Location | Source Scenario | Required qualification |
 |-------|----------|----------------|----------------------|
-| "1.70x faster AVIF encoding" | PERFORMANCE.md, TRUE_BENCHMARKS.md | PNG → AVIF (no resize, 5000×5000) | Must cite format + input size |
-| "40.9% smaller AVIF output" | PERFORMANCE.md, TRUE_BENCHMARKS.md | PNG → AVIF (no resize, 5000×5000) | Must cite format + input size |
-| "17.0% smaller JPEG output" | PERFORMANCE.md, TRUE_BENCHMARKS.md | PNG → JPEG (no resize, 5000×5000) | Must cite format + input size |
-| "0.7% smaller WebP, 7x slower encoding" | PERFORMANCE.md, TRUE_BENCHMARKS.md | PNG → WebP (no resize, 5000×5000) | Must cite format + input size; encoding is significantly slower |
+| "17.0% smaller JPEG output" | PERFORMANCE.md, TRUE_BENCHMARKS.md | PNG -> JPEG (no resize, 5000×5000) | Must cite format + input size |
+| "20.0% smaller JPEG output" | PERFORMANCE.md, TRUE_BENCHMARKS.md | PNG -> JPEG (resize 800px, 5000×5000 input) | Must cite format + resize context |
+| "AVIF is slower and larger in current canonical PNG -> AVIF benchmarks" | PERFORMANCE.md, TRUE_BENCHMARKS.md | PNG -> AVIF no-resize and resize 800px | Must cite exact scenario; do not turn into a universal AVIF claim |
+| "WebP is slower and similar/larger in current canonical PNG -> WebP benchmarks" | PERFORMANCE.md, TRUE_BENCHMARKS.md | PNG -> WebP no-resize and resize 800px | Must cite exact scenario; do not turn into a universal WebP claim |
 
 **Rule of thumb:** If removing the scenario context would mislead a reader into thinking the claim is universal, it is workload-specific.
 
 ## Quoting Rules
 
 1. **Always qualify codec and workload.** Never say "lazy-image is faster than sharp" without specifying the format and scenario.
-2. **"20-30% smaller" is the safe summary claim.** It spans JPEG (−17%) through AVIF (−41%) and is appropriate for README-level messaging.
-3. **Speed claims are workload-specific.** AVIF encoding is faster; WebP encoding is slower. Always cite the specific scenario.
+2. **"17-20% smaller JPEG" is the safe summary claim.** It applies only to the canonical PNG -> JPEG scenarios currently measured.
+3. **Speed claims are workload-specific.** Current JPEG resize was faster, JPEG no-resize was slightly slower, and AVIF/WebP favored sharp in the measured scenarios. Always cite the specific scenario.
 4. **Do not mix resize and no-resize numbers.** Results differ significantly when resize is involved.
 5. **Cite the test environment.** TRUE_BENCHMARKS.md specifies the machine, Node version, and library versions used.
 
@@ -48,22 +48,28 @@ These **must always include the codec, input format, and scenario** when quoted:
 These rules prevent drift between documents:
 
 1. **Upstream-first.** Update TRUE_BENCHMARKS.md before any downstream doc. Never update README or PERFORMANCE.md with numbers that are not yet in TRUE_BENCHMARKS.md.
-2. **README uses ranges only.** README may state "20-30% smaller" but must not cite specific percentages (e.g. "40.9%") — those belong in PERFORMANCE.md with a link to the source scenario.
+2. **README uses qualified ranges only.** README may state "17-20% smaller JPEG" but must not imply all codecs are smaller or faster.
 3. **Mandatory qualification.** Workload-specific claims must include format, input dimensions, and whether resize was applied. Omitting any of these is a documentation bug.
-4. **Version-bump trigger.** When lazy-image, sharp, or any core encoder dependency (mozjpeg, ravif, libwebp) is updated, re-run `npm run test:bench:compare` and update TRUE_BENCHMARKS.md before merging.
+4. **Version-bump trigger.** When lazy-image, sharp, or any core encoder dependency (mozjpeg, libavif, libwebp) is updated, re-run `npm run test:bench`, `node --expose-gc test/benchmarks/convert-only.bench.js`, and `npm run test:bench:extended` before updating TRUE_BENCHMARKS.md.
 5. **Atomic updates.** When a benchmark number changes, update all downstream files in the same PR. Partial updates create drift windows.
 
 ## How to Detect Drift
 
 ### Automated (CI)
 
-The benchmark regression workflow (`.github/workflows/CI.yml` quality job + `npm run test:bench:verify`) compares actual encoding output against baseline values. If file sizes drift beyond 5% or speed beyond 15%, CI reports it.
+`npm run test:bench:verify` and benchmark smoke checks ensure the benchmark scripts still execute. Numeric public-claim drift is currently governed by this document and manual upstream-first updates; broader baseline automation is tracked separately.
 
 ### Local Verification
 
 ```bash
 # Run the full benchmark comparison
 npm run test:bench:compare
+
+# Run no-resize conversion numbers cited in TRUE_BENCHMARKS.md
+node --expose-gc test/benchmarks/convert-only.bench.js
+
+# Run extended AVIF/WebP/JPEG, memory, and cold-start snapshots
+npm run test:bench:extended
 
 # Verify README claims match actual results
 npm run test:bench:verify
@@ -77,7 +83,7 @@ npm run test:bench:smoke
 Use this checklist when updating any performance claim:
 
 **Before updating:**
-- [ ] Run `npm run test:bench:compare` locally and record current numbers
+- [ ] Run `npm run test:bench`, `node --expose-gc test/benchmarks/convert-only.bench.js`, and `npm run test:bench:extended` locally and record current numbers
 - [ ] Verify the specific scenario exists in TRUE_BENCHMARKS.md
 - [ ] Cross-check the claim against the inventory tables above
 
@@ -88,8 +94,8 @@ Use this checklist when updating any performance claim:
 - [ ] Ensure workload-specific claims include format, input size, and resize context
 
 **After updating:**
-- [ ] Run `npm run test:bench:verify` to confirm README/doc claims are consistent
-- [ ] Verify CI passes the quality regression job
+- [ ] Run `npm run test:bench:verify` to confirm benchmark verification still executes
+- [ ] Verify CI passes the benchmark and test jobs
 - [ ] Update the version tracking section below if library versions changed
 
 ### Files to Check
@@ -98,16 +104,16 @@ When TRUE_BENCHMARKS.md is updated, also check:
 
 | File | What to verify |
 |------|---------------|
-| `README.md` | Summary claims containing "20-30% smaller" stay within measured range (grep, don't rely on line numbers) |
+| `README.md` | Summary claims containing "17-20% smaller JPEG" stay within measured range (grep, don't rely on line numbers) |
 | `docs/PERFORMANCE.md` | Canonical scenarios table matches TRUE_BENCHMARKS.md |
 | `docs/MIGRATION_FROM_SHARP.md` | Comparison references are current |
 | `docs/ROI_CALCULATOR.md` | Example reduction percentage is plausible |
 | `docs/BENCHMARK_RESULTS.md` | Historical snapshots are not confused with current numbers |
 | `docs/BENCHMARK_OPERATIONS.md` | Operation-level benchmarks are consistent |
-| `test/benchmarks/readme-verification.bench.js` | Expected values match TRUE_BENCHMARKS.md |
+| `test/benchmarks/readme-verification.bench.js` | Script still executes and any reintroduced expected values match TRUE_BENCHMARKS.md |
 
 ## Version Tracking
 
 The `*Last updated:*` footer at the bottom of TRUE_BENCHMARKS.md records the lazy-image and sharp versions used. When either dependency updates significantly, re-run benchmarks and update all downstream claims.
 
-Current: lazy-image v0.12.0, sharp v0.34.x
+Current: lazy-image v0.15.0, Node.js v24.2.0, sharp v0.34.5 (benchmarked 2026-05-29)

--- a/docs/BENCHMARK_CLAIMS.md
+++ b/docs/BENCHMARK_CLAIMS.md
@@ -18,7 +18,7 @@ These may appear in README, marketing, and migration guides **without qualificat
 
 | Claim | Location | Source Scenario | Notes |
 |-------|----------|----------------|-------|
-| "17-20% smaller JPEG outputs than sharp" | README.md, PERFORMANCE.md | PNG -> JPEG no-resize -17.0%; PNG -> JPEG resize 800px -20.0% | JPEG-specific; do not generalize to AVIF/WebP |
+| "17-20% smaller JPEG outputs than sharp" | README.md, PERFORMANCE.md | PNG -> JPEG no-resize -17.0%; PNG -> JPEG resize 800px -20.0% | JPEG-specific and limited to the two simple measured cases; do not generalize to AVIF/WebP or multi-operation JPEG pipelines |
 | "18% file size reduction" | ROI_CALCULATOR.md (example) | JPEG-oriented worked example | Labeled as example, not a guarantee |
 | Binary size savings (5-9 MB vs 15-21 MB) | PERFORMANCE.md | Measured `.node` binary sizes | Platform-specific, factual |
 
@@ -38,7 +38,7 @@ These **must always include the codec, input format, and scenario** when quoted:
 ## Quoting Rules
 
 1. **Always qualify codec and workload.** Never say "lazy-image is faster than sharp" without specifying the format and scenario.
-2. **"17-20% smaller JPEG" is the safe summary claim.** It applies only to the canonical PNG -> JPEG scenarios currently measured.
+2. **"17-20% smaller JPEG" is the safe summary claim.** It applies only to the two simple canonical PNG -> JPEG scenarios currently measured: no-resize conversion and resize-to-800px.
 3. **Speed claims are workload-specific.** Current JPEG resize was faster, JPEG no-resize was slightly slower, and AVIF/WebP favored sharp in the measured scenarios. Always cite the specific scenario.
 4. **Do not mix resize and no-resize numbers.** Results differ significantly when resize is involved.
 5. **Cite the test environment.** TRUE_BENCHMARKS.md specifies the machine, Node version, and library versions used.
@@ -48,7 +48,7 @@ These **must always include the codec, input format, and scenario** when quoted:
 These rules prevent drift between documents:
 
 1. **Upstream-first.** Update TRUE_BENCHMARKS.md before any downstream doc. Never update README or PERFORMANCE.md with numbers that are not yet in TRUE_BENCHMARKS.md.
-2. **README uses qualified ranges only.** README may state "17-20% smaller JPEG" but must not imply all codecs are smaller or faster.
+2. **README uses qualified ranges only.** README may state "17-20% smaller JPEG" only when scoped to the two simple canonical cases; it must not imply all codecs, all JPEG pipelines, or all operation chains are smaller or faster.
 3. **Mandatory qualification.** Workload-specific claims must include format, input dimensions, and whether resize was applied. Omitting any of these is a documentation bug.
 4. **Version-bump trigger.** When lazy-image, sharp, or any core encoder dependency (mozjpeg, libavif, libwebp) is updated, re-run `npm run test:bench`, `node --expose-gc test/benchmarks/convert-only.bench.js`, and `npm run test:bench:extended` before updating TRUE_BENCHMARKS.md.
 5. **Atomic updates.** When a benchmark number changes, update all downstream files in the same PR. Partial updates create drift windows.
@@ -104,7 +104,7 @@ When TRUE_BENCHMARKS.md is updated, also check:
 
 | File | What to verify |
 |------|---------------|
-| `README.md` | Summary claims containing "17-20% smaller JPEG" stay within measured range (grep, don't rely on line numbers) |
+| `README.md` | Summary claims containing "17-20% smaller JPEG" stay scoped to the two simple canonical cases (grep, don't rely on line numbers) |
 | `docs/PERFORMANCE.md` | Canonical scenarios table matches TRUE_BENCHMARKS.md |
 | `docs/MIGRATION_FROM_SHARP.md` | Comparison references are current |
 | `docs/ROI_CALCULATOR.md` | Example reduction percentage is plausible |

--- a/docs/BENCHMARK_RESULTS.md
+++ b/docs/BENCHMARK_RESULTS.md
@@ -48,3 +48,65 @@ Notes:
 - AVIF rows compare quality bands (q45/q60/q75) to expose practical speed/size trade-offs.
 - `metrics.peakRss` is process peak RSS (`getrusage`) and not per-operation isolated memory.
 - RSS delta is measured as before/after process RSS approximation, mainly for trend monitoring.
+
+## Issue #619 (Benchmark Claim Refresh)
+
+Date: 2026-05-29
+Branch: `fix/benchmark-claims-619`
+Environment: macOS 26.3, Apple M4 (arm64), Node.js v24.2.0, sharp v0.34.5, lazy-image v0.15.0
+
+### Commands
+
+```bash
+npm run test:bench
+node --expose-gc test/benchmarks/convert-only.bench.js
+npm run test:bench:extended
+```
+
+### Canonical No-Resize Conversion
+
+| Conversion | lazy-image | sharp | Speed Ratio (sharp/lazy) | Size Diff |
+|------------|-----------:|------:|--------------------------:|----------:|
+| PNG -> WebP | 4,323ms / 1,150,954 bytes | 909ms / 1,124,232 bytes | 0.21x | +2.4% |
+| PNG -> AVIF | 12,668ms / 1,718,430 bytes | 4,729ms / 1,290,501 bytes | 0.37x | +33.2% |
+| PNG -> JPEG | 700ms / 1,224,894 bytes | 660ms / 1,475,223 bytes | 0.94x | -17.0% |
+
+### Resize 800px Comparison
+
+| Scenario | lazy-image | sharp | Speed Ratio (sharp/lazy) | Size Diff |
+|----------|-----------:|------:|--------------------------:|----------:|
+| PNG -> JPEG resize 800px | 70ms / 31,518 bytes | 79ms / 39,416 bytes | 1.13x | -20.0% |
+| PNG -> WebP resize 800px | 166ms / 32,448 bytes | 90ms / 29,686 bytes | 0.54x | +9.3% |
+| PNG -> AVIF resize 800px | 442ms / 28,678 bytes | 179ms / 22,227 bytes | 0.40x | +29.0% |
+| Resize + rotate + grayscale -> JPEG | 68ms / 27,129 bytes | 112ms / 24,650 bytes | 1.65x | +10.1% |
+
+### Extended AVIF / WebP / JPEG Matrix
+
+| Case | lazy-image avg ms | sharp avg ms | speed ratio (sharp/lazy) | lazy size | sharp size | size diff | Note |
+|---|---:|---:|---:|---:|---:|---:|---|
+| AVIF q45 | 331.8 | 157.6 | 0.48x | 16.2 KB | 13.6 KB | 18.5% | lower quality / smaller output |
+| AVIF q60 | 449.1 | 164.2 | 0.37x | 28.0 KB | 21.7 KB | 29.0% | default quality baseline |
+| AVIF q75 | 526.3 | 200.4 | 0.38x | 39.9 KB | 34.1 KB | 17.0% | higher quality / larger output |
+| WebP q80 | 161.6 | 77.7 | 0.48x | 31.7 KB | 29.0 KB | 9.3% | WebP baseline |
+| JPEG q80 | 57.4 | 71.8 | 1.25x | 30.8 KB | 38.5 KB | -20.0% | JPEG baseline |
+
+### Memory Tracking
+
+| Scenario | Estimated weight (MB) | Avg RSS delta (MB) | Avg metrics.peakRss (MB) | Avg time (ms) | Avg output (KB) | delta/estimate |
+|---|---:|---:|---:|---:|---:|---:|
+| jpeg-noops-q80 | 113.2 | 6.9 | 326.5 | 653.5 | 1196.2 | 0.06 |
+| webp-resize800-q80 | 103.4 | 11.4 | 410.8 | 162.0 | 31.7 | 0.11 |
+| jpeg-resize-rotate-gray-q75 | 103.4 | 9.0 | 484.8 | 90.5 | 47.6 | 0.09 |
+
+### Cold Start
+
+| Metric | Avg | p50 | p95 |
+|---|---:|---:|---:|
+| require() time | 3.0ms | 3.0ms | 3.5ms |
+| first toBuffer() time | 28.5ms | 28.4ms | 29.5ms |
+| total cold start | 31.5ms | 31.3ms | 32.5ms |
+
+Notes:
+- Current public size win is JPEG-specific in these measured scenarios.
+- Current AVIF/WebP measurements favor sharp for speed and usually output size.
+- Speed ratios use `sharp time / lazy-image time`; values below 1.0 mean sharp was faster.

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -5,7 +5,7 @@
 lazy-image is an **opinionated web image optimization engine**. It is **not** a
 drop-in replacement for sharp. The API is intentionally smaller and focuses on:
 
-- Smaller file sizes (especially JPEG/AVIF)
+- Smaller JPEG files in canonical benchmarks
 - Predictable, safe behavior (strict limits and error taxonomy)
 - Low memory usage for server workloads
 
@@ -31,7 +31,7 @@ You can query at runtime with `supportedInputFormats()` and
 | Animated images (GIF/WebP) | ❌ | ✅ |
 | Streaming pipeline | Disk-backed bounded-memory pipeline (`createStreamingPipeline()`), not true streaming transforms | ✅ |
 | Metadata | ICC + EXIF (GPS auto-strip, XMP unsupported) | ✅ (EXIF/XMP/etc) |
-| AVIF encoding | ✅ (focus area) | ✅ |
+| AVIF encoding | ✅ (supported; benchmark size/speed per workload) | ✅ |
 
 ## Non-goals
 
@@ -41,8 +41,8 @@ You can query at runtime with `supportedInputFormats()` and
 
 ## When to Choose lazy-image
 
-- You want **smaller files** and are OK with a smaller API surface.
-- You care about **AVIF speed** and **JPEG size optimization**.
+- You want **smaller JPEG files** and are OK with a smaller API surface.
+- You care about **JPEG size optimization**, metadata safety, and bounded-memory file-path processing.
 - You want clear error taxonomy and strict limits for user uploads.
 - You are fine with a disk-backed bounded-memory pipeline instead of true chunk transform streaming.
 

--- a/docs/METADATA_SUPPORT.md
+++ b/docs/METADATA_SUPPORT.md
@@ -35,7 +35,7 @@ await ImageEngine.fromPath('input.jpg')
 | JPEG | supported | supported | stripped by default, opt-in preserve | not supported | Orientation is normalized after auto-orient |
 | PNG | ICC supported | not currently documented as preserved | n/a | not supported | PNG metadata support is narrower than JPEG |
 | WebP | ICC supported | not currently documented as preserved | n/a | not supported | Favor explicit testing before relying on non-ICC metadata |
-| AVIF | ICC supported on v0.9.x+ with `libavif-sys` | not currently documented as preserved | n/a | not supported | On older/ravif-only builds ICC may be dropped |
+| AVIF | ICC supported on v0.9.x+ with `libavif-sys` | not currently documented as preserved | n/a | not supported | On older/alternate backend builds ICC may be dropped |
 
 ## Important Caveats
 

--- a/docs/MIGRATION_FROM_SHARP.md
+++ b/docs/MIGRATION_FROM_SHARP.md
@@ -3,7 +3,7 @@
 This guide helps teams port common sharp workflows to **lazy-image**. The focus is on web-image optimization use cases; lazy-image is not a drop-in replacement for sharp's full surface.
 
 ## Quick Differences
-- Web optimization first: smaller JPEG/AVIF files and lower memory use; narrower feature set than sharp.
+- Web optimization first: smaller JPEG files in canonical benchmarks and lower-memory file-path processing; narrower feature set than sharp.
 - Metadata defaults: both libraries strip most metadata; lazy-image additionally auto-strips GPS. Use `.keepMetadata(...)` (lazy-image) or `.withMetadata()` (sharp) to retain data.
 - Formats: lazy-image inputs jpeg/png/webp; outputs jpeg/png/webp/avif. Use sharp if you need TIFF, GIF, HEIF, or multi-page inputs.
 - Streaming: lazy-image lacks sharp's true streaming transforms; `createStreamingPipeline()` stages to disk for bounded-memory processing.
@@ -14,7 +14,7 @@ In many teams, the best migration is **not** full replacement.
 
 Recommended split:
 - Use `sharp` or another editor for compositing, overlays, filters, animation, and broad input-format support
-- Use `lazy-image` for final JPEG/WebP/AVIF optimization, metadata stripping, and lower-heap file-to-file processing
+- Use `lazy-image` for final JPEG optimization, WebP/AVIF output when its safety defaults fit, metadata stripping, and lower-heap file-to-file processing
 
 This keeps existing editing workflows intact while still gaining lazy-image's web-delivery strengths.
 
@@ -57,8 +57,8 @@ const output = await ImageEngine.from(input)
 ```
 
 ## Performance Comparison (when to switch)
-- AVIF: in the canonical `PNG -> AVIF (no resize, 5000×5000)` benchmark, lazy-image is **1.70x faster** and produces **40.9% smaller** output. See [TRUE_BENCHMARKS.md](./TRUE_BENCHMARKS.md).
-- JPEG: in the canonical `PNG -> JPEG (no resize, 5000×5000)` benchmark, lazy-image produces **17.0% smaller** output. Encoding speed depends on workload and settings.
+- JPEG: in the canonical `PNG -> JPEG` benchmarks, lazy-image produces **17.0% smaller** output for no-resize conversion and **20.0% smaller** output for resize-to-800px. Encoding speed depends on workload and settings.
+- AVIF: in the current canonical `PNG -> AVIF` benchmarks, sharp is faster and produces smaller output. Use lazy-image AVIF when you need its output path, metadata behavior, and safety defaults; benchmark before switching for size/speed.
 - WebP: use if you want the safer defaults and metadata stripping, but expect sharp to remain faster in many throughput-sensitive workloads.
 - Latency-sensitive or filter-heavy workloads still favor sharp; build-time optimization and batch processing favor lazy-image.
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -29,7 +29,7 @@ Full data: [TRUE_BENCHMARKS.md](./TRUE_BENCHMARKS.md).
 ## When to Use lazy-image
 
 - **Node-runtime serverless (AWS Lambda, Google Cloud Run, Vercel Node Functions, Google Cloud Functions)** — Avoid OOM and smaller cold-start footprint. V8-isolate runtimes such as Cloudflare Workers and Vercel Edge are **not supported** by the native NAPI build (tracked under [#87](https://github.com/albert-einshutoin/lazy-image/issues/87) for future Wasm support).
-- **Bandwidth-sensitive JPEG delivery** — Smaller JPEG saves CDN and transfer costs in the canonical PNG → JPEG benchmarks.
+- **Bandwidth-sensitive JPEG delivery** — Smaller JPEG saves CDN and transfer costs in the two simple canonical PNG → JPEG benchmarks; multi-operation pipelines need their own measurement.
 - **AVIF output support** — Use when you need lazy-image's AVIF output path, ICC handling, and safety defaults; benchmark target AVIF workloads before assuming size or speed wins.
 - **Memory-constrained** — 512MB containers; `fromPath()` bypasses the V8 heap (read-into-memory ≤ 256 MB, mmap with advisory locks > 256 MB).
 - **Safety-first** — Rust memory safety; built-in decompression limits and Image Firewall.

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,6 +1,6 @@
 # Performance & When to Use
 
-lazy-image is optimized for **smaller output and memory safety** rather than raw throughput. This guide helps you choose between lazy-image and sharp and use lazy-image effectively.
+lazy-image is optimized for **JPEG output size and memory safety** rather than raw throughput. This guide helps you choose between lazy-image and sharp and use lazy-image effectively.
 
 ## Canonical Benchmark Source
 
@@ -14,10 +14,12 @@ For the full inventory of public claims and quoting rules, see [BENCHMARK_CLAIMS
 
 | Scenario | Metric | lazy-image | sharp | Interpretation |
 |---------|--------|------------|-------|----------------|
-| PNG → AVIF (no resize, 5000×5000) | Encode time | **3,137ms** | 5,320ms | lazy-image is **1.70x faster** in this specific format-conversion workload |
-| PNG → AVIF (no resize, 5000×5000) | Output size | **762,711 bytes** | 1,290,501 bytes | lazy-image output is **40.9% smaller** in this workload |
 | PNG → JPEG (no resize, 5000×5000) | Output size | **1,224,894 bytes** | 1,475,223 bytes | lazy-image output is **17.0% smaller** |
-| PNG → WebP (no resize, 5000×5000) | Encode time | 6,777ms | **975ms** | sharp is much faster for this workload |
+| PNG → JPEG (resize 800px, 5000×5000 input) | Output size | **31,518 bytes** | 39,416 bytes | lazy-image output is **20.0% smaller** |
+| PNG → JPEG (resize 800px, 5000×5000 input) | Encode time | **70ms** | 79ms | lazy-image was **1.13x faster** in this run |
+| PNG → AVIF (no resize, 5000×5000) | Encode time | 12,668ms | **4,729ms** | sharp is faster for this workload |
+| PNG → AVIF (no resize, 5000×5000) | Output size | 1,718,430 bytes | **1,290,501 bytes** | sharp output is smaller for this workload |
+| PNG → WebP (no resize, 5000×5000) | Encode time | 4,323ms | **909ms** | sharp is much faster for this workload |
 | JPEG/WebP real-time resize workloads | Latency | varies by codec and settings | often faster | use sharp if sub-100ms latency is the main priority |
 
 Full data: [TRUE_BENCHMARKS.md](./TRUE_BENCHMARKS.md).
@@ -27,8 +29,8 @@ Full data: [TRUE_BENCHMARKS.md](./TRUE_BENCHMARKS.md).
 ## When to Use lazy-image
 
 - **Node-runtime serverless (AWS Lambda, Google Cloud Run, Vercel Node Functions, Google Cloud Functions)** — Avoid OOM and smaller cold-start footprint. V8-isolate runtimes such as Cloudflare Workers and Vercel Edge are **not supported** by the native NAPI build (tracked under [#87](https://github.com/albert-einshutoin/lazy-image/issues/87) for future Wasm support).
-- **Bandwidth-sensitive** — Smaller JPEG/AVIF saves CDN and transfer costs.
-- **AVIF generation** — Strong results in the benchmarked PNG → AVIF format-conversion workloads.
+- **Bandwidth-sensitive JPEG delivery** — Smaller JPEG saves CDN and transfer costs in the canonical PNG → JPEG benchmarks.
+- **AVIF output support** — Use when you need lazy-image's AVIF output path, ICC handling, and safety defaults; benchmark target AVIF workloads before assuming size or speed wins.
 - **Memory-constrained** — 512MB containers; `fromPath()` bypasses the V8 heap (read-into-memory ≤ 256 MB, mmap with advisory locks > 256 MB).
 - **Safety-first** — Rust memory safety; built-in decompression limits and Image Firewall.
 
@@ -36,11 +38,11 @@ Full data: [TRUE_BENCHMARKS.md](./TRUE_BENCHMARKS.md).
 
 - **Heavy persistent servers** — Plenty of RAM and CPU.
 - **Throughput-critical** — Thousands of JPEG/WebP resizes per second.
-- **No AVIF** — Legacy formats only and maximum resize speed.
+- **AVIF/WebP speed or size is decisive** — Current canonical AVIF/WebP benchmarks favor sharp for speed, and often for output size.
 
 ## Philosophy
 
-lazy-image trades raw JPEG/WebP encoding speed for **smaller files** and **stable memory**. Treat benchmark wins as **codec- and workload-specific**, not universal throughput claims.
+lazy-image trades raw throughput for **JPEG compression efficiency**, **stable memory**, and **safe defaults**. Treat benchmark wins as **codec- and workload-specific**, not universal throughput claims.
 
 ---
 
@@ -65,7 +67,7 @@ await ImageEngine.from(buf).resize(800).toBuffer('jpeg', 80);
 - Build-time optimization (SSG, CI/CD)
 - Batch thumbnails / media pipelines
 - CDN / mobile backends
-- AVIF and WebP encoding (v0.8.1+ WebP tuned for speed)
+- AVIF and WebP encoding when feature support and safety defaults matter; benchmark when speed/size is critical
 - Color-accurate workflows (ICC preservation)
 
 ### When sharp may be better

--- a/docs/PROJECT_PHILOSOPHY.md
+++ b/docs/PROJECT_PHILOSOPHY.md
@@ -4,7 +4,7 @@
 
 ## Priorities
 
-1. Smaller JPEG outputs than typical `sharp` defaults for web delivery, with codec-specific claims for other formats.
+1. Smaller JPEG outputs than typical `sharp` defaults for simple web-delivery benchmarks, with codec- and pipeline-specific claims for other formats or operation chains.
 2. Predictable memory behavior and bounded-resource execution.
 3. Safe defaults for metadata, decompression limits, and operational use.
 4. A non-destructive, lazy pipeline API that fits batch and build workflows.
@@ -17,7 +17,7 @@
 
 ## How to interpret performance claims
 
-- For JPEG, `lazy-image` intentionally prioritizes smaller files in the canonical benchmarked scenarios.
+- For JPEG, `lazy-image` intentionally prioritizes smaller files in the two simple canonical benchmarked scenarios; additional operations can change the size result.
 - For WebP, do not assume smaller output or faster encoding; benchmark the target workload.
 - For AVIF, do not assume a blanket speed or size win over `sharp`; benchmark the target workload and treat any advantage as scenario-specific, not the project's primary identity.
 - The project should describe benchmark wins precisely by codec and workload, and avoid broad claims like "faster than sharp" without scope.

--- a/docs/PROJECT_PHILOSOPHY.md
+++ b/docs/PROJECT_PHILOSOPHY.md
@@ -4,7 +4,7 @@
 
 ## Priorities
 
-1. Smaller outputs than typical `sharp` defaults for web delivery.
+1. Smaller JPEG outputs than typical `sharp` defaults for web delivery, with codec-specific claims for other formats.
 2. Predictable memory behavior and bounded-resource execution.
 3. Safe defaults for metadata, decompression limits, and operational use.
 4. A non-destructive, lazy pipeline API that fits batch and build workflows.
@@ -17,6 +17,7 @@
 
 ## How to interpret performance claims
 
-- For JPEG/WebP, `lazy-image` intentionally trades encode latency for smaller files.
-- For AVIF, `lazy-image` may be faster than `sharp` in some real workloads, but that is an advantage within a narrower target area, not the project's primary identity.
+- For JPEG, `lazy-image` intentionally prioritizes smaller files in the canonical benchmarked scenarios.
+- For WebP, do not assume smaller output or faster encoding; benchmark the target workload.
+- For AVIF, do not assume a blanket speed or size win over `sharp`; benchmark the target workload and treat any advantage as scenario-specific, not the project's primary identity.
 - The project should describe benchmark wins precisely by codec and workload, and avoid broad claims like "faster than sharp" without scope.

--- a/docs/ROI_CALCULATOR.md
+++ b/docs/ROI_CALCULATOR.md
@@ -63,13 +63,13 @@ The README example uses `$0.085/GB` as a practical reference point, not a univer
 
 Assumptions:
 - `avg_size_mb_before = 1.0`
-- `reduction_percent = 25`
+- `reduction_percent = 18` (JPEG-oriented example, not a universal cross-codec reduction)
 - `cdn_cost_per_gb = 0.085`
 
 For `10,000,000` monthly deliveries:
 - `transfer_before_gb = 9,765.63 GB`
-- `saved_gb = 2,441.41 GB`
-- `monthly_bandwidth_savings_usd = 207.52`
+- `saved_gb = 1,757.81 GB`
+- `monthly_bandwidth_savings_usd = 149.41`
 
 ## Caveats
 

--- a/docs/TRUE_BENCHMARKS.md
+++ b/docs/TRUE_BENCHMARKS.md
@@ -12,8 +12,9 @@ Do not mix numbers from different workloads without clearly labeling the scenari
 
 This document provides comprehensive benchmark documentation showing the actual performance characteristics of lazy-image, with a focus on:
 
-- **AVIF encoding speed advantages** in a specific PNG → AVIF format-conversion workload
 - **JPEG file size advantages** in benchmarked web-delivery scenarios
+- **AVIF/WebP trade-offs** where current sharp results are often faster or smaller
+- **Copy and memory semantics** that distinguish V8-heap avoidance from codec working buffers
 
 ## Test Environment
 
@@ -26,68 +27,72 @@ All benchmarks use images from `test/fixtures/*` directory:
 
 | Item | Version/Spec |
 |------|--------------|
-| **Node.js** | v22.x |
-| **sharp** | 0.34.x |
+| **lazy-image** | v0.15.0 |
+| **Node.js** | v24.2.0 |
+| **sharp** | 0.34.5 |
 | **Test Images** | `test/fixtures/*` (test_4.5MB_5000x5000.png: 4.5MB, 5000×5000, test_100KB_*, etc.) |
-| **Output Size** | 800px width (auto height) |
+| **Output Size** | No-resize conversion and 800px width resize scenarios |
 | **Quality** | JPEG: 80, WebP: 80, AVIF: 60 |
-| **Platform** | macOS (Apple Silicon) |
-| **Test Date** | Actual benchmark results from test execution |
+| **Platform** | macOS 26.3, Apple M4 (arm64) |
+| **Test Date** | 2026-05-29 |
 
 **How to reproduce:**
 ```bash
-npm run test:bench:compare
+npm run test:bench
+node --expose-gc test/benchmarks/convert-only.bench.js
+npm run test:bench:extended
 ```
 
 > **Note**: Benchmark results may vary depending on hardware, Node.js version, and sharp version. These results are for reference only.
 
 ---
 
-## AVIF Encoding Speed Advantages
+## AVIF Current Trade-offs
 
-In the benchmarked no-resize PNG → AVIF scenario below, lazy-image outperforms sharp in AVIF encoding speed.
+In the current benchmarked PNG → AVIF scenarios below, sharp is faster and produces smaller AVIF output. Do not quote AVIF as a blanket speed or size win for lazy-image.
 
 ### Performance Results
 
-| Scenario | Format | lazy-image | sharp | Speed Advantage |
+| Scenario | Format | lazy-image | sharp | Outcome |
 | :--- | :--- | :--- | :--- | :--- |
-| **Speed (No Resize)** | **AVIF** | **3,137ms** 🚀 | 5,320ms | **1.70x Faster** |
-| **Speed (Resize 800px)** | **AVIF** | **180ms** ⚡ | 195ms | **1.08x Faster** |
-| **File Size (No Resize)** | **AVIF** | **762,711 bytes** 📉 | 1,290,501 bytes | **-40.9%** ✅ |
-| **File Size (Resize 800px)** | **AVIF** | **24,343 bytes** | 22,227 bytes | +9.5% |
+| **Speed (No Resize)** | **AVIF** | 12,668ms | **4,729ms** | lazy-image 0.37x speed ratio (sharp/lazy) |
+| **Speed (Resize 800px)** | **AVIF** | 442ms | **179ms** | lazy-image 0.40x speed ratio (sharp/lazy) |
+| **File Size (No Resize)** | **AVIF** | 1,718,430 bytes | **1,290,501 bytes** | **+33.2%** |
+| **File Size (Resize 800px)** | **AVIF** | 28,678 bytes | **22,227 bytes** | **+29.0%** |
 
 ### Technical Explanation
 
-lazy-image uses **ravif**, a pure Rust AVIF encoder based on AV1 compression. The speed advantages come from:
+lazy-image uses **libavif** through safe Rust wrappers. Current AVIF behavior is shaped by:
 
 1. **Optimized Speed Settings**: Quality-based speed tuning that balances encoding speed and file size
-   - Higher quality (70-80): Speed 4-6 (faster encoding)
-   - Medium quality (50-70): Speed 2-4 (balanced)
-   - Lower quality (30-50): Speed 1-2 (maximum compression)
+   - Higher quality (85+): Speed 6
+   - Balanced quality (70-84): Speed 7
+   - Speed-leaning quality (50-69): Speed 8
+   - Fastest lower-quality band (<50): Speed 9
 
-2. **RGB Encoding for Opaque Images**: Automatically detects RGB images and uses `encode_rgb()` instead of `encode_rgba()`, reducing file size by 5-10% for opaque images
+2. **libavif RGB/YUV handoff**: The encoder converts the image to RGBA8 (`img.to_rgba8()`), then asks libavif to convert into YUV planes. This is not a no-copy codec path.
 
-3. **Zero-Copy Architecture**: For format conversions without pixel manipulation, lazy-image's Copy-on-Write (CoW) architecture avoids intermediate buffer allocations
+3. **Input-path memory model**: `fromPath()` avoids staging the source file in the V8 heap, but codec-level working buffers and output buffers still exist.
 
-4. **Pure Rust Implementation**: No FFI overhead compared to sharp's libvips-based approach
+4. **Safety wrappers**: AVIF FFI calls are wrapped to keep unsafe blocks small and checked.
 
 ### Use Cases
 
 - **Batch AVIF generation**: Process large image galleries with AVIF format
 - **Build-time optimization**: Generate AVIF variants during static site generation
-- **CDN optimization**: Serve next-generation formats with faster encoding
+- **CDN optimization**: Serve next-generation formats when AVIF output is required, after benchmarking the target workload
 
 ### Example Usage
 
 ```javascript
 const { ImageEngine } = require('@alberteinshutoin/lazy-image');
 
-// Fast AVIF encoding
+// AVIF output with lazy-image defaults
 const avifBuffer = await ImageEngine.fromPath('test/fixtures/test_4.5MB_5000x5000.png')
   .resize(800, null)
-  .toBuffer('avif', 60); // Quality 60, optimized speed
+  .toBuffer('avif', 60); // Quality 60
 
-// Compare with sharp (slower)
+// Compare with sharp for your workload before making size/speed claims
 // const sharpAvif = await sharp('test/fixtures/test_4.5MB_5000x5000.png')
 //   .resize(800)
 //   .avif({ quality: 60 })
@@ -106,8 +111,8 @@ lazy-image produces significantly smaller JPEG files than sharp, thanks to mozjp
 | :--- | :--- | :--- | :--- | :--- |
 | **File Size (No Resize)** | **JPEG** | **1,224,894 bytes** 📉 | 1,475,223 bytes | **-17.0%** ✅ |
 | **File Size (Resize 800px)** | **JPEG** | **31,518 bytes** 📉 | 39,416 bytes | **-20.0%** ✅ |
-| **Speed (No Resize)** | JPEG | 668ms | **681ms** | **1.02x Faster** ⚡ |
-| **Speed (Resize 800px)** | JPEG | 115ms | **92ms** | 0.80x slower (optimized for size) |
+| **Speed (No Resize)** | JPEG | 700ms | **660ms** | 0.94x speed ratio (sharp/lazy) |
+| **Speed (Resize 800px)** | JPEG | **70ms** | 79ms | **1.13x speed ratio (sharp/lazy)** ⚡ |
 
 ### Technical Explanation: mozjpeg Optimization
 
@@ -176,7 +181,7 @@ const jpegBuffer = await ImageEngine.fromPath('test/fixtures/test_4.5MB_5000x500
   .resize(800, null)
   .toBuffer('jpeg', 80); // Quality 80, mozjpeg optimization
 
-// Result: 17-20% smaller than sharp with same quality
+// Result in canonical benchmarks: 17-20% smaller than sharp at the same quality setting
 ```
 
 ---
@@ -185,38 +190,52 @@ const jpegBuffer = await ImageEngine.fromPath('test/fixtures/test_4.5MB_5000x500
 
 ### Format Conversion Efficiency (No Resize)
 
-When converting formats without resizing, lazy-image's CoW architecture delivers exceptional performance:
+When converting formats without resizing, current results are codec-specific. CoW avoids unnecessary pipeline materialization, but encoders still allocate codec working buffers.
 
 | Conversion | lazy-image | sharp | Speed | File Size |
 |------------|------------|-------|-------|-----------|
-| **PNG → AVIF** | 3,137ms | 5,320ms | **1.70x faster** ⚡ | **-40.9%** ✅ |
-| **PNG → JPEG** | 668ms | 681ms | **1.02x faster** ⚡ | **-17.0%** ✅ |
-| **PNG → WebP** | 6,777ms | 975ms | 0.14x slower 🐢 | **-0.7%** ✅ |
+| **PNG → AVIF** | 12,668ms | 4,729ms | 0.37x speed ratio | +33.2% |
+| **PNG → JPEG** | 700ms | 660ms | 0.94x speed ratio | **-17.0%** ✅ |
+| **PNG → WebP** | 4,323ms | 909ms | 0.21x speed ratio | +2.4% |
 
 > *Pure format conversion without pixel manipulation. 4.5MB PNG (5000×5000) input from `test/fixtures/test_4.5MB_5000x5000.png`.*
 
-> *\* WebP encoding optimized in v0.8.1+: settings adjusted (method 4, single pass) to improve speed.*
+> *Speed ratio is `sharp time / lazy-image time`; values below 1.0 mean sharp was faster.*
 
-### Why the Difference?
+### Resize 800px Web-Delivery Scenario
 
-lazy-image's **zero-copy architecture** avoids intermediate buffer allocations during format conversion, making it ideal for batch processing pipelines:
+`npm run test:bench:compare` measured the following representative 800px resize results:
 
-1. **True Lazy Loading**: `fromPath()` creates a lightweight reference. File I/O only occurs when `toBuffer()`/`toFile()` is called.
-2. **Zero-Copy Conversions**: For format conversions (e.g., PNG → WebP) without pixel manipulation (resize/crop), **no pixel buffer allocation or copy occurs**. The engine reuses the decoded buffer directly.
-3. **Smart Cloning**: `.clone()` operations are instant and memory-free until a destructive operation is applied.
+| Scenario | lazy-image | sharp | Speed | File Size |
+|----------|------------|-------|-------|-----------|
+| **PNG → JPEG resize 800px** | 70ms / 31,518 bytes | 79ms / 39,416 bytes | 1.13x speed ratio | **-20.0%** ✅ |
+| **PNG → WebP resize 800px** | 166ms / 32,448 bytes | 90ms / 29,686 bytes | 0.54x speed ratio | +9.3% |
+| **PNG → AVIF resize 800px** | 442ms / 28,678 bytes | 179ms / 22,227 bytes | 0.40x speed ratio | +29.0% |
+| **Resize + rotate + grayscale → JPEG** | 68ms / 27,129 bytes | 112ms / 24,650 bytes | 1.65x speed ratio | +10.1% |
+
+### Copy and Allocation Scope
+
+lazy-image's **zero-copy** claim is about the input crossing the JS boundary, not about every internal codec step:
+
+1. **V8-heap avoidance**: `fromPath()` and `processBatch()` do not place source bytes in the Node.js heap. Files <= 256 MB are read into Rust-owned memory; files > 256 MB use mmap with advisory locks.
+2. **Pipeline CoW**: A format-only path can avoid materializing operation outputs, while resize/crop/rotate/grayscale materialize transformed images.
+3. **Codec buffers**: Encoders allocate output and working buffers. AVIF currently materializes an RGBA8 buffer and libavif YUV/alpha planes.
+4. **Smart cloning**: `.clone()` shares pipeline state until divergent or destructive work is applied.
+
+See [ZERO_COPY.md](./ZERO_COPY.md) for the precise scope and validation method.
 
 ---
 
 ## Key Advantages Summary
 
 ```
-AVIF: 1.70x faster encoding (format conversion) + 40.9% smaller files
-JPEG: 17-20% smaller files (optimized for compression ratio)
-WebP: 0.7% smaller files (but slower encoding)
-Memory: Zero-copy architecture for format conversions
+JPEG: 17-20% smaller files in benchmarked PNG -> JPEG scenarios
+AVIF: current PNG -> AVIF benchmarks are slower and larger than sharp
+WebP: current PNG -> WebP benchmarks are slower and similar/larger than sharp
+Memory: fromPath avoids V8-heap input copies; codec working buffers still exist
 ```
 
-**Summary**: lazy-image excels at **AVIF generation** in the benchmarked format-conversion workload and **JPEG compression efficiency** in the benchmarked delivery-oriented scenarios. For WebP, lazy-image produces slightly smaller files but with slower encoding speed.
+**Summary**: lazy-image's current public size advantage is strongest for **JPEG compression efficiency** in the benchmarked delivery-oriented scenarios. AVIF and WebP must be treated as workload-specific trade-offs, not blanket wins over sharp.
 
 ---
 
@@ -231,10 +250,10 @@ All benchmarks use images from `test/fixtures/*` directory:
 
 ### Test Procedure
 
-1. **Warm-up**: Run each test 3 times to warm up the JIT compiler
-2. **Measurement**: Run each test 10-30 times and calculate average
-3. **Comparison**: Compare lazy-image vs sharp with identical parameters
-4. **Validation**: Verify output quality is visually equivalent
+1. **Comparison**: Compare lazy-image vs sharp with identical format, quality, and resize parameters.
+2. **Scenario separation**: Keep no-resize conversion, resize, memory, and cold-start results separate.
+3. **Iteration counts**: Use each benchmark script's own warm-up and iteration settings; some scripts are representative single-run checks while extended matrix benchmarks average multiple runs.
+4. **Validation**: Track file size, wall-clock timing, and quality metrics where the script reports them. Public claims should cite only the measured scenario.
 
 ### Reproducing Benchmarks
 
@@ -267,8 +286,9 @@ For ongoing CI/threshold operation rules, see [docs/BENCHMARK_OPERATIONS.md](./B
 
 ### Performance Trade-offs
 
-- **JPEG encoding speed**: lazy-image prioritizes compression ratio over raw encoding speed. This means slightly longer processing times (2-3x) but significantly smaller files (up to 50% reduction). This trade-off is intentional to save bandwidth costs.
-- **Real-time processing**: For strict latency requirements (<100ms), sharp may be more suitable due to its faster JPEG encoding.
+- **JPEG encoding speed**: lazy-image prioritizes compression ratio and produced 17-20% smaller JPEG outputs in the current benchmarked PNG -> JPEG scenarios. Speed was comparable in these runs and should be remeasured on target hardware.
+- **AVIF/WebP encoding speed and size**: current PNG -> AVIF and PNG -> WebP benchmarks favor sharp for speed, and often for output size.
+- **Real-time processing**: For strict latency requirements (<100ms), benchmark the target codec and image mix before choosing lazy-image.
 
 ### Test Environment Variations
 
@@ -287,22 +307,23 @@ These benchmarks are for reference only and should be validated in your specific
 
 lazy-image provides significant advantages in:
 
-1. **AVIF encoding speed**: 1.70x faster than sharp for format conversion, making it ideal for next-generation image formats
-2. **JPEG file size**: 17-20% smaller files through mozjpeg optimization, reducing bandwidth costs
-3. **Memory efficiency**: Zero-copy architecture for format conversions
+1. **JPEG file size**: 17-20% smaller files through mozjpeg optimization in the canonical PNG -> JPEG scenarios
+2. **Memory efficiency**: `fromPath()` avoids V8-heap input copies and keeps decoded pixels in Rust memory
+3. **Operational safety**: metadata stripping, Image Firewall, structured errors, and panic guards
 4. **Build-time optimization**: Ideal for static site generation and CI/CD pipelines
 
 Choose lazy-image when:
-- File size optimization is critical (bandwidth savings)
-- AVIF generation is needed (speed advantage)
+- JPEG file size optimization is critical (bandwidth savings)
+- Native AVIF/WebP/JPEG output support is needed and you have benchmarked the target workload
 - Memory constraints exist (serverless, containers)
 - Batch processing is acceptable (build-time optimization)
 
 Choose sharp when:
 - Real-time processing with strict latency requirements (<100ms)
 - Maximum throughput is needed (high-volume processing)
+- AVIF/WebP speed or size is the primary decision criterion in the current benchmarked scenarios
 - Complex operations are needed (advanced filters, color space conversions)
 
 ---
 
-*Last updated: Based on lazy-image v0.12.0 and sharp v0.34.x. Re-run `npm run test:bench` periodically to reflect encoder and dependency changes.*
+*Last updated: 2026-05-29, based on lazy-image v0.15.0, Node.js v24.2.0, and sharp v0.34.5. Re-run `npm run test:bench`, `node --expose-gc test/benchmarks/convert-only.bench.js`, and `npm run test:bench:extended` when encoder dependencies or public claims change.*

--- a/docs/TRUE_BENCHMARKS.md
+++ b/docs/TRUE_BENCHMARKS.md
@@ -159,7 +159,7 @@ lazy-image uses **mozjpeg** (Mozilla's JPEG encoder) with aggressive web optimiz
 
 ### Trade-offs
 
-**File Size vs Speed**: lazy-image prioritizes compression ratio (smaller file sizes) over raw encoding speed for JPEG. This results in:
+**File Size vs Speed**: lazy-image prioritizes compression ratio (smaller file sizes) over raw encoding speed for JPEG. In the two simple PNG -> JPEG cases this results in:
 - **Smaller files** (17-20% reduction) to save bandwidth costs
 - **Comparable or slightly longer processing times** compared to sharp (depending on scenario)
 - **Intentional trade-off**: Bandwidth savings often outweigh processing time in web applications
@@ -181,7 +181,7 @@ const jpegBuffer = await ImageEngine.fromPath('test/fixtures/test_4.5MB_5000x500
   .resize(800, null)
   .toBuffer('jpeg', 80); // Quality 80, mozjpeg optimization
 
-// Result in canonical benchmarks: 17-20% smaller than sharp at the same quality setting
+// Result in simple canonical JPEG benchmarks: 17-20% smaller than sharp at the same quality setting
 ```
 
 ---
@@ -229,7 +229,7 @@ See [ZERO_COPY.md](./ZERO_COPY.md) for the precise scope and validation method.
 ## Key Advantages Summary
 
 ```
-JPEG: 17-20% smaller files in benchmarked PNG -> JPEG scenarios
+JPEG: 17-20% smaller files in simple PNG -> JPEG no-resize and resize-800px scenarios
 AVIF: current PNG -> AVIF benchmarks are slower and larger than sharp
 WebP: current PNG -> WebP benchmarks are slower and similar/larger than sharp
 Memory: fromPath avoids V8-heap input copies; codec working buffers still exist
@@ -286,7 +286,7 @@ For ongoing CI/threshold operation rules, see [docs/BENCHMARK_OPERATIONS.md](./B
 
 ### Performance Trade-offs
 
-- **JPEG encoding speed**: lazy-image prioritizes compression ratio and produced 17-20% smaller JPEG outputs in the current benchmarked PNG -> JPEG scenarios. Speed was comparable in these runs and should be remeasured on target hardware.
+- **JPEG encoding speed**: lazy-image prioritizes compression ratio and produced 17-20% smaller JPEG outputs in the two simple current benchmarked PNG -> JPEG scenarios. Speed was comparable in these runs and should be remeasured on target hardware.
 - **AVIF/WebP encoding speed and size**: current PNG -> AVIF and PNG -> WebP benchmarks favor sharp for speed, and often for output size.
 - **Real-time processing**: For strict latency requirements (<100ms), benchmark the target codec and image mix before choosing lazy-image.
 
@@ -307,7 +307,7 @@ These benchmarks are for reference only and should be validated in your specific
 
 lazy-image provides significant advantages in:
 
-1. **JPEG file size**: 17-20% smaller files through mozjpeg optimization in the canonical PNG -> JPEG scenarios
+1. **JPEG file size**: 17-20% smaller files through mozjpeg optimization in the two simple canonical PNG -> JPEG scenarios
 2. **Memory efficiency**: `fromPath()` avoids V8-heap input copies and keeps decoded pixels in Rust memory
 3. **Operational safety**: metadata stripping, Image Firewall, structured errors, and panic guards
 4. **Build-time optimization**: Ideal for static site generation and CI/CD pipelines

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@alberteinshutoin/lazy-image",
   "version": "0.15.0",
-  "description": "Web image optimization engine for Node.js - smaller files than sharp, powered by Rust + mozjpeg",
+  "description": "Web image optimization engine for Node.js - smaller JPEG files than sharp in canonical benchmarks, powered by Rust + mozjpeg",
   "main": "index.js",
   "exports": {
     ".": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@alberteinshutoin/lazy-image",
   "version": "0.15.0",
-  "description": "Web image optimization engine for Node.js - smaller JPEG files than sharp in canonical benchmarks, powered by Rust + mozjpeg",
+  "description": "Web image optimization engine for Node.js - smaller JPEG files in simple canonical benchmarks, powered by Rust + mozjpeg",
   "main": "index.js",
   "exports": {
     ".": {

--- a/test/benchmarks/convert-only.bench.js
+++ b/test/benchmarks/convert-only.bench.js
@@ -2,10 +2,10 @@
  * Benchmark: Format Conversion Only (No Resize)
  * 
  * This benchmark tests pure format conversion without pixel manipulation.
- * lazy-image's Copy-on-Write (CoW) architecture should excel here:
- * - No intermediate buffer allocations
- * - Direct decode → encode pipeline
- * - Memory efficiency advantage
+ * This isolates codec behavior from resize/crop/rotate work:
+ * - Direct decode -> encode pipeline
+ * - No operation materialization
+ * - Codec-level working buffers still exist
  */
 
 const fs = require('fs');
@@ -93,7 +93,7 @@ async function benchmarkSharpConvert(format, quality) {
 async function runBenchmark() {
     console.log('=== Format Conversion Benchmark (No Resize) ===\n');
     console.log('This test measures pure format conversion performance.');
-    console.log('lazy-image\'s CoW architecture should excel here.\n');
+    console.log('This isolates codec behavior from resize/crop/rotate work.\n');
     console.log(`Input: ${TEST_IMAGE}`);
     const stats = fs.statSync(TEST_IMAGE);
     console.log(`Size: ${(stats.size / 1024 / 1024).toFixed(1)} MB\n`);
@@ -197,4 +197,3 @@ runBenchmark()
         cleanup();
         process.exit(1);
     });
-


### PR DESCRIPTION
## Summary
- Refreshes canonical benchmark docs for lazy-image v0.15.0 / sharp v0.34.5 using current local benchmark output.
- Replaces stale AVIF/WebP speed and size wins with scenario-specific trade-offs, and narrows the public safe claim to 17-20% smaller JPEG outputs.
- Clarifies zero-copy/copy semantics: file-path inputs avoid V8 heap copies, while codec working buffers still exist, including AVIF RGBA/YUV handoff.

## Validation
- `npm run test:bench`
- `node --expose-gc test/benchmarks/convert-only.bench.js`
- `npm run test:bench:extended`
- `npm run test:bench:verify`
- `git diff --check`
- `npm run build`
- `npm test`

Closes #619
