### PR TITLE
ci: gate default-feature clippy

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -172,11 +172,16 @@ jobs:
       - name: Check formatting
         run: cargo fmt --check
 
-      - name: Run Clippy
+      # Default features are the shipping Rust surface: NAPI bindings, jemalloc
+      # where supported, and AVIF support. Gate it separately from lean builds.
+      - name: Run Clippy (default features)
+        run: cargo clippy -- -D warnings
+
+      - name: Run Clippy (without default features)
         run: cargo clippy --no-default-features -- -D warnings
 
       # The `stress` feature (example: stress_test) is not built by the default
-      # clippy/test jobs, so type changes can break it invisibly. Gate it here.
+      # or no-default clippy/test jobs, so type changes can break it invisibly.
       - name: Check stress feature compiles
         run: cargo clippy --no-default-features --features stress -- -D warnings
 

--- a/src/codecs/avif_safe.rs
+++ b/src/codecs/avif_safe.rs
@@ -41,10 +41,7 @@ impl SafeAvifImage {
         if width > MAX_DIMENSION || height > MAX_DIMENSION {
             return Err(LazyImageError::encode_failed(
                 "avif",
-                format!(
-                    "Dimensions exceed MAX_DIMENSION {} ({}x{})",
-                    MAX_DIMENSION, width, height
-                ),
+                format!("Dimensions exceed MAX_DIMENSION {MAX_DIMENSION} ({width}x{height})"),
             ));
         }
 
@@ -55,7 +52,7 @@ impl SafeAvifImage {
         if pixels > MAX_PIXELS {
             return Err(LazyImageError::encode_failed(
                 "avif",
-                format!("Pixel count {} exceeds MAX_PIXELS {}", pixels, MAX_PIXELS),
+                format!("Pixel count {pixels} exceeds MAX_PIXELS {MAX_PIXELS}"),
             ));
         }
 
@@ -143,7 +140,7 @@ impl SafeAvifImage {
         if result != AVIF_RESULT_OK {
             return Err(LazyImageError::encode_failed(
                 "avif",
-                format!("Failed to set ICC profile: {:?}", result),
+                format!("Failed to set ICC profile: {result:?}"),
             ));
         }
         Ok(())
@@ -168,7 +165,7 @@ impl SafeAvifImage {
         if result != AVIF_RESULT_OK {
             return Err(LazyImageError::encode_failed(
                 "avif",
-                format!("Failed to allocate planes: {:?}", result),
+                format!("Failed to allocate planes: {result:?}"),
             ));
         }
         Ok(())
@@ -195,7 +192,7 @@ impl SafeAvifImage {
         if result != AVIF_RESULT_OK {
             return Err(LazyImageError::encode_failed(
                 "avif",
-                format!("Failed to convert RGB to YUV: {:?}", result),
+                format!("Failed to convert RGB to YUV: {result:?}"),
             ));
         }
         Ok(())
@@ -382,7 +379,7 @@ impl SafeAvifEncoder {
         if result != AVIF_RESULT_OK {
             return Err(LazyImageError::encode_failed(
                 "avif",
-                format!("Failed to add image to encoder: {:?}", result),
+                format!("Failed to add image to encoder: {result:?}"),
             ));
         }
         Ok(())
@@ -409,7 +406,7 @@ impl SafeAvifEncoder {
         if result != AVIF_RESULT_OK {
             return Err(LazyImageError::encode_failed(
                 "avif",
-                format!("Failed to finish encoding: {:?}", result),
+                format!("Failed to finish encoding: {result:?}"),
             ));
         }
         Ok(())

--- a/src/engine/api/pipeline_ops.rs
+++ b/src/engine/api/pipeline_ops.rs
@@ -177,7 +177,7 @@ impl ImageEngine {
         if xmp && !self.xmp_warning_emitted {
             let warning =
                 "keepMetadata: XMP preservation is not implemented yet; XMP data will be stripped.";
-            eprintln!("{}", warning);
+            eprintln!("{warning}");
             self.xmp_warning_emitted = true;
         }
 

--- a/src/engine/memory/cgroup.rs
+++ b/src/engine/memory/cgroup.rs
@@ -177,7 +177,7 @@ fn strip_mount_root(root: &str, rel: &str) -> String {
 fn join_mount_rel_file(mount_point: &str, rel: &str, file: &str) -> String {
     let base = mount_point.trim_end_matches('/');
     if rel.is_empty() {
-        return format!("{}/{}", base, file);
+        return format!("{base}/{file}");
     }
     format!("{}/{}/{}", base, rel.trim_start_matches('/'), file)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ fn read_inspect_metadata<R: BufRead + Seek>(
         .with_guessed_format()
         .map_err(|e| LazyImageError::decode_failed(format!("failed to read image header: {e}")))?;
 
-    let format = reader.format().map(|f| format!("{:?}", f).to_lowercase());
+    let format = reader.format().map(|f| format!("{f:?}").to_lowercase());
     let (width, height) = reader
         .into_dimensions()
         .map_err(|e| LazyImageError::decode_failed(format!("failed to read dimensions: {e}")))?;


### PR DESCRIPTION
## Summary
- Add a Rust Quality CI step for `cargo clippy -- -D warnings` so the default shipping feature set is gated.
- Keep the existing no-default-features and stress clippy gates.
- Document why default features need a separate clippy pass.

## Validation
- `cargo clippy -- -D warnings`
- `cargo clippy --no-default-features -- -D warnings`
- `cargo clippy --no-default-features --features stress -- -D warnings`
- `cargo fmt --check`
- `npm run build`
- `npm test`

Closes #623