### PR TITLE
chore: ignore local agent artifacts and stray build binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,12 +24,14 @@ Thumbs.db
 .idea/
 .vscode/
 .cursor/
+.claude/
 *.swp
 *.swo
 
 # Build artifacts
 npm/
 artifacts/
+/rust_out
 
 # Coverage reports (generated files)
 coverage/
@@ -50,5 +52,6 @@ BENCHMARK_COMPARISON_RESULTS.md
 BENCHMARK_REPORT.md
 BENCHMARK_VERIFICATION_REPORT.md
 CLAUDE.md
+AGENTS.md
 RELEASE_READINESS.md
 SHARP_COMPARISON.md


### PR DESCRIPTION
## Summary

Adds three `.gitignore` entries for local-only files that were showing up as untracked and should never be committed:

| Entry | What it is | Why ignore |
|---|---|---|
| `.claude/` | Claude Code local settings + worktrees | Per-developer local state, like the already-ignored `.vscode/` / `.cursor/` |
| `/rust_out` | Stray compiled Rust binary (Mach-O executable) | Build artifact, anchored to repo root |
| `AGENTS.md` | Codex guidance doc (mirror of `CLAUDE.md`) | Internal "not for public" doc — `CLAUDE.md` is already ignored for the same reason |

## Context

While reviewing the uncommitted state on `feature/rust-engineering-hardening`, these local artifacts were polluting `git status`. The Rust-hardening and Wasm-docs work from that branch is already merged into `develop`, so this is the only non-redundant hygiene change worth keeping.

## Test plan

- [x] `.gitignore`-only change — no build/runtime impact
- [x] `git check-ignore -v` confirms all three patterns match (`.claude/`, `rust_out`, `AGENTS.md`)
- [x] No tracked files affected