### PR TITLE
test: harden NAPI stress reliability coverage

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -495,7 +495,7 @@ jobs:
             exit 1
           fi
           export LD_PRELOAD="$ASAN_RT${LD_PRELOAD:+:$LD_PRELOAD}"
-          npm run test:stress:napi -- --iterations 5
+          npm run test:stress:napi -- --iterations 10 --malformed-rounds 10 --rss-growth-limit-mb 1536
 
   publish:
     name: Publish to npm

--- a/test/stress/napi-boundary.stress.js
+++ b/test/stress/napi-boundary.stress.js
@@ -6,23 +6,101 @@ const { resolveFixture, resolveTemp } = require('../helpers/paths');
 const INPUT_JPEG = resolveFixture('test_input.jpg');
 const INPUT_PNG = resolveFixture('test_input.png');
 
-function parseIterations() {
+function parsePositiveInt(value, optionName) {
+  const parsed = Number.parseInt(value || '', 10);
+  if (Number.isFinite(parsed) && parsed > 0) {
+    return parsed;
+  }
+  throw new Error(`${optionName} must be a positive integer`);
+}
+
+function parseNonNegativeNumber(value, optionName) {
+  const parsed = Number.parseFloat(value || '');
+  if (Number.isFinite(parsed) && parsed >= 0) {
+    return parsed;
+  }
+  throw new Error(`${optionName} must be a non-negative number`);
+}
+
+function parseNonNegativeInt(value, optionName) {
+  const parsed = Number.parseInt(value || '', 10);
+  if (Number.isFinite(parsed) && parsed >= 0) {
+    return parsed;
+  }
+  throw new Error(`${optionName} must be a non-negative integer`);
+}
+
+function parseOptions() {
   const args = process.argv.slice(2);
+  const options = {
+    iterations: process.env.NAPI_STRESS_ITERATIONS
+      ? parsePositiveInt(process.env.NAPI_STRESS_ITERATIONS, 'NAPI_STRESS_ITERATIONS')
+      : 20,
+    malformedRounds: process.env.NAPI_STRESS_MALFORMED_ROUNDS
+      ? parseNonNegativeInt(process.env.NAPI_STRESS_MALFORMED_ROUNDS, 'NAPI_STRESS_MALFORMED_ROUNDS')
+      : 20,
+    rssGrowthLimitMb: process.env.NAPI_STRESS_RSS_GROWTH_LIMIT_MB
+      ? parseNonNegativeNumber(process.env.NAPI_STRESS_RSS_GROWTH_LIMIT_MB, 'NAPI_STRESS_RSS_GROWTH_LIMIT_MB')
+      : 0,
+  };
+
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i];
     if (arg === '--iterations' || arg === '-n') {
-      const parsed = Number.parseInt(args[i + 1] || '', 10);
-      if (Number.isFinite(parsed) && parsed > 0) {
-        return parsed;
-      }
+      options.iterations = parsePositiveInt(args[i + 1], arg);
+      i += 1;
+    } else if (arg === '--malformed-rounds') {
+      options.malformedRounds = parseNonNegativeInt(args[i + 1], arg);
+      i += 1;
+    } else if (arg === '--rss-growth-limit-mb') {
+      options.rssGrowthLimitMb = parseNonNegativeNumber(args[i + 1], arg);
+      i += 1;
+    } else if (!arg.startsWith('-')) {
+      options.iterations = parsePositiveInt(arg, 'iterations');
     } else {
-      const parsed = Number.parseInt(arg, 10);
-      if (Number.isFinite(parsed) && parsed > 0) {
-        return parsed;
-      }
+      throw new Error(`Unknown option: ${arg}`);
     }
   }
-  return 20;
+
+  return options;
+}
+
+function buildMalformedInputs() {
+  const jpeg = fs.readFileSync(INPUT_JPEG);
+  return [
+    { name: 'empty', data: Buffer.alloc(0) },
+    { name: 'random-bytes', data: Buffer.from([0x42, 0x00, 0xff, 0x13, 0x7f, 0x80, 0x01, 0x02]) },
+    { name: 'jpeg-soi-only', data: Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]) },
+    { name: 'truncated-jpeg', data: jpeg.subarray(0, Math.min(jpeg.length, 200)) },
+    {
+      name: 'png-huge-dimensions-header',
+      data: Buffer.from([
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+        0x00, 0x00, 0x00, 0x0d,
+        0x49, 0x48, 0x44, 0x52,
+        0x7f, 0xff, 0xff, 0xff,
+        0x7f, 0xff, 0xff, 0xff,
+        0x08, 0x02, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00,
+      ]),
+    },
+  ];
+}
+
+async function expectRejects(label, fn) {
+  try {
+    await fn();
+  } catch (error) {
+    if (!error || typeof error.message !== 'string' || error.message.length === 0) {
+      throw new Error(`${label}: rejection did not expose a useful Error`);
+    }
+    if (typeof error.errorCode !== 'string' || error.errorCode.length === 0) {
+      throw new Error(`${label}: rejection did not expose a structured lazy-image errorCode`);
+    }
+    return;
+  }
+
+  throw new Error(`${label}: unexpectedly succeeded`);
 }
 
 async function runIteration(iteration, rootDir) {
@@ -73,20 +151,99 @@ async function runIteration(iteration, rootDir) {
   }
 }
 
+async function runMalformedRound(round, malformedInputs) {
+  for (const input of malformedInputs) {
+    await expectRejects(`malformed round ${round}: ${input.name}`, () => (
+      ImageEngine.from(input.data)
+        .sanitize({ policy: 'strict' })
+        .resize({ width: 64, fit: 'inside' })
+        .toBufferWithMetrics('jpeg', 80)
+    ));
+  }
+
+  await expectRejects(`malformed round ${round}: unsupported format`, () => (
+    ImageEngine.fromPath(INPUT_JPEG)
+      .resize({ width: 64, fit: 'inside' })
+      .toBuffer('gif', 80)
+  ));
+
+  await expectRejects(`malformed round ${round}: invalid sanitize policy`, () => (
+    ImageEngine.fromPath(INPUT_JPEG).sanitize({ policy: 'invalid_policy' })
+  ));
+
+  await expectRejects(`malformed round ${round}: invalid rotation`, () => (
+    ImageEngine.fromPath(INPUT_JPEG)
+      .rotate(45)
+      .toBuffer('jpeg', 80)
+  ));
+}
+
+function maybeCollectGarbage() {
+  if (typeof global.gc === 'function') {
+    global.gc();
+  }
+}
+
+function recordMemorySample(samples, phase) {
+  maybeCollectGarbage();
+  samples.push({
+    phase,
+    rssMb: process.memoryUsage().rss / 1024 / 1024,
+  });
+}
+
+function assertRssGrowthWithinLimit(samples, limitMb) {
+  if (limitMb <= 0 || samples.length < 3) {
+    return;
+  }
+
+  const measured = samples.slice(1);
+  const baseline = measured[0].rssMb;
+  const peak = Math.max(...measured.map((sample) => sample.rssMb));
+  const growth = peak - baseline;
+
+  if (growth > limitMb) {
+    throw new Error(
+      `RSS growth ${growth.toFixed(1)} MiB exceeded limit ${limitMb} MiB ` +
+        `(baseline ${baseline.toFixed(1)} MiB, peak ${peak.toFixed(1)} MiB)`,
+    );
+  }
+}
+
 async function main() {
-  const iterations = parseIterations();
+  const options = parseOptions();
+  const malformedInputs = buildMalformedInputs();
+  const memorySamples = [];
   const rootDir = resolveTemp('napi-boundary-stress');
   fs.rmSync(rootDir, { recursive: true, force: true });
   fs.mkdirSync(rootDir, { recursive: true });
 
-  for (let i = 0; i < iterations; i += 1) {
+  recordMemorySample(memorySamples, 'start');
+
+  for (let i = 0; i < options.iterations; i += 1) {
     await runIteration(i, rootDir);
+    if (i < options.malformedRounds) {
+      await runMalformedRound(i, malformedInputs);
+    }
+    recordMemorySample(memorySamples, `iteration-${i}`);
     if (i % 5 === 0) {
       console.error(`napi stress iteration ${i} completed`);
     }
   }
 
+  for (let i = options.iterations; i < options.malformedRounds; i += 1) {
+    await runMalformedRound(i, malformedInputs);
+    recordMemorySample(memorySamples, `malformed-${i}`);
+  }
+
+  assertRssGrowthWithinLimit(memorySamples, options.rssGrowthLimitMb);
+
   fs.rmSync(rootDir, { recursive: true, force: true });
+  const peakRssMb = Math.max(...memorySamples.map((sample) => sample.rssMb));
+  console.error(
+    `napi stress completed: iterations=${options.iterations}, ` +
+      `malformedRounds=${options.malformedRounds}, peakRss=${peakRssMb.toFixed(1)} MiB`,
+  );
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## Summary
- expand the NAPI boundary stress harness with configurable iterations, malformed-input rounds, and optional RSS growth limits
- exercise structured error paths for empty/random/truncated/huge-header inputs and invalid API options inside the stress loop
- run the ASan leak-detection CI job with 10 success iterations, 10 malformed rounds, and an RSS growth guard

## Issue priority
Selected #646 first because it is the only open P1 reliability/adoption umbrella and maps directly to ROADMAP current priority #1. #638 and #639 are also P1, but they are larger codec bake-off tracks and need benchmark/prototype slices before a safe backend change.

Refs #646

## Verification
- npm ci
- npm run build
- npm test
- npm run test:stress:napi -- --iterations 10 --malformed-rounds 10 --rss-growth-limit-mb 1536