### PR TITLE
test: align napi stress with fuzz corpus

### DIFF
--- a/test/integration/napi-stress-corpus.test.js
+++ b/test/integration/napi-stress-corpus.test.js
@@ -1,0 +1,59 @@
+/**
+ * Regression coverage for the NAPI boundary stress corpus.
+ *
+ * Keep this as a short smoke test; the long ASan/LSan run is covered by CI.
+ */
+
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const { resolveRoot } = require('../helpers/paths');
+
+const STRESS_SCRIPT = resolveRoot('test/stress/napi-boundary.stress.js');
+
+let passed = 0;
+let failed = 0;
+
+function report(name, error) {
+  if (error) {
+    console.log(`not ok - ${name}`);
+    console.log(`   Error: ${error.message}`);
+    failed += 1;
+  } else {
+    console.log(`ok - ${name}`);
+    passed += 1;
+  }
+}
+
+function test(name, fn) {
+  try {
+    fn();
+    report(name);
+  } catch (error) {
+    report(name, error);
+  }
+}
+
+console.log('=== NAPI Stress Corpus Tests ===\n');
+
+test('stress smoke includes generated malformed fuzz seeds', () => {
+  const result = spawnSync(process.execPath, [
+    STRESS_SCRIPT,
+    '--iterations',
+    '1',
+    '--malformed-rounds',
+    '1',
+    '--rss-growth-limit-mb',
+    '0',
+  ], {
+    cwd: resolveRoot(),
+    encoding: 'utf8',
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(`${result.stdout}\n${result.stderr}`, /malformedInputs=25/);
+});
+
+console.log(`\nTests passed: ${passed}, failed: ${failed}`);
+if (failed > 0) {
+  process.exit(1);
+}

--- a/test/stress/napi-boundary.stress.js
+++ b/test/stress/napi-boundary.stress.js
@@ -1,10 +1,12 @@
 const fs = require('node:fs');
 const path = require('node:path');
+const { spawnSync } = require('node:child_process');
 const { ImageEngine } = require('../../index.js');
-const { resolveFixture, resolveTemp } = require('../helpers/paths');
+const { resolveFixture, resolveRoot, resolveTemp } = require('../helpers/paths');
 
 const INPUT_JPEG = resolveFixture('test_input.jpg');
 const INPUT_PNG = resolveFixture('test_input.png');
+const FUZZ_SEED_SCRIPT = resolveRoot('scripts/fuzz/write-seed-corpus.mjs');
 
 function parsePositiveInt(value, optionName) {
   const parsed = Number.parseInt(value || '', 10);
@@ -65,7 +67,7 @@ function parseOptions() {
   return options;
 }
 
-function buildMalformedInputs() {
+function buildInlineMalformedInputs() {
   const jpeg = fs.readFileSync(INPUT_JPEG);
   return [
     { name: 'empty', data: Buffer.alloc(0) },
@@ -84,6 +86,58 @@ function buildMalformedInputs() {
         0x00, 0x00, 0x00, 0x00,
       ]),
     },
+  ];
+}
+
+function collectGeneratedFuzzSeeds(corpusRoot) {
+  const result = spawnSync(process.execPath, [
+    FUZZ_SEED_SCRIPT,
+    '--corpus-root',
+    corpusRoot,
+  ], {
+    cwd: resolveRoot(),
+    encoding: 'utf8',
+  });
+
+  if (result.status !== 0) {
+    throw new Error(
+      `failed to generate malformed fuzz seed corpus: ${result.stderr || result.stdout}`,
+    );
+  }
+
+  const inputs = [];
+  for (const target of fs.readdirSync(corpusRoot).sort()) {
+    const targetDir = path.join(corpusRoot, target);
+    if (!fs.statSync(targetDir).isDirectory()) {
+      continue;
+    }
+
+    for (const fileName of fs.readdirSync(targetDir).sort()) {
+      const filePath = path.join(targetDir, fileName);
+      if (!fs.statSync(filePath).isFile()) {
+        continue;
+      }
+
+      inputs.push({
+        name: `fuzz/${target}/${fileName}`,
+        data: fs.readFileSync(filePath),
+      });
+    }
+  }
+
+  if (inputs.length === 0) {
+    throw new Error('malformed fuzz seed corpus generation produced no inputs');
+  }
+
+  return inputs;
+}
+
+function buildMalformedInputs(rootDir) {
+  const corpusRoot = path.join(rootDir, 'malformed-fuzz-corpus');
+  fs.rmSync(corpusRoot, { recursive: true, force: true });
+  return [
+    ...buildInlineMalformedInputs(),
+    ...collectGeneratedFuzzSeeds(corpusRoot),
   ];
 }
 
@@ -212,11 +266,11 @@ function assertRssGrowthWithinLimit(samples, limitMb) {
 
 async function main() {
   const options = parseOptions();
-  const malformedInputs = buildMalformedInputs();
   const memorySamples = [];
   const rootDir = resolveTemp('napi-boundary-stress');
   fs.rmSync(rootDir, { recursive: true, force: true });
   fs.mkdirSync(rootDir, { recursive: true });
+  const malformedInputs = buildMalformedInputs(rootDir);
 
   recordMemorySample(memorySamples, 'start');
 
@@ -242,7 +296,8 @@ async function main() {
   const peakRssMb = Math.max(...memorySamples.map((sample) => sample.rssMb));
   console.error(
     `napi stress completed: iterations=${options.iterations}, ` +
-      `malformedRounds=${options.malformedRounds}, peakRss=${peakRssMb.toFixed(1)} MiB`,
+      `malformedRounds=${options.malformedRounds}, malformedInputs=${malformedInputs.length}, ` +
+      `peakRss=${peakRssMb.toFixed(1)} MiB`,
   );
 }
 


### PR DESCRIPTION
## Summary
- extend the NAPI boundary stress test to generate and replay the malformed fuzz seed corpus
- keep the original inline malformed inputs, then add target-qualified fuzz seeds such as AVIF, WebP, ICC, and EXIF malformed cases
- add a short integration smoke test so normal `npm test` verifies the stress corpus wiring while the long ASan/LSan run stays in CI

## Issue fit / self-review
- Refs #646
- This is a focused reliability slice for the `malformed-input` and `NAPI boundary` parts of the umbrella issue.
- It does not close #646 because the umbrella still includes longer-running leak/sanitizer expansion and benchmark/fuzz alignment work.
- The implementation reuses the existing fuzz seed generator instead of duplicating the catalog, so future seed additions are exercised by ASan stress automatically.

## Verification
- `node --check test/stress/napi-boundary.stress.js`
- `npm run test:stress:napi -- --iterations 1 --malformed-rounds 1 --rss-growth-limit-mb 0`
- `node --check test/integration/napi-stress-corpus.test.js`
- `node test/integration/napi-stress-corpus.test.js`
- `git diff --check`
- `npm run build`
- `npm test`