### PR TITLE
ci: cache dependencies and dedupe nasm setup

### DIFF
--- a/.github/actions/setup-nasm/action.yml
+++ b/.github/actions/setup-nasm/action.yml
@@ -1,0 +1,19 @@
+name: Setup NASM
+description: Install NASM on Linux, macOS, and Windows runners.
+
+runs:
+  using: composite
+  steps:
+    - name: Install NASM (Linux)
+      if: runner.os == 'Linux'
+      shell: bash
+      run: sudo apt-get update && sudo apt-get install -y nasm
+
+    - name: Install NASM (macOS)
+      if: runner.os == 'macOS'
+      shell: bash
+      run: brew install nasm
+
+    - name: Install NASM (Windows)
+      if: runner.os == 'Windows'
+      uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,17 +45,14 @@ jobs:
           # Linux (glibc)
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            build: |
-              sudo apt-get update
-              sudo apt-get install -y nasm
-              npm run build -- --target x86_64-unknown-linux-gnu
+            build: npm run build -- --target x86_64-unknown-linux-gnu
 
           # Linux (glibc, ARM64)
           - host: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             build: |
               sudo apt-get update
-              sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu lld nasm
+              sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu lld
               export CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc
               export CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++
               export AR_aarch64_unknown_linux_gnu=aarch64-linux-gnu-ar
@@ -67,7 +64,7 @@ jobs:
             target: x86_64-unknown-linux-musl
             build: |
               sudo apt-get update
-              sudo apt-get install -y musl-tools nasm
+              sudo apt-get install -y musl-tools
               npm run build -- --target x86_64-unknown-linux-musl
 
     name: Build - ${{ matrix.settings.target }}
@@ -80,6 +77,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 20
+          cache: npm
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -87,13 +85,14 @@ jobs:
           toolchain: 1.88.0
           targets: ${{ matrix.settings.target }}
 
-      - name: Install NASM (macOS)
-        if: matrix.settings.host == 'macos-latest'
-        run: brew install nasm
+      - name: Setup NASM
+        uses: ./.github/actions/setup-nasm
 
-      - name: Install NASM (Windows)
-        if: matrix.settings.host == 'windows-latest'
-        uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1
+      - name: Cache Cargo dependencies
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          cache-on-failure: true
+          shared-key: build-${{ matrix.settings.target }}
 
       - name: Install dependencies
         run: npm ci
@@ -125,13 +124,8 @@ jobs:
         with:
           toolchain: 1.88.0
 
-      - name: Install NASM (Linux)
-        if: matrix.host == 'ubuntu-latest'
-        run: sudo apt-get update && sudo apt-get install -y nasm
-
-      - name: Install NASM (macOS)
-        if: matrix.host == 'macos-14'
-        run: brew install nasm
+      - name: Setup NASM
+        uses: ./.github/actions/setup-nasm
 
       - name: Cache Cargo dependencies
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -161,8 +155,8 @@ jobs:
           toolchain: 1.88.0
           components: clippy, rustfmt
 
-      - name: Install NASM
-        run: sudo apt-get update && sudo apt-get install -y nasm
+      - name: Setup NASM
+        uses: ./.github/actions/setup-nasm
 
       - name: Cache Cargo dependencies
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -196,6 +190,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 20
+          cache: npm
 
       - name: Install dependencies
         run: npm ci
@@ -228,21 +223,13 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: ${{ matrix.node }}
+          cache: npm
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Install NASM (Linux)
-        if: matrix.settings.host == 'ubuntu-latest'
-        run: sudo apt-get update && sudo apt-get install -y nasm
-
-      - name: Install NASM (macOS)
-        if: matrix.settings.host == 'macos-14'
-        run: brew install nasm
-
-      - name: Install NASM (Windows)
-        if: matrix.settings.host == 'windows-latest'
-        uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1
+      - name: Setup NASM
+        uses: ./.github/actions/setup-nasm
 
       - name: Download artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -269,9 +256,10 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 20
+          cache: npm
 
-      - name: Install NASM
-        run: sudo apt-get update && sudo apt-get install -y nasm
+      - name: Setup NASM
+        uses: ./.github/actions/setup-nasm
 
       - name: Install dependencies
         run: npm ci
@@ -304,9 +292,10 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 20
+          cache: npm
 
-      - name: Install NASM
-        run: sudo apt-get update && sudo apt-get install -y nasm
+      - name: Setup NASM
+        uses: ./.github/actions/setup-nasm
 
       - name: Install dependencies
         run: npm ci
@@ -336,6 +325,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 20
+          cache: npm
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -386,8 +376,8 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@617b2c1f0f6355a96a120720d1c14499d0e12814 # cargo-llvm-cov
 
-      - name: Install NASM
-        run: sudo apt-get update && sudo apt-get install -y nasm
+      - name: Setup NASM
+        uses: ./.github/actions/setup-nasm
 
       - name: Cache Cargo dependencies
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -398,6 +388,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 20
+          cache: npm
 
       - name: Install dependencies
         run: npm ci
@@ -430,9 +421,13 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 20
+          cache: npm
+
+      - name: Setup NASM
+        uses: ./.github/actions/setup-nasm
 
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y nasm lld
+        run: sudo apt-get update && sudo apt-get install -y lld
 
       - name: Install npm dependencies
         run: npm ci
@@ -532,6 +527,7 @@ jobs:
           node-version: 20
           registry-url: https://registry.npmjs.org
           scope: '@alberteinshutoin'
+          cache: npm
       
       # Note: OIDC authentication only works during npm publish
       # npm whoami will not work with OIDC - this is expected behavior

--- a/.github/workflows/benchmark-regression.yml
+++ b/.github/workflows/benchmark-regression.yml
@@ -41,6 +41,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 20
+          cache: npm
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -48,8 +49,8 @@ jobs:
           toolchain: 1.88.0
           targets: x86_64-unknown-linux-gnu
 
-      - name: Install NASM
-        run: sudo apt-get update && sudo apt-get install -y nasm
+      - name: Setup NASM
+        uses: ./.github/actions/setup-nasm
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -65,10 +65,13 @@ jobs:
       - name: Install cargo-fuzz
         run: cargo +${FUZZ_TOOLCHAIN} install cargo-fuzz --locked
 
+      - name: Setup NASM
+        uses: ./.github/actions/setup-nasm
+
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake nasm clang lld
+          sudo apt-get install -y cmake clang lld
 
       - name: Cache cargo registry
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -71,6 +71,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 20
+          cache: npm
       
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
- Enable npm dependency caching for every workflow job that runs `npm ci`.
- Add Cargo cache coverage to the main CI build matrix.
- Move NASM setup into a local composite action and reuse it from CI, benchmark, and fuzz workflows.

## Notes
- The latest `develop` already includes `windows-latest` in the integration test matrix, so this keeps that #547 acceptance item intact while completing the remaining cache/setup items.

## Validation
- `git diff --check`
- `ruby -e 'require "psych"; ARGV.each { |f| Psych.parse_file(f); puts "#{f}: ok" }' .github/workflows/CI.yml .github/workflows/benchmark-regression.yml .github/workflows/security.yml .github/workflows/fuzz.yml .github/actions/setup-nasm/action.yml`\n- `npm run build`\n- `npm test`\n\nCloses #547\nRefs #624