### PR TITLE
docs: repoint Wasm tracking refs to #645 (supersedes closed #87)

### DIFF
--- a/docs/ADOPTION_GUIDE.md
+++ b/docs/ADOPTION_GUIDE.md
@@ -202,7 +202,7 @@ Same pattern as Lambda. Use `/tmp` for scratch files. For Cloud Run, set `--memo
 
 These environments run in V8 isolates and **do not support the native NAPI binary** that lazy-image ships. The published `@alberteinshutoin/lazy-image` package requires a Node.js runtime (Vercel Node Functions, Netlify Node Functions, AWS Lambda, Cloud Run, etc.).
 
-For Edge / Workers, process images in a background Node-runtime function and serve the results from a CDN. Wasm support for V8-isolate runtimes is tracked under [#87](https://github.com/albert-einshutoin/lazy-image/issues/87).
+For Edge / Workers, process images in a background Node-runtime function and serve the results from a CDN. Wasm support for V8-isolate runtimes is tracked under [#645](https://github.com/albert-einshutoin/lazy-image/issues/645).
 The current product direction is documented in [WASM_STRATEGY.md](./WASM_STRATEGY.md), with benchmark expectations in [WASM_BENCHMARKING.md](./WASM_BENCHMARKING.md).
 
 ### Cold start optimization

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -28,7 +28,7 @@ Full data: [TRUE_BENCHMARKS.md](./TRUE_BENCHMARKS.md).
 
 ## When to Use lazy-image
 
-- **Node-runtime serverless (AWS Lambda, Google Cloud Run, Vercel Node Functions, Google Cloud Functions)** — Avoid OOM and smaller cold-start footprint. V8-isolate runtimes such as Cloudflare Workers and Vercel Edge are **not supported** by the native NAPI build (tracked under [#87](https://github.com/albert-einshutoin/lazy-image/issues/87) for future Wasm support).
+- **Node-runtime serverless (AWS Lambda, Google Cloud Run, Vercel Node Functions, Google Cloud Functions)** — Avoid OOM and smaller cold-start footprint. V8-isolate runtimes such as Cloudflare Workers and Vercel Edge are **not supported** by the native NAPI build (tracked under [#645](https://github.com/albert-einshutoin/lazy-image/issues/645) for future Wasm support).
 - **Bandwidth-sensitive JPEG delivery** — Smaller JPEG saves CDN and transfer costs in the two simple canonical PNG → JPEG benchmarks; multi-operation pipelines need their own measurement.
 - **AVIF output support** — Use when you need lazy-image's AVIF output path, ICC handling, and safety defaults; benchmark target AVIF workloads before assuming size or speed wins.
 - **Memory-constrained** — 512MB containers; `fromPath()` bypasses the V8 heap (read-into-memory ≤ 256 MB, mmap with advisory locks > 256 MB).
@@ -94,4 +94,4 @@ await ImageEngine.from(buf).resize(800).toBuffer('jpeg', 80);
 
 **Ideal for Node-runtime serverless**: AWS Lambda, Google Cloud Functions, Google Cloud Run, Vercel Node Functions.
 
-**Not supported**: V8-isolate runtimes such as Cloudflare Workers and Vercel Edge. The published native NAPI module requires a Node.js runtime; Wasm support is tracked under [#87](https://github.com/albert-einshutoin/lazy-image/issues/87).
+**Not supported**: V8-isolate runtimes such as Cloudflare Workers and Vercel Edge. The published native NAPI module requires a Node.js runtime; Wasm support is tracked under [#645](https://github.com/albert-einshutoin/lazy-image/issues/645).


### PR DESCRIPTION
## Summary

#87 (the old Wasm tracking issue) was closed as **not planned** — its body described an approach the project explicitly rejects in [WASM_STRATEGY.md](../blob/develop/docs/WASM_STRATEGY.md) (compiling the native core to Wasm, `ImageEngine` parity, Wasm-vs-native perf claims). The current-strategy tracker is **#645**.

This updates the three docs that still pointed readers at the closed issue:

- `docs/ADOPTION_GUIDE.md` (1 ref)
- `docs/PERFORMANCE.md` (2 refs)

## Test plan

- [x] `git grep "issues/87" docs/` returns no matches
- [x] Docs-only change, no build/runtime impact