### PR TITLE
docs: document PNG/WebP EXIF support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -254,7 +254,7 @@ jobs:
         run: node test/helpers/create-test-image.js
 
       - name: Test
-        run: npm test
+        run: npm run test:js
 
   quality:
     name: Quality Regression

--- a/docs/METADATA_SUPPORT.md
+++ b/docs/METADATA_SUPPORT.md
@@ -33,14 +33,16 @@ await ImageEngine.fromPath('input.jpg')
 | Output format | ICC | EXIF | GPS | XMP | Notes |
 |---|---|---|---|---|---|
 | JPEG | supported | supported | stripped by default, opt-in preserve | not supported | Orientation is normalized after auto-orient |
-| PNG | ICC supported | not currently documented as preserved | n/a | not supported | PNG metadata support is narrower than JPEG |
-| WebP | ICC supported | not currently documented as preserved | n/a | not supported | Favor explicit testing before relying on non-ICC metadata |
-| AVIF | ICC supported on v0.9.x+ with `libavif-sys` | not currently documented as preserved | n/a | not supported | On older/alternate backend builds ICC may be dropped |
+| PNG | supported | supported via `eXIf` chunk | stripped by default when EXIF is preserved | not supported | Orientation is normalized after auto-orient |
+| WebP | supported | supported via `EXIF` chunk | stripped by default when EXIF is preserved | not supported | Orientation is normalized after auto-orient |
+| AVIF | supported on v0.9.x+ with `libavif-sys` | not supported | n/a | not supported | On older/alternate backend builds ICC may be dropped |
 
 ## Important Caveats
 
 - `xmp: true` currently does **not** preserve XMP. It only emits a warning and continues processing.
-- EXIF Orientation is reset to `1` after auto-orient to avoid downstream double rotation.
+- JPEG, PNG, and WebP EXIF preservation is a documented support guarantee when `keepMetadata({ exif: true })` is set and the input contains EXIF. lazy-image writes sanitized EXIF into JPEG APP1, PNG `eXIf`, and WebP `EXIF` containers.
+- EXIF Orientation is reset to `1` after auto-orient for JPEG, PNG, and WebP outputs to avoid downstream double rotation.
+- GPS data inside EXIF is stripped by default for JPEG, PNG, and WebP outputs. Use `keepMetadata({ exif: true, stripGps: false })` only when location metadata must be retained.
 - `sanitize({ policy: 'strict' })` can override metadata preservation and strip metadata for safety.
 - For workflows that depend on exact metadata retention, validate behavior in integration tests against your target output format.
 
@@ -49,7 +51,7 @@ await ImageEngine.fromPath('input.jpg')
 - Web delivery: keep the default strip behavior unless ICC/EXIF is genuinely required
 - Photography / color-sensitive workflows: opt into ICC explicitly
 - Privacy-sensitive uploads: keep GPS stripping enabled
-- Metadata-critical pipelines: prefer JPEG if you need the clearest documented EXIF path today
+- Metadata-critical pipelines: JPEG, PNG, and WebP have documented EXIF preservation paths; prefer JPEG if downstream tools do not read PNG `eXIf` or WebP `EXIF` chunks reliably
 
 ## References
 

--- a/docs/METADATA_SUPPORT.md
+++ b/docs/METADATA_SUPPORT.md
@@ -24,7 +24,7 @@ await ImageEngine.fromPath('input.jpg')
 | Metadata type | Default | Opt-in API | Current status |
 |---|---|---|---|
 | ICC | stripped | `keepMetadata({ icc: true })` | supported |
-| EXIF | stripped | `keepMetadata({ exif: true })` | supported |
+| EXIF | stripped | `keepMetadata({ exif: true })` | supported for extractable JPEG EXIF |
 | GPS | stripped | `keepMetadata({ exif: true, stripGps: false })` | supported, privacy-first default is strip |
 | XMP | stripped | `keepMetadata({ xmp: true })` | not supported, emits runtime warning |
 
@@ -40,7 +40,8 @@ await ImageEngine.fromPath('input.jpg')
 ## Important Caveats
 
 - `xmp: true` currently does **not** preserve XMP. It only emits a warning and continues processing.
-- JPEG, PNG, and WebP EXIF preservation is a documented support guarantee when `keepMetadata({ exif: true })` is set and the input contains EXIF. lazy-image writes sanitized EXIF into JPEG APP1, PNG `eXIf`, and WebP `EXIF` containers.
+- JPEG, PNG, and WebP EXIF preservation is a documented support guarantee when `keepMetadata({ exif: true })` is set and the input is a JPEG with extractable EXIF. EXIF extraction is capped at 8 MiB of source data to avoid copying unbounded metadata from oversized inputs.
+- lazy-image writes sanitized EXIF into JPEG APP1, PNG `eXIf`, and WebP `EXIF` containers.
 - EXIF Orientation is reset to `1` after auto-orient for JPEG, PNG, and WebP outputs to avoid downstream double rotation.
 - GPS data inside EXIF is stripped by default for JPEG, PNG, and WebP outputs. Use `keepMetadata({ exif: true, stripGps: false })` only when location metadata must be retained.
 - `sanitize({ policy: 'strict' })` can override metadata preservation and strip metadata for safety.


### PR DESCRIPTION
## Summary
- Document PNG `eXIf` and WebP `EXIF` preservation as supported when `keepMetadata({ exif: true })` is set.
- Record tested privacy semantics: orientation reset and GPS stripped by default.
- Qualify EXIF preservation to extractable JPEG EXIF with the current 8 MiB source extraction cap.
- Clarify AVIF remains ICC-only for metadata preservation.
- Keep the CI Node/OS matrix focused on JS/NAPI tests; Rust tests remain covered by the dedicated Rust Tests job.

## Validation
- `node test/integration/exif-roundtrip.test.js`
- `npm run test:pack-contract`
- `npm run build`
- `npm test`

## CI follow-up
- Initial CI failed on Windows Node 22 during `npm ci` with `ECONNRESET`.
- Initial CI failed on Windows Node 18 because the Node matrix ran full `npm test`, redundantly cold-compiling Rust tests until the 20-minute job timeout.
- Updated the Node matrix to run `npm run test:js`, matching its prebuilt NAPI artifact validation role while keeping Rust coverage in `test-rust`.

## Review follow-up
- Addressed the Codex review by documenting that EXIF preservation depends on extractable JPEG EXIF and the 8 MiB source extraction cap.

Closes #622