### PR TITLE
wasm: add upload preflight MVP package

### DIFF
--- a/docs/WASM_BENCHMARKING.md
+++ b/docs/WASM_BENCHMARKING.md
@@ -5,6 +5,9 @@ It complements the native sharp comparison benchmarks; it does not replace
 `TRUE_BENCHMARKS.md` as the source for public native performance claims.
 The planned package and policy API is defined in
 [WASM_PACKAGE_API.md](./WASM_PACKAGE_API.md).
+The initial implementation package lives in `packages/lazy-image-wasm`; this
+benchmark remains the comparison artifact generator rather than a replacement
+for browser-runner validation.
 
 ## Commands
 

--- a/docs/WASM_PACKAGE_API.md
+++ b/docs/WASM_PACKAGE_API.md
@@ -1,9 +1,10 @@
 # Wasm Package And Policy API
 
-This document defines the intended package shape and shared policy contract for
-the future Wasm/browser/Edge track. It is a design contract, not a published
-package announcement. The native Node package remains the production package
-until a Wasm package is implemented and benchmarked.
+This document defines the package shape and shared policy contract for the
+Wasm/browser/Edge track. The initial package lives under
+`packages/lazy-image-wasm`; it is not yet a public npm release. The native Node
+package remains the production package until the Wasm package is benchmarked in
+real browser and Edge runtimes.
 
 ## Package Shape
 
@@ -48,6 +49,11 @@ const optimizer = await createUploadOptimizer({
 The package may use `WebAssembly.instantiateStreaming()` when available, but it
 must provide a fallback for runtimes that return the wrong MIME type for Wasm
 assets.
+
+The first implementation uses jSquash Wasm codecs as the low-level browser/V8
+codec layer and keeps lazy-image's differentiation in policy normalization,
+byte-budget search, metrics, and structured errors. A future Rust-owned codec
+core can replace that adapter without changing the public policy shape.
 
 ## Public API
 
@@ -124,6 +130,12 @@ Default policy:
 - `stripMetadata`: `true`
 - `qualityFloorPolicy`: `best-effort`
 - `profile`: `upload-safe`
+
+`fit: "inside"` preserves aspect ratio within the provided max dimensions.
+`fit: "cover"` crops and resizes to exact `maxWidth` and `maxHeight`.
+`fit: "fill"` stretches to the provided dimensions. `limits.timeoutMs` is a
+best-effort, inter-stage checkpoint across input, decode, resize, and encode;
+it does not preempt a codec while that codec is already running.
 
 The Wasm policy names should map to the native package's safety and byte-budget
 vocabulary, but the Wasm API should not expose native-only file or thread
@@ -228,6 +240,7 @@ concurrency.
 In scope:
 
 - JPEG and WebP output
+- JPEG, PNG, and WebP input
 - resize to max width and/or max height
 - metadata stripping by default
 - best-effort target-byte search

--- a/docs/WASM_STRATEGY.md
+++ b/docs/WASM_STRATEGY.md
@@ -22,6 +22,11 @@ Squoosh-style packages more directly than it competes with sharp.
 The package and policy contract is defined in
 [WASM_PACKAGE_API.md](./WASM_PACKAGE_API.md).
 
+The first repository implementation is `packages/lazy-image-wasm`. It uses
+jSquash Wasm codecs as a browser/V8 codec adapter while lazy-image owns the
+high-level upload policy, target-byte search, metrics vocabulary, and error
+taxonomy.
+
 ## Where Native Remains The Right Answer
 
 Use the native Node package for:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@alberteinshutoin/lazy-image",
       "version": "0.15.0",
       "license": "MIT",
+      "workspaces": [
+        "packages/lazy-image-wasm"
+      ],
       "devDependencies": {
         "@napi-rs/cli": "^3.5.1",
         "@types/node": "^25.1.0",
@@ -106,6 +109,10 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/@alberteinshutoin/lazy-image-wasm": {
+      "resolved": "packages/lazy-image-wasm",
+      "link": true
     },
     "node_modules/@alberteinshutoin/lazy-image-win32-x64-msvc": {
       "version": "0.15.0",
@@ -989,6 +996,33 @@
         "@types/node": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@jsquash/jpeg": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jsquash/jpeg/-/jpeg-1.6.0.tgz",
+      "integrity": "sha512-zwN46Awh1VM6gXlIcALwb5WzqK5H2e6+Awcs1QP8AvS8ohsK/sbE4esvmH4jhlhW7+CgiUUww66vg0aTnlSIMA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@jsquash/png": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@jsquash/png/-/png-3.1.1.tgz",
+      "integrity": "sha512-C10pc+0H6j0h8fENOfnGOvkXCmvpSQTDGlfGd0sHphZhPSGTyLjIrHba0FaZZdsKqA/wlmhYicUHb92vfZphaw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@jsquash/resize": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@jsquash/resize/-/resize-2.1.1.tgz",
+      "integrity": "sha512-0R5UL1ZLHUT+carjVikcE1QfA+kfNQ2YamYyGVRmhfh4zttU5EY3bQBGxPIPtY2xIAw1P4Kgyxm2xrceRw1r2w==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@jsquash/webp": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jsquash/webp/-/webp-1.5.0.tgz",
+      "integrity": "sha512-KggLoj2MnRSfIqTeKe1EmbljTX2vuV7mh79k89PCL1pyqiDULcPM1L47twxXt0hkb68F70bXiL31MxsuoZtKFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "wasm-feature-detect": "^1.2.11"
       }
     },
     "node_modules/@napi-rs/cli": {
@@ -2558,6 +2592,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/wasm-feature-detect": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
+      "integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/wrap-ansi": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
@@ -2574,6 +2614,20 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "packages/lazy-image-wasm": {
+      "name": "@alberteinshutoin/lazy-image-wasm",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@jsquash/jpeg": "1.6.0",
+        "@jsquash/png": "3.1.1",
+        "@jsquash/resize": "2.1.1",
+        "@jsquash/webp": "1.5.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -36,9 +36,12 @@
   "bugs": {
     "url": "https://github.com/albert-einshutoin/lazy-image/issues"
   },
+  "workspaces": [
+    "packages/lazy-image-wasm"
+  ],
   "scripts": {
     "build": "napi build --platform --release && node scripts/postbuild-fixup.js",
-    "test": "npm run test:js && npm run test:rust",
+    "test": "npm run test:js && npm run test:rust && npm run test:wasm:package",
     "test:js": "npm run test:js:specs && npm run test:js:type-safety && npm run test:pack-contract && npm run test:release-policy && npm run test:types",
     "test:js:specs": "node test/integration/run.js",
     "test:js:type-safety": "node test/type-safety/runtime-type-safety-exit.test.js && node test/type-safety/runtime-type-safety.test.js",
@@ -54,6 +57,7 @@
     "test:bench:cold-start": "node test/benchmarks/cold-start.bench.js",
     "test:bench:extended": "npm run test:bench:avif && npm run test:bench:memory && npm run test:bench:cold-start",
     "test:bench:wasm": "node test/benchmarks/wasm-upload-comparison.bench.js --runtime all",
+    "test:wasm:package": "npm --workspace @alberteinshutoin/lazy-image-wasm test",
     "bench:wasm:browser": "node test/benchmarks/wasm-upload-comparison.bench.js --runtime browser",
     "bench:wasm:edge": "node test/benchmarks/wasm-upload-comparison.bench.js --runtime edge",
     "bench:wasm:report": "node test/benchmarks/wasm-upload-comparison.bench.js --runtime all",

--- a/packages/lazy-image-wasm/README.md
+++ b/packages/lazy-image-wasm/README.md
@@ -1,0 +1,52 @@
+# @alberteinshutoin/lazy-image-wasm
+
+Browser and Edge upload-preflight optimizer for lazy-image policy APIs.
+
+This package is the first Wasm MVP. It uses jSquash Wasm codecs as the low-level
+browser/V8 codec adapter while lazy-image owns the upload policy, target-byte
+search, metrics, and structured errors.
+
+## Browser
+
+```js
+import { optimizeUpload } from '@alberteinshutoin/lazy-image-wasm/browser';
+
+const result = await optimizeUpload(file, {
+  format: 'webp',
+  maxWidth: 1600,
+  maxHeight: 1600,
+  targetBytes: 350_000,
+  output: 'blob',
+});
+```
+
+## Edge
+
+Edge runtimes often need explicit Wasm module loading. Pass compiled
+`WebAssembly.Module`, `ArrayBuffer`, or `Uint8Array` values via `wasmModules`.
+
+```js
+import { createUploadOptimizer } from '@alberteinshutoin/lazy-image-wasm/edge';
+
+const optimizer = await createUploadOptimizer({ wasmModules });
+const result = await optimizer.optimizeUpload(new Uint8Array(await request.arrayBuffer()), {
+  format: 'jpeg',
+  maxWidth: 1200,
+  maxHeight: 1200,
+  targetBytes: 250_000,
+});
+```
+
+## Worker
+
+```js
+import { createUploadWorkerHandler } from '@alberteinshutoin/lazy-image-wasm/worker';
+
+self.addEventListener('message', createUploadWorkerHandler());
+```
+
+The MVP supports JPEG, PNG, and WebP input; JPEG and WebP output; metadata
+stripping by default; best-effort and strict target-byte policies; and metrics
+compatible with the native lazy-image vocabulary where possible. Resize policies
+support `inside`, `cover`, and `fill`; `limits.timeoutMs` is enforced between
+input, decode, resize, and encode stages as a best-effort checkpoint.

--- a/packages/lazy-image-wasm/browser.d.ts
+++ b/packages/lazy-image-wasm/browser.d.ts
@@ -1,0 +1,12 @@
+import type { CreateUploadOptimizerOptions, WasmImageInput, WasmOptimizeOptions, WasmOptimizeResult } from './shared.js';
+
+export declare function createUploadOptimizer(
+  options?: CreateUploadOptimizerOptions
+): Promise<{
+  optimizeUpload(input: WasmImageInput, options: WasmOptimizeOptions): Promise<WasmOptimizeResult>;
+}>;
+
+export declare function optimizeUpload(
+  input: WasmImageInput,
+  options: WasmOptimizeOptions
+): Promise<WasmOptimizeResult>;

--- a/packages/lazy-image-wasm/browser.js
+++ b/packages/lazy-image-wasm/browser.js
@@ -1,0 +1,263 @@
+import jpegDecode, { init as initJpegDecode } from '@jsquash/jpeg/decode.js';
+import jpegEncode, { init as initJpegEncode } from '@jsquash/jpeg/encode.js';
+import pngDecode, { init as initPngDecode } from '@jsquash/png/decode.js';
+import resizeImage, { initResize } from '@jsquash/resize';
+import webpDecode, { init as initWebpDecode } from '@jsquash/webp/decode.js';
+import webpEncode, { init as initWebpEncode } from '@jsquash/webp/encode.js';
+
+import {
+  LazyImageWasmError,
+  VERSION,
+  checkAbort,
+  checkTimeout,
+  detectInputFormat,
+  exactArrayBuffer,
+  inputToBytes,
+  makeResultData,
+  normalizeOptions,
+  nowMs,
+  resolveTargetDimensions,
+  throwWasmError,
+  validateInputLimits,
+  validatePixelLimits,
+} from './shared.js';
+
+const DEFAULT_RUNTIME = 'browser';
+
+export async function createUploadOptimizer(options = {}) {
+  const runtime = options.runtime ?? DEFAULT_RUNTIME;
+  const defaultOutput = options.defaultOutput ?? 'blob';
+  const now = options.now ?? (() => performance.now());
+  const instantiateStart = nowMs(now);
+  await initializeCodecs(options);
+  const instantiateMs = nowMs(now) - instantiateStart;
+
+  return {
+    async optimizeUpload(input, optimizeOptions) {
+      return optimizeUploadWithRuntime(input, optimizeOptions, {
+        defaultOutput,
+        instantiateMs,
+        now,
+        runtime,
+      });
+    },
+  };
+}
+
+export async function optimizeUpload(input, options) {
+  const optimizer = await createUploadOptimizer();
+  return optimizer.optimizeUpload(input, options);
+}
+
+async function optimizeUploadWithRuntime(input, options, runtimeOptions) {
+  const totalStart = nowMs(runtimeOptions.now);
+  const normalized = normalizeOptions(options, { output: runtimeOptions.defaultOutput });
+
+  checkAbort(normalized.signal);
+  const bytes = await inputToBytes(input);
+  checkTimeout(totalStart, 'input-read', normalized, runtimeOptions.now);
+  validateInputLimits(bytes, normalized);
+
+  const inputFormat = detectInputFormat(bytes);
+  const decodeStart = nowMs(runtimeOptions.now);
+  const imageData = await decodeImage(bytes, inputFormat);
+  const decodeMs = nowMs(runtimeOptions.now) - decodeStart;
+  checkTimeout(totalStart, 'decode', normalized, runtimeOptions.now);
+  validatePixelLimits(imageData.width, imageData.height, normalized);
+
+  checkAbort(normalized.signal);
+  const opsStart = nowMs(runtimeOptions.now);
+  const targetDimensions = resolveTargetDimensions(imageData.width, imageData.height, normalized);
+  const processed =
+    targetDimensions.width === imageData.width && targetDimensions.height === imageData.height
+      ? imageData
+      : await resizeImage(imageData, {
+          width: targetDimensions.width,
+          height: targetDimensions.height,
+          fitMethod: normalized.fit === 'cover' ? 'contain' : 'stretch',
+          method: 'lanczos3',
+          premultiply: true,
+          linearRGB: true,
+        });
+  const opsMs = nowMs(runtimeOptions.now) - opsStart;
+  checkTimeout(totalStart, 'process', normalized, runtimeOptions.now);
+
+  checkAbort(normalized.signal);
+  const encodeStart = nowMs(runtimeOptions.now);
+  const encoded = await encodeWithPolicy(processed, normalized, runtimeOptions.now, totalStart);
+  const encodeMs = nowMs(runtimeOptions.now) - encodeStart;
+  const totalMs = nowMs(runtimeOptions.now) - totalStart;
+  checkTimeout(totalStart, 'encode', normalized, runtimeOptions.now);
+  const resultBuffer = exactArrayBuffer(encoded.data);
+
+  const metrics = {
+    version: VERSION,
+    runtime: runtimeOptions.runtime,
+    bytesIn: bytes.byteLength,
+    bytesOut: resultBuffer.byteLength,
+    formatIn: inputFormat,
+    formatOut: normalized.format,
+    widthIn: imageData.width,
+    heightIn: imageData.height,
+    widthOut: processed.width,
+    heightOut: processed.height,
+    qualityUsed: encoded.qualityUsed,
+    budgetMet: encoded.budgetMet,
+    targetBytes: normalized.targetBytes,
+    instantiateMs: runtimeOptions.instantiateMs,
+    decodeMs,
+    opsMs,
+    encodeMs,
+    totalMs,
+    firstEncodeMs: encoded.firstEncodeMs,
+    metadataStripped: normalized.stripMetadata,
+    policyViolations: encoded.budgetMet ? [] : ['targetBytes'],
+    memory: {
+      peakBytes: undefined,
+      source: 'unavailable',
+    },
+  };
+
+  return {
+    data: makeResultData(resultBuffer, normalized.output, normalized.format),
+    format: normalized.format,
+    qualityUsed: encoded.qualityUsed,
+    bytesOut: resultBuffer.byteLength,
+    budgetMet: encoded.budgetMet,
+    targetBytes: normalized.targetBytes,
+    metrics,
+  };
+}
+
+async function initializeCodecs(options) {
+  if (!options.wasmModules || Object.keys(options.wasmModules).length === 0) {
+    return undefined;
+  }
+  const modules = options.wasmModules ?? {};
+  const tasks = [];
+
+  if (modules.jpegDecode) tasks.push(initJpegDecode(await toWasmModule(modules.jpegDecode)));
+  if (modules.jpegEncode) tasks.push(initJpegEncode(await toWasmModule(modules.jpegEncode)));
+  if (modules.pngDecode) tasks.push(initPngDecode(await toWasmModule(modules.pngDecode)));
+  if (modules.resize) tasks.push(initResize(await toWasmModule(modules.resize)));
+  if (modules.webpDecode) tasks.push(initWebpDecode(await toWasmModule(modules.webpDecode)));
+  if (modules.webpEncode) tasks.push(initWebpEncode(await toWasmModule(modules.webpEncode)));
+
+  await Promise.all(tasks);
+}
+
+async function toWasmModule(input) {
+  if (input instanceof WebAssembly.Module) {
+    return input;
+  }
+  if (input instanceof ArrayBuffer) {
+    return WebAssembly.compile(input);
+  }
+  if (ArrayBuffer.isView(input)) {
+    return WebAssembly.compile(input.buffer.slice(input.byteOffset, input.byteOffset + input.byteLength));
+  }
+  return input;
+}
+
+async function decodeImage(bytes, inputFormat) {
+  const buffer = exactArrayBuffer(bytes);
+  try {
+    if (inputFormat === 'jpeg') return await jpegDecode(buffer, { preserveOrientation: true });
+    if (inputFormat === 'png') return await pngDecode(buffer);
+    if (inputFormat === 'webp') return await webpDecode(buffer);
+  } catch (error) {
+    if (error instanceof LazyImageWasmError) throw error;
+    throwWasmError('E102', `Failed to decode ${inputFormat} input: ${error.message}`, {
+      recoveryHint: 'Check that the input image is not corrupt.',
+    });
+  }
+  throwWasmError('E103', `Unsupported input format: ${inputFormat}`);
+}
+
+async function encodeWithPolicy(imageData, options, now, totalStart) {
+  if (!options.targetBytes) {
+    const start = nowMs(now);
+    const data = await encodeAtQuality(imageData, options.format, options.maxQuality);
+    const firstEncodeMs = nowMs(now) - start;
+    checkTimeout(totalStart, 'encode', options, now);
+    return {
+      data,
+      qualityUsed: options.maxQuality,
+      budgetMet: true,
+      firstEncodeMs,
+    };
+  }
+
+  let low = options.minQuality;
+  let high = options.maxQuality;
+  let firstEncodeMs;
+  let bestUnderBudget = null;
+  let smallest = null;
+
+  while (low <= high) {
+    checkAbort(options.signal);
+    checkTimeout(totalStart, 'encode', options, now);
+    const quality = Math.floor((low + high) / 2);
+    const start = nowMs(now);
+    const data = await encodeAtQuality(imageData, options.format, quality);
+    const elapsed = nowMs(now) - start;
+    checkTimeout(totalStart, 'encode', options, now);
+    if (firstEncodeMs === undefined) {
+      firstEncodeMs = elapsed;
+    }
+
+    const candidate = {
+      data,
+      qualityUsed: quality,
+      bytesOut: exactArrayBuffer(data).byteLength,
+    };
+
+    if (!smallest || candidate.bytesOut < smallest.bytesOut) {
+      smallest = candidate;
+    }
+    if (candidate.bytesOut <= options.targetBytes) {
+      bestUnderBudget = candidate;
+      low = quality + 1;
+    } else {
+      high = quality - 1;
+    }
+  }
+
+  const selected = bestUnderBudget ?? smallest;
+  const budgetMet = selected.bytesOut <= options.targetBytes;
+  if (!budgetMet && options.qualityFloorPolicy === 'strict') {
+    throwWasmError('E201', `Unable to meet targetBytes=${options.targetBytes} within quality floor.`, {
+      recoveryHint: 'Increase targetBytes, reduce max dimensions, or use qualityFloorPolicy: "best-effort".',
+    });
+  }
+
+  return {
+    data: selected.data,
+    qualityUsed: selected.qualityUsed,
+    budgetMet,
+    firstEncodeMs,
+  };
+}
+
+async function encodeAtQuality(imageData, format, quality) {
+  try {
+    if (format === 'jpeg') {
+      return await jpegEncode(imageData, {
+        quality,
+        progressive: true,
+        optimize_coding: true,
+        auto_subsample: true,
+      });
+    }
+    if (format === 'webp') {
+      return await webpEncode(imageData, {
+        quality,
+        lossless: 0,
+      });
+    }
+  } catch (error) {
+    if (error instanceof LazyImageWasmError) throw error;
+    throwWasmError('E303', `Failed to encode ${format} output: ${error.message}`);
+  }
+  throwWasmError('E301', `Unsupported output format: ${format}`);
+}

--- a/packages/lazy-image-wasm/edge.d.ts
+++ b/packages/lazy-image-wasm/edge.d.ts
@@ -1,0 +1,12 @@
+import type { CreateUploadOptimizerOptions, WasmImageInput, WasmOptimizeOptions, WasmOptimizeResult } from './shared.js';
+
+export declare function createUploadOptimizer(
+  options?: CreateUploadOptimizerOptions
+): Promise<{
+  optimizeUpload(input: WasmImageInput, options: WasmOptimizeOptions): Promise<WasmOptimizeResult>;
+}>;
+
+export declare function optimizeUpload(
+  input: WasmImageInput,
+  options: WasmOptimizeOptions
+): Promise<WasmOptimizeResult>;

--- a/packages/lazy-image-wasm/edge.js
+++ b/packages/lazy-image-wasm/edge.js
@@ -1,0 +1,14 @@
+import { createUploadOptimizer as createBrowserUploadOptimizer } from './browser.js';
+
+export async function createUploadOptimizer(options = {}) {
+  return createBrowserUploadOptimizer({
+    ...options,
+    defaultOutput: options.defaultOutput ?? 'arrayBuffer',
+    runtime: 'edge-isolate',
+  });
+}
+
+export async function optimizeUpload(input, options) {
+  const optimizer = await createUploadOptimizer();
+  return optimizer.optimizeUpload(input, options);
+}

--- a/packages/lazy-image-wasm/examples/worker.mjs
+++ b/packages/lazy-image-wasm/examples/worker.mjs
@@ -1,0 +1,3 @@
+import { createUploadWorkerHandler } from '../worker.js';
+
+self.addEventListener('message', createUploadWorkerHandler());

--- a/packages/lazy-image-wasm/package.json
+++ b/packages/lazy-image-wasm/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@alberteinshutoin/lazy-image-wasm",
+  "version": "0.1.0",
+  "description": "Browser and Edge upload-preflight optimizer for lazy-image policy APIs",
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    "./browser": {
+      "types": "./browser.d.ts",
+      "import": "./browser.js"
+    },
+    "./edge": {
+      "types": "./edge.d.ts",
+      "import": "./edge.js"
+    },
+    "./shared": {
+      "types": "./shared.d.ts",
+      "import": "./shared.js"
+    },
+    "./worker": {
+      "types": "./worker.d.ts",
+      "import": "./worker.js"
+    }
+  },
+  "files": [
+    "README.md",
+    "browser.js",
+    "browser.d.ts",
+    "edge.js",
+    "edge.d.ts",
+    "shared.js",
+    "shared.d.ts",
+    "worker.js",
+    "worker.d.ts",
+    "examples/"
+  ],
+  "scripts": {
+    "test": "node test/run.mjs"
+  },
+  "dependencies": {
+    "@jsquash/jpeg": "1.6.0",
+    "@jsquash/png": "3.1.1",
+    "@jsquash/resize": "2.1.1",
+    "@jsquash/webp": "1.5.0"
+  },
+  "engines": {
+    "node": ">= 18"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "MIT"
+}

--- a/packages/lazy-image-wasm/shared.d.ts
+++ b/packages/lazy-image-wasm/shared.d.ts
@@ -1,0 +1,90 @@
+export type WasmImageInput = File | Blob | ArrayBuffer | Uint8Array;
+export type WasmOutputFormat = 'jpeg' | 'webp';
+export type WasmOutputKind = 'blob' | 'arrayBuffer' | 'uint8Array';
+export type WasmResizeFit = 'inside' | 'cover' | 'fill';
+export type WasmQualityFloorPolicy = 'best-effort' | 'strict';
+export type WasmProfile = 'upload-safe' | 'avatar' | 'attachment' | 'balanced';
+export type WasmRuntime = 'browser' | 'browser-worker' | 'edge-isolate';
+
+export interface CreateUploadOptimizerOptions {
+  wasmModules?: {
+    jpegDecode?: WebAssembly.Module | ArrayBuffer | Uint8Array;
+    jpegEncode?: WebAssembly.Module | ArrayBuffer | Uint8Array;
+    pngDecode?: WebAssembly.Module | ArrayBuffer | Uint8Array;
+    resize?: WebAssembly.Module | ArrayBuffer | Uint8Array;
+    webpDecode?: WebAssembly.Module | ArrayBuffer | Uint8Array;
+    webpEncode?: WebAssembly.Module | ArrayBuffer | Uint8Array;
+  };
+  defaultOutput?: WasmOutputKind;
+  runtime?: WasmRuntime;
+  now?: () => number;
+}
+
+export interface WasmOptimizeOptions {
+  format: WasmOutputFormat;
+  output?: WasmOutputKind;
+  maxWidth?: number;
+  maxHeight?: number;
+  fit?: WasmResizeFit;
+  targetBytes?: number;
+  minQuality?: number;
+  maxQuality?: number;
+  qualityFloorPolicy?: WasmQualityFloorPolicy;
+  stripMetadata?: boolean;
+  profile?: WasmProfile;
+  limits?: WasmLimits;
+  signal?: AbortSignal;
+}
+
+export interface WasmLimits {
+  maxBytes?: number;
+  maxPixels?: number;
+  timeoutMs?: number;
+}
+
+export interface WasmOptimizeResult {
+  data: Blob | ArrayBuffer | Uint8Array;
+  format: WasmOutputFormat;
+  qualityUsed: number;
+  bytesOut: number;
+  budgetMet: boolean;
+  targetBytes?: number;
+  metrics: WasmProcessingMetrics;
+}
+
+export interface WasmProcessingMetrics {
+  version: string;
+  runtime: WasmRuntime;
+  bytesIn: number;
+  bytesOut: number;
+  formatIn?: string | null;
+  formatOut: WasmOutputFormat;
+  widthIn?: number;
+  heightIn?: number;
+  widthOut?: number;
+  heightOut?: number;
+  qualityUsed: number;
+  budgetMet: boolean;
+  targetBytes?: number;
+  instantiateMs?: number;
+  decodeMs: number;
+  opsMs: number;
+  encodeMs: number;
+  totalMs: number;
+  firstEncodeMs?: number;
+  metadataStripped: boolean;
+  policyViolations: string[];
+  memory?: {
+    peakBytes?: number;
+    source: 'performance-api' | 'runtime-estimate' | 'unavailable';
+  };
+}
+
+export declare class LazyImageWasmError extends Error {
+  code: string;
+  category: 'Input' | 'Processing' | 'Output' | 'Config' | 'Internal';
+  recoverable: boolean;
+  recoveryHint?: string;
+}
+
+export declare const VERSION: string;

--- a/packages/lazy-image-wasm/shared.js
+++ b/packages/lazy-image-wasm/shared.js
@@ -1,0 +1,284 @@
+export const VERSION = '0.1.0';
+
+export const ERROR_CATEGORIES = {
+  Input: 'Input',
+  Processing: 'Processing',
+  Output: 'Output',
+  Config: 'Config',
+  Internal: 'Internal',
+};
+
+const FORMATS = new Set(['jpeg', 'webp']);
+const OUTPUT_KINDS = new Set(['blob', 'arrayBuffer', 'uint8Array']);
+const FITS = new Set(['inside', 'cover', 'fill']);
+const FLOOR_POLICIES = new Set(['best-effort', 'strict']);
+const PROFILES = new Set(['upload-safe', 'avatar', 'attachment', 'balanced']);
+
+const PROFILE_DEFAULTS = {
+  'upload-safe': {
+    minQuality: 45,
+    maxQuality: 85,
+  },
+  avatar: {
+    maxWidth: 512,
+    maxHeight: 512,
+    minQuality: 45,
+    maxQuality: 82,
+  },
+  attachment: {
+    minQuality: 40,
+    maxQuality: 86,
+  },
+  balanced: {
+    minQuality: 50,
+    maxQuality: 80,
+  },
+};
+
+export class LazyImageWasmError extends Error {
+  constructor(code, message, options = {}) {
+    super(message);
+    this.name = 'LazyImageWasmError';
+    this.code = code;
+    this.category = options.category ?? categoryForCode(code);
+    this.recoverable = options.recoverable ?? this.category !== ERROR_CATEGORIES.Internal;
+    if (options.recoveryHint) {
+      this.recoveryHint = options.recoveryHint;
+    }
+  }
+}
+
+export function categoryForCode(code) {
+  if (/^E1\d\d$/.test(code)) return ERROR_CATEGORIES.Input;
+  if (/^E2\d\d$/.test(code)) return ERROR_CATEGORIES.Processing;
+  if (/^E3\d\d$/.test(code)) return ERROR_CATEGORIES.Output;
+  if (/^E4\d\d$/.test(code)) return ERROR_CATEGORIES.Config;
+  return ERROR_CATEGORIES.Internal;
+}
+
+export function throwWasmError(code, message, options) {
+  throw new LazyImageWasmError(code, message, options);
+}
+
+export async function inputToBytes(input) {
+  if (input instanceof ArrayBuffer) {
+    return new Uint8Array(input);
+  }
+  if (ArrayBuffer.isView(input)) {
+    return new Uint8Array(input.buffer, input.byteOffset, input.byteLength);
+  }
+  if (input && typeof input.arrayBuffer === 'function') {
+    const buffer = await input.arrayBuffer();
+    return new Uint8Array(buffer);
+  }
+  throwWasmError('E101', 'Unsupported input type for Wasm upload optimization.', {
+    recoveryHint: 'Pass a File, Blob, ArrayBuffer, or Uint8Array.',
+  });
+}
+
+export function detectInputFormat(bytes) {
+  if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
+    return 'jpeg';
+  }
+  if (
+    bytes.length >= 8 &&
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47 &&
+    bytes[4] === 0x0d &&
+    bytes[5] === 0x0a &&
+    bytes[6] === 0x1a &&
+    bytes[7] === 0x0a
+  ) {
+    return 'png';
+  }
+  if (
+    bytes.length >= 12 &&
+    bytes[0] === 0x52 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x46 &&
+    bytes[8] === 0x57 &&
+    bytes[9] === 0x45 &&
+    bytes[10] === 0x42 &&
+    bytes[11] === 0x50
+  ) {
+    return 'webp';
+  }
+  throwWasmError('E103', 'Unsupported input image format for the Wasm MVP.', {
+    recoveryHint: 'Use JPEG, PNG, or WebP input for the first upload-preflight slice.',
+  });
+}
+
+export function normalizeOptions(options = {}, runtimeDefaults = {}) {
+  const profile = options.profile ?? 'upload-safe';
+  if (!PROFILES.has(profile)) {
+    throwWasmError('E401', `Invalid Wasm profile: ${profile}`);
+  }
+
+  const defaults = PROFILE_DEFAULTS[profile];
+  const normalized = {
+    fit: 'inside',
+    output: runtimeDefaults.output ?? 'blob',
+    stripMetadata: true,
+    qualityFloorPolicy: 'best-effort',
+    profile,
+    ...defaults,
+    ...options,
+  };
+
+  if (!FORMATS.has(normalized.format)) {
+    throwWasmError('E301', `Unsupported Wasm output format: ${normalized.format}`, {
+      recoveryHint: 'Use "jpeg" or "webp". AVIF is deferred for the MVP.',
+    });
+  }
+  if (!OUTPUT_KINDS.has(normalized.output)) {
+    throwWasmError('E302', `Unsupported Wasm output kind: ${normalized.output}`);
+  }
+  if (!FITS.has(normalized.fit)) {
+    throwWasmError('E202', `Unsupported resize fit: ${normalized.fit}`);
+  }
+  if (!FLOOR_POLICIES.has(normalized.qualityFloorPolicy)) {
+    throwWasmError('E402', `Unsupported qualityFloorPolicy: ${normalized.qualityFloorPolicy}`);
+  }
+
+  normalized.minQuality = normalizeQuality(normalized.minQuality, 'minQuality');
+  normalized.maxQuality = normalizeQuality(normalized.maxQuality, 'maxQuality');
+  if (normalized.minQuality > normalized.maxQuality) {
+    throwWasmError('E402', 'minQuality must be less than or equal to maxQuality.');
+  }
+
+  for (const key of ['maxWidth', 'maxHeight', 'targetBytes']) {
+    if (normalized[key] !== undefined) {
+      normalized[key] = normalizePositiveInteger(normalized[key], key);
+    }
+  }
+
+  const limits = normalized.limits ?? {};
+  for (const key of ['maxBytes', 'maxPixels', 'timeoutMs']) {
+    if (limits[key] !== undefined) {
+      limits[key] = normalizePositiveInteger(limits[key], `limits.${key}`);
+    }
+  }
+  normalized.limits = limits;
+
+  return normalized;
+}
+
+export function validateInputLimits(bytes, options) {
+  if (options.limits.maxBytes !== undefined && bytes.byteLength > options.limits.maxBytes) {
+    throwWasmError('E104', `Input exceeds limits.maxBytes (${options.limits.maxBytes}).`);
+  }
+}
+
+export function validatePixelLimits(width, height, options) {
+  const pixels = width * height;
+  if (options.limits.maxPixels !== undefined && pixels > options.limits.maxPixels) {
+    throwWasmError('E105', `Input exceeds limits.maxPixels (${options.limits.maxPixels}).`);
+  }
+}
+
+export function resolveTargetDimensions(width, height, options) {
+  const maxWidth = options.maxWidth;
+  const maxHeight = options.maxHeight;
+  if (!maxWidth && !maxHeight) {
+    return { width, height };
+  }
+
+  if (options.fit === 'cover') {
+    if (!maxWidth || !maxHeight) {
+      throwWasmError('E202', 'cover fit requires both maxWidth and maxHeight.');
+    }
+    return {
+      width: maxWidth,
+      height: maxHeight,
+    };
+  }
+
+  if (options.fit === 'fill') {
+    return {
+      width: maxWidth ?? width,
+      height: maxHeight ?? height,
+    };
+  }
+
+  const widthRatio = maxWidth ? maxWidth / width : 1;
+  const heightRatio = maxHeight ? maxHeight / height : 1;
+  const ratio = Math.min(widthRatio, heightRatio, 1);
+  return {
+    width: Math.max(1, Math.round(width * ratio)),
+    height: Math.max(1, Math.round(height * ratio)),
+  };
+}
+
+export function checkAbort(signal) {
+  if (signal?.aborted) {
+    throwWasmError('E204', 'Wasm upload optimization was aborted.', {
+      recoverable: true,
+    });
+  }
+}
+
+export function checkTimeout(startMs, stage, options, now) {
+  const timeoutMs = options.limits?.timeoutMs;
+  if (timeoutMs === undefined) {
+    return;
+  }
+
+  const elapsedMs = nowMs(now) - startMs;
+  if (elapsedMs > timeoutMs) {
+    throwWasmError('E205', `Wasm upload optimization exceeded limits.timeoutMs (${timeoutMs}) at ${stage}.`, {
+      recoveryHint:
+        'Increase limits.timeoutMs, reduce max dimensions, or use AbortController for external cancellation.',
+    });
+  }
+}
+
+export function exactArrayBuffer(buffer) {
+  if (buffer instanceof ArrayBuffer) {
+    return buffer;
+  }
+  if (ArrayBuffer.isView(buffer)) {
+    return buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
+  }
+  throwWasmError('E901', 'Codec returned an unsupported buffer type.', {
+    recoverable: false,
+  });
+}
+
+export function makeResultData(arrayBuffer, output, format) {
+  const exact = exactArrayBuffer(arrayBuffer);
+  if (output === 'arrayBuffer') {
+    return exact;
+  }
+  if (output === 'uint8Array') {
+    return new Uint8Array(exact);
+  }
+  if (typeof Blob !== 'function') {
+    throwWasmError('E303', 'Blob output is not available in this runtime.', {
+      recoveryHint: 'Use output: "arrayBuffer" or output: "uint8Array".',
+    });
+  }
+  return new Blob([exact], { type: format === 'jpeg' ? 'image/jpeg' : 'image/webp' });
+}
+
+export function nowMs(now) {
+  return typeof now === 'function' ? now() : performance.now();
+}
+
+function normalizeQuality(value, key) {
+  const quality = value === undefined ? undefined : Number(value);
+  if (!Number.isInteger(quality) || quality < 1 || quality > 100) {
+    throwWasmError('E402', `${key} must be an integer from 1 to 100.`);
+  }
+  return quality;
+}
+
+function normalizePositiveInteger(value, key) {
+  const normalized = Number(value);
+  if (!Number.isInteger(normalized) || normalized <= 0) {
+    throwWasmError('E402', `${key} must be a positive integer.`);
+  }
+  return normalized;
+}

--- a/packages/lazy-image-wasm/test/run.mjs
+++ b/packages/lazy-image-wasm/test/run.mjs
@@ -1,0 +1,193 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createUploadOptimizer } from '../browser.js';
+import { createUploadOptimizer as createEdgeUploadOptimizer } from '../edge.js';
+import { LazyImageWasmError } from '../shared.js';
+
+if (typeof globalThis.ImageData !== 'function') {
+  globalThis.ImageData = class ImageData {
+    constructor(data, width, height) {
+      this.data = data;
+      this.width = width;
+      this.height = height;
+    }
+  };
+}
+
+const require = createRequire(import.meta.url);
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const repoRoot = path.resolve(packageRoot, '..', '..');
+const fixtureRoot = path.join(repoRoot, 'test', 'fixtures');
+
+function packageFile(packageName, relativePath) {
+  return path.join(path.dirname(require.resolve(`${packageName}/package.json`)), relativePath);
+}
+
+async function readWasm(packageName, relativePath) {
+  return fs.readFile(packageFile(packageName, relativePath));
+}
+
+async function loadWasmModules() {
+  return {
+    jpegDecode: await readWasm('@jsquash/jpeg', 'codec/dec/mozjpeg_dec.wasm'),
+    jpegEncode: await readWasm('@jsquash/jpeg', 'codec/enc/mozjpeg_enc.wasm'),
+    pngDecode: await readWasm('@jsquash/png', 'codec/pkg/squoosh_png_bg.wasm'),
+    resize: await readWasm('@jsquash/resize', 'lib/resize/pkg/squoosh_resize_bg.wasm'),
+    webpDecode: await readWasm('@jsquash/webp', 'codec/dec/webp_dec.wasm'),
+    webpEncode: await readWasm('@jsquash/webp', 'codec/enc/webp_enc.wasm'),
+  };
+}
+
+async function fixture(name) {
+  return fs.readFile(path.join(fixtureRoot, name));
+}
+
+async function test(name, fn) {
+  try {
+    await fn();
+    console.log(`ok - ${name}`);
+  } catch (error) {
+    console.error(`not ok - ${name}`);
+    throw error;
+  }
+}
+
+const wasmModules = await loadWasmModules();
+const optimizer = await createUploadOptimizer({
+  wasmModules,
+  defaultOutput: 'arrayBuffer',
+});
+
+await test('optimizes JPEG input to JPEG with a target byte budget', async () => {
+  const input = await fixture('test_100KB_1057x1057.jpg');
+  const result = await optimizer.optimizeUpload(input, {
+    format: 'jpeg',
+    maxWidth: 512,
+    maxHeight: 512,
+    targetBytes: 35_000,
+    minQuality: 35,
+    maxQuality: 85,
+    output: 'arrayBuffer',
+  });
+
+  assert.equal(result.format, 'jpeg');
+  assert.ok(result.data instanceof ArrayBuffer);
+  assert.ok(result.bytesOut <= 35_000, `bytesOut=${result.bytesOut}`);
+  assert.equal(result.budgetMet, true);
+  assert.equal(result.metrics.formatIn, 'jpeg');
+  assert.equal(result.metrics.metadataStripped, true);
+  assert.ok(result.metrics.widthOut <= 512);
+  assert.ok(result.metrics.heightOut <= 512);
+});
+
+await test('optimizes JPEG input to WebP with best-effort target search', async () => {
+  const input = await fixture('test_100KB_1057x1057.jpg');
+  const result = await optimizer.optimizeUpload(input, {
+    format: 'webp',
+    maxWidth: 512,
+    maxHeight: 512,
+    targetBytes: 30_000,
+    minQuality: 35,
+    maxQuality: 82,
+    output: 'uint8Array',
+  });
+
+  assert.equal(result.format, 'webp');
+  assert.ok(result.data instanceof Uint8Array);
+  assert.equal(result.budgetMet, true);
+  assert.equal(result.metrics.formatOut, 'webp');
+  assert.ok(result.metrics.encodeMs >= 0);
+});
+
+await test('optimizes PNG input to JPEG for upload conversion', async () => {
+  const input = await fixture('test_input.png');
+  const result = await optimizer.optimizeUpload(input, {
+    format: 'jpeg',
+    output: 'arrayBuffer',
+  });
+
+  assert.equal(result.metrics.formatIn, 'png');
+  assert.equal(result.format, 'jpeg');
+  assert.ok(result.bytesOut > 0);
+});
+
+await test('cover fit produces exact target dimensions', async () => {
+  const input = await fixture('test_100KB_1057x1057.jpg');
+  const result = await optimizer.optimizeUpload(input, {
+    format: 'jpeg',
+    fit: 'cover',
+    maxWidth: 320,
+    maxHeight: 180,
+    output: 'arrayBuffer',
+  });
+
+  assert.equal(result.metrics.widthOut, 320);
+  assert.equal(result.metrics.heightOut, 180);
+});
+
+await test('strict target byte policy fails with structured processing error', async () => {
+  const input = await fixture('test_38kb_input.jpg');
+  await assert.rejects(
+    () =>
+      optimizer.optimizeUpload(input, {
+        format: 'jpeg',
+        targetBytes: 10,
+        minQuality: 50,
+        maxQuality: 51,
+        qualityFloorPolicy: 'strict',
+        output: 'arrayBuffer',
+      }),
+    (error) => error instanceof LazyImageWasmError && error.code === 'E201' && error.category === 'Processing'
+  );
+});
+
+await test('limits.timeoutMs fails with structured processing error', async () => {
+  let fakeNow = 0;
+  const timeoutOptimizer = await createUploadOptimizer({
+    wasmModules,
+    defaultOutput: 'arrayBuffer',
+    now: () => {
+      fakeNow += 5;
+      return fakeNow;
+    },
+  });
+  const input = await fixture('test_38kb_input.jpg');
+
+  await assert.rejects(
+    () =>
+      timeoutOptimizer.optimizeUpload(input, {
+        format: 'jpeg',
+        output: 'arrayBuffer',
+        limits: {
+          timeoutMs: 1,
+        },
+      }),
+    (error) => error instanceof LazyImageWasmError && error.code === 'E205' && error.category === 'Processing'
+  );
+});
+
+await test('unsupported input format fails with E103', async () => {
+  await assert.rejects(
+    () =>
+      optimizer.optimizeUpload(new Uint8Array([1, 2, 3, 4]), {
+        format: 'jpeg',
+        output: 'arrayBuffer',
+      }),
+    (error) => error instanceof LazyImageWasmError && error.code === 'E103' && error.category === 'Input'
+  );
+});
+
+await test('edge entrypoint defaults to ArrayBuffer output', async () => {
+  const edgeOptimizer = await createEdgeUploadOptimizer({ wasmModules });
+  const input = await fixture('test_input.jpg');
+  const result = await edgeOptimizer.optimizeUpload(input, {
+    format: 'jpeg',
+  });
+
+  assert.ok(result.data instanceof ArrayBuffer);
+  assert.equal(result.metrics.runtime, 'edge-isolate');
+});

--- a/packages/lazy-image-wasm/worker.d.ts
+++ b/packages/lazy-image-wasm/worker.d.ts
@@ -1,0 +1,3 @@
+import type { CreateUploadOptimizerOptions } from './shared.js';
+
+export declare function createUploadWorkerHandler(options?: CreateUploadOptimizerOptions): (event: MessageEvent) => Promise<void>;

--- a/packages/lazy-image-wasm/worker.js
+++ b/packages/lazy-image-wasm/worker.js
@@ -1,0 +1,30 @@
+import { createUploadOptimizer } from './browser.js';
+
+export function createUploadWorkerHandler(options = {}) {
+  const optimizerPromise = createUploadOptimizer({
+    ...options,
+    runtime: 'browser-worker',
+  });
+
+  return async function handleUploadOptimizationMessage(event) {
+    const { id, input, options: optimizeOptions } = event.data ?? {};
+    try {
+      const optimizer = await optimizerPromise;
+      const result = await optimizer.optimizeUpload(input, optimizeOptions);
+      event.target?.postMessage?.({ id, ok: true, result });
+    } catch (error) {
+      event.target?.postMessage?.({
+        id,
+        ok: false,
+        error: {
+          name: error.name,
+          message: error.message,
+          code: error.code,
+          category: error.category,
+          recoverable: error.recoverable,
+          recoveryHint: error.recoveryHint,
+        },
+      });
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- add `packages/lazy-image-wasm` with browser, edge, shared, and worker entrypoints
- use jSquash Wasm codecs as the low-level browser/V8 codec adapter while lazy-image owns upload policy, target-byte search, metrics, and structured errors
- support JPEG/PNG/WebP input, JPEG/WebP output, metadata stripping via decode/re-encode, `inside`/`cover`/`fill` resize policies, best-effort/strict `targetBytes`, and inter-stage `limits.timeoutMs`
- wire the workspace into root `npm test` and document the implementation in Wasm strategy/package/benchmarking docs

## Verification
- `npm run test:wasm:package`
- `npm run build`
- `npm test`
- `git diff --check`
- `npm --workspace @alberteinshutoin/lazy-image-wasm pack --dry-run`

Closes #633
Related #87
