### PR TITLE
test: publish NAPI stress summaries

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -495,7 +495,28 @@ jobs:
             exit 1
           fi
           export LD_PRELOAD="$ASAN_RT${LD_PRELOAD:+:$LD_PRELOAD}"
-          npm run test:stress:napi -- --iterations 10 --malformed-rounds 10 --rss-growth-limit-mb 1536
+          mkdir -p artifacts/reliability
+          npm run test:stress:napi -- \
+            --iterations 10 \
+            --malformed-rounds 10 \
+            --rss-growth-limit-mb 1536 \
+            --summary-json artifacts/reliability/napi-boundary-stress.json \
+            --summary-md artifacts/reliability/napi-boundary-stress.md
+
+      - name: Add NAPI stress summary
+        if: always()
+        run: |
+          if [ -f artifacts/reliability/napi-boundary-stress.md ]; then
+            cat artifacts/reliability/napi-boundary-stress.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload NAPI stress artifacts
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: napi-boundary-stress
+          path: artifacts/reliability/napi-boundary-stress.*
+          if-no-files-found: ignore
 
   publish:
     name: Publish to npm

--- a/test/integration/napi-stress-corpus.test.js
+++ b/test/integration/napi-stress-corpus.test.js
@@ -5,10 +5,13 @@
  */
 
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
 const { spawnSync } = require('node:child_process');
-const { resolveRoot } = require('../helpers/paths');
+const { resolveRoot, resolveTemp } = require('../helpers/paths');
 
 const STRESS_SCRIPT = resolveRoot('test/stress/napi-boundary.stress.js');
+const SUMMARY_DIR = resolveTemp(`napi-stress-corpus-${process.pid}`);
 
 let passed = 0;
 let failed = 0;
@@ -35,7 +38,11 @@ function test(name, fn) {
 
 console.log('=== NAPI Stress Corpus Tests ===\n');
 
-test('stress smoke includes generated malformed fuzz seeds', () => {
+fs.rmSync(SUMMARY_DIR, { recursive: true, force: true });
+
+test('stress smoke includes generated malformed fuzz seeds and writes summaries', () => {
+  const summaryJsonPath = path.join(SUMMARY_DIR, 'summary.json');
+  const summaryMdPath = path.join(SUMMARY_DIR, 'summary.md');
   const result = spawnSync(process.execPath, [
     STRESS_SCRIPT,
     '--iterations',
@@ -44,6 +51,10 @@ test('stress smoke includes generated malformed fuzz seeds', () => {
     '1',
     '--rss-growth-limit-mb',
     '0',
+    '--summary-json',
+    summaryJsonPath,
+    '--summary-md',
+    summaryMdPath,
   ], {
     cwd: resolveRoot(),
     encoding: 'utf8',
@@ -51,9 +62,26 @@ test('stress smoke includes generated malformed fuzz seeds', () => {
 
   assert.equal(result.status, 0, result.stderr || result.stdout);
   assert.match(`${result.stdout}\n${result.stderr}`, /malformedInputs=25/);
+
+  const summary = JSON.parse(fs.readFileSync(summaryJsonPath, 'utf8'));
+  assert.equal(summary.tool, 'napi-boundary-stress');
+  assert.equal(summary.status, 'passed');
+  assert.equal(summary.options.iterations, 1);
+  assert.equal(summary.options.malformedRounds, 1);
+  assert.equal(summary.malformedInputs.total, 25);
+  assert.equal(summary.malformedInputs.inline, 5);
+  assert.equal(summary.malformedInputs.generatedFuzzSeeds, 20);
+  assert.equal(summary.memory.sampleCount, 2);
+  assert.ok(summary.memory.peakRssMb > 0);
+  assert.ok(summary.memory.samples.some((sample) => sample.phase === 'iteration-0'));
+
+  const markdown = fs.readFileSync(summaryMdPath, 'utf8');
+  assert.match(markdown, /NAPI Boundary Stress Summary/);
+  assert.match(markdown, /generatedFuzzSeeds: 20/);
 });
 
 console.log(`\nTests passed: ${passed}, failed: ${failed}`);
+fs.rmSync(SUMMARY_DIR, { recursive: true, force: true });
 if (failed > 0) {
   process.exit(1);
 }

--- a/test/stress/napi-boundary.stress.js
+++ b/test/stress/napi-boundary.stress.js
@@ -32,6 +32,21 @@ function parseNonNegativeInt(value, optionName) {
   throw new Error(`${optionName} must be a non-negative integer`);
 }
 
+function requireOptionValue(args, index, optionName) {
+  const value = args[index + 1];
+  if (!value || value.startsWith('-')) {
+    throw new Error(`${optionName} requires a path value`);
+  }
+  return value;
+}
+
+function resolveOutputPath(value) {
+  if (!value) {
+    return null;
+  }
+  return path.resolve(resolveRoot(), value);
+}
+
 function parseOptions() {
   const args = process.argv.slice(2);
   const options = {
@@ -44,6 +59,8 @@ function parseOptions() {
     rssGrowthLimitMb: process.env.NAPI_STRESS_RSS_GROWTH_LIMIT_MB
       ? parseNonNegativeNumber(process.env.NAPI_STRESS_RSS_GROWTH_LIMIT_MB, 'NAPI_STRESS_RSS_GROWTH_LIMIT_MB')
       : 0,
+    summaryJsonPath: resolveOutputPath(process.env.NAPI_STRESS_SUMMARY_JSON),
+    summaryMdPath: resolveOutputPath(process.env.NAPI_STRESS_SUMMARY_MD),
   };
 
   for (let i = 0; i < args.length; i += 1) {
@@ -56,6 +73,12 @@ function parseOptions() {
       i += 1;
     } else if (arg === '--rss-growth-limit-mb') {
       options.rssGrowthLimitMb = parseNonNegativeNumber(args[i + 1], arg);
+      i += 1;
+    } else if (arg === '--summary-json') {
+      options.summaryJsonPath = resolveOutputPath(requireOptionValue(args, i, arg));
+      i += 1;
+    } else if (arg === '--summary-md') {
+      options.summaryMdPath = resolveOutputPath(requireOptionValue(args, i, arg));
       i += 1;
     } else if (!arg.startsWith('-')) {
       options.iterations = parsePositiveInt(arg, 'iterations');
@@ -139,6 +162,32 @@ function buildMalformedInputs(rootDir) {
     ...buildInlineMalformedInputs(),
     ...collectGeneratedFuzzSeeds(corpusRoot),
   ];
+}
+
+function roundMb(value) {
+  return Number(value.toFixed(1));
+}
+
+function summarizeMalformedInputs(inputs) {
+  const generatedFuzzTargets = {};
+  let generatedFuzzSeeds = 0;
+
+  for (const input of inputs) {
+    if (!input.name.startsWith('fuzz/')) {
+      continue;
+    }
+
+    generatedFuzzSeeds += 1;
+    const target = input.name.split('/')[1] || 'unknown';
+    generatedFuzzTargets[target] = (generatedFuzzTargets[target] || 0) + 1;
+  }
+
+  return {
+    total: inputs.length,
+    inline: inputs.length - generatedFuzzSeeds,
+    generatedFuzzSeeds,
+    generatedFuzzTargets,
+  };
 }
 
 async function expectRejects(label, fn) {
@@ -246,21 +295,99 @@ function recordMemorySample(samples, phase) {
   });
 }
 
-function assertRssGrowthWithinLimit(samples, limitMb) {
-  if (limitMb <= 0 || samples.length < 3) {
+function summarizeMemorySamples(samples) {
+  const measured = samples.slice(1);
+  const peakSamples = measured.length > 0 ? measured : samples;
+  const baseline = measured[0]?.rssMb || samples[0]?.rssMb || 0;
+  const peak = Math.max(...peakSamples.map((sample) => sample.rssMb), 0);
+  const growth = Math.max(0, peak - baseline);
+
+  return {
+    sampleCount: samples.length,
+    baselineRssMb: roundMb(baseline),
+    peakRssMb: roundMb(peak),
+    growthRssMb: roundMb(growth),
+    samples: samples.map((sample) => ({
+      phase: sample.phase,
+      rssMb: roundMb(sample.rssMb),
+    })),
+  };
+}
+
+function assertRssGrowthWithinLimit(memorySummary, limitMb) {
+  if (limitMb <= 0 || memorySummary.sampleCount < 3) {
     return;
   }
 
-  const measured = samples.slice(1);
-  const baseline = measured[0].rssMb;
-  const peak = Math.max(...measured.map((sample) => sample.rssMb));
-  const growth = peak - baseline;
-
-  if (growth > limitMb) {
+  if (memorySummary.growthRssMb > limitMb) {
     throw new Error(
-      `RSS growth ${growth.toFixed(1)} MiB exceeded limit ${limitMb} MiB ` +
-        `(baseline ${baseline.toFixed(1)} MiB, peak ${peak.toFixed(1)} MiB)`,
+      `RSS growth ${memorySummary.growthRssMb.toFixed(1)} MiB exceeded limit ${limitMb} MiB ` +
+        `(baseline ${memorySummary.baselineRssMb.toFixed(1)} MiB, ` +
+        `peak ${memorySummary.peakRssMb.toFixed(1)} MiB)`,
     );
+  }
+}
+
+function buildSummary(options, malformedInputs, memorySamples) {
+  return {
+    version: 1,
+    tool: 'napi-boundary-stress',
+    generatedAt: new Date().toISOString(),
+    status: 'passed',
+    options: {
+      iterations: options.iterations,
+      malformedRounds: options.malformedRounds,
+      rssGrowthLimitMb: options.rssGrowthLimitMb,
+    },
+    malformedInputs: summarizeMalformedInputs(malformedInputs),
+    memory: summarizeMemorySamples(memorySamples),
+  };
+}
+
+function formatSummaryMarkdown(summary) {
+  const targetEntries = Object.entries(summary.malformedInputs.generatedFuzzTargets);
+  const targetRows = targetEntries.length === 0
+    ? ['_No generated fuzz seed targets._']
+    : [
+        '| target | seeds |',
+        '| --- | ---: |',
+        ...targetEntries.map(([target, count]) => `| ${target} | ${count} |`),
+      ];
+
+  return [
+    '# NAPI Boundary Stress Summary',
+    '',
+    `- status: ${summary.status}`,
+    `- generatedAt: ${summary.generatedAt}`,
+    `- iterations: ${summary.options.iterations}`,
+    `- malformedRounds: ${summary.options.malformedRounds}`,
+    `- malformedInputs: ${summary.malformedInputs.total}`,
+    `- generatedFuzzSeeds: ${summary.malformedInputs.generatedFuzzSeeds}`,
+    `- peakRss: ${summary.memory.peakRssMb.toFixed(1)} MiB`,
+    `- rssGrowth: ${summary.memory.growthRssMb.toFixed(1)} MiB`,
+    `- rssGrowthLimit: ${summary.options.rssGrowthLimitMb.toFixed(1)} MiB`,
+    '',
+    '## Generated Fuzz Seed Targets',
+    '',
+    ...targetRows,
+    '',
+  ].join('\n');
+}
+
+function writeSummaryArtifacts(summary, options) {
+  const writes = [
+    [options.summaryJsonPath, `${JSON.stringify(summary, null, 2)}\n`],
+    [options.summaryMdPath, formatSummaryMarkdown(summary)],
+  ];
+
+  for (const [filePath, contents] of writes) {
+    if (!filePath) {
+      continue;
+    }
+
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, contents);
+    console.error(`napi stress summary written: ${filePath}`);
   }
 }
 
@@ -290,14 +417,22 @@ async function main() {
     recordMemorySample(memorySamples, `malformed-${i}`);
   }
 
-  assertRssGrowthWithinLimit(memorySamples, options.rssGrowthLimitMb);
+  const summary = buildSummary(options, malformedInputs, memorySamples);
+  try {
+    assertRssGrowthWithinLimit(summary.memory, options.rssGrowthLimitMb);
+  } catch (error) {
+    summary.status = 'failed';
+    summary.error = { message: error.message };
+    writeSummaryArtifacts(summary, options);
+    throw error;
+  }
+  writeSummaryArtifacts(summary, options);
 
   fs.rmSync(rootDir, { recursive: true, force: true });
-  const peakRssMb = Math.max(...memorySamples.map((sample) => sample.rssMb));
   console.error(
     `napi stress completed: iterations=${options.iterations}, ` +
       `malformedRounds=${options.malformedRounds}, malformedInputs=${malformedInputs.length}, ` +
-      `peakRss=${peakRssMb.toFixed(1)} MiB`,
+      `peakRss=${summary.memory.peakRssMb.toFixed(1)} MiB`,
   );
 }
 


### PR DESCRIPTION
## Summary

Refs #646.

- add JSON/Markdown summary outputs to `test:stress:napi`
- publish the ASan NAPI-boundary stress summary to the CI step summary and upload it as a `napi-boundary-stress` artifact
- extend the short integration smoke to verify generated fuzz seed coverage and summary contents

## Self-review

- Issue validity: #646 is a valid reliability hardening umbrella because v1.x adoption needs auditable leak/sanitizer and malformed-input coverage, not only pass/fail logs.
- Implementation fit: this keeps production Rust/NAPI behavior unchanged and only adds observability around the existing NAPI stress harness.
- Failure behavior: RSS-threshold failures write `status: failed` summaries before rethrowing, so CI has evidence when the gate trips.

## Verification

- `node --check test/stress/napi-boundary.stress.js`
- `node --check test/integration/napi-stress-corpus.test.js`
- `node test/integration/napi-stress-corpus.test.js`
- `npm run test:stress:napi -- --iterations 1 --malformed-rounds 1 --rss-growth-limit-mb 0 --summary-json .tmp/napi-stress-summary-smoke/summary.json --summary-md .tmp/napi-stress-summary-smoke/summary.md`
- negative-path smoke: intentionally low `--rss-growth-limit-mb 0.1` writes `status: failed` summary and exits non-zero
- `git diff --check`
- `npm run build`
- `npm test`
