### PR TITLE
docs: update README architecture overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,17 +39,19 @@ console.log(`Wrote ${bytesWritten} bytes`);
 ## Architecture Overview
 
 ```
-src/                        # Rust core
+src/                        # selected high-level Rust core modules
 ├── engine/
-│   ├── api.rs              # ImageEngine public API + NAPI bindings
-│   ├── pipeline.rs         # Operation queue, validation, optimization
+│   ├── api/                # ImageEngine public API + NAPI-facing operations
+│   ├── pipeline/           # Operation application, color state, capabilities, optimization
+│   ├── tasks/              # NAPI async task contexts and encode/batch/write execution
+│   ├── memory/             # Cgroup detection, memory estimates, weighted semaphore
+│   ├── io/                 # File sources, mmap, ICC/EXIF extraction and embedding
 │   ├── resize.rs           # Dimension calc, fast_image_resize dispatch
-│   ├── tasks.rs            # NAPI async tasks (encode, batch, target-bytes)
 │   ├── encoder.rs          # JPEG/PNG/WebP/AVIF encoding + ICC/EXIF embedding
 │   ├── decoder.rs          # Format detection + decoding
 │   ├── firewall.rs         # Input sanitization policies
-│   ├── memory.rs           # Cgroup detection, concurrency estimation
-│   └── io.rs               # File I/O, mmap, ICC/EXIF extraction
+│   ├── metadata.rs         # Metadata policy and preservation state
+│   └── validation.rs       # Input, operation, and output validation helpers
 ├── ops.rs                  # Operation enum, presets, output formats
 ├── error.rs                # 4-tier error taxonomy (E1xx–E9xx)
 └── codecs/avif_safe.rs     # Safe libavif FFI wrappers

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,7 +16,7 @@ lazy-image uses a **Copy-on-Write (CoW)** design and avoids the V8 (JS) heap on 
 2. **V8-heap bypass for file inputs** — `fromPath()` and `processBatch()` never copy the source file into the Node.js heap. Implementation is size-tiered to eliminate SIGBUS/SIGSEGV risk:
    - **Files ≤ 256 MB**: read once into a Rust-owned buffer (no mmap).
    - **Files > 256 MB**: opened via `mmap` with an advisory lock + fd retained for the engine lifetime.
-   The size threshold (`MMAP_SIZE_THRESHOLD`) lives in [`src/engine/io.rs`](../src/engine/io.rs).
+   The size threshold (`MMAP_SIZE_THRESHOLD`) lives in [`src/engine/io/mod.rs`](../src/engine/io/mod.rs).
 3. **Zero-copy conversions** — Format conversion without resize/crop reuses the decoded buffer (no extra pixel buffer).
 4. **Clone** — `.clone()` is cheap and does not allocate until a destructive op runs.
 5. **Verification** — See [ZERO_COPY.md](./ZERO_COPY.md). Run `node --expose-gc docs/scripts/measure-zero-copy.js` to check heap/RSS.


### PR DESCRIPTION
## Summary
- Update README Architecture Overview to show the current split engine submodules (`api/`, `pipeline/`, `tasks/`, `memory/`, `io/`).
- Keep the overview concise and refresh the architecture deep-link path for `src/engine/io/mod.rs`.
- Verified README.ja has no matching stale architecture diagram.

## Validation
- `npm run test:pack-contract`
- `npm run build`
- `npm test`

Closes #620