### PR TITLE
test: stress malformed fuzz files through NAPI

### DIFF
--- a/test/integration/napi-stress-corpus.test.js
+++ b/test/integration/napi-stress-corpus.test.js
@@ -71,6 +71,7 @@ test('stress smoke includes generated malformed fuzz seeds and writes summaries'
   assert.equal(summary.malformedInputs.total, 25);
   assert.equal(summary.malformedInputs.inline, 5);
   assert.equal(summary.malformedInputs.generatedFuzzSeeds, 20);
+  assert.equal(summary.malformedInputs.generatedFuzzFilePathSeeds, 20);
   assert.equal(summary.memory.sampleCount, 2);
   assert.ok(summary.memory.peakRssMb > 0);
   assert.ok(summary.memory.samples.some((sample) => sample.phase === 'iteration-0'));
@@ -78,6 +79,7 @@ test('stress smoke includes generated malformed fuzz seeds and writes summaries'
   const markdown = fs.readFileSync(summaryMdPath, 'utf8');
   assert.match(markdown, /NAPI Boundary Stress Summary/);
   assert.match(markdown, /generatedFuzzSeeds: 20/);
+  assert.match(markdown, /generatedFuzzFilePathSeeds: 20/);
 });
 
 console.log(`\nTests passed: ${passed}, failed: ${failed}`);

--- a/test/stress/napi-boundary.stress.js
+++ b/test/stress/napi-boundary.stress.js
@@ -143,6 +143,8 @@ function collectGeneratedFuzzSeeds(corpusRoot) {
 
       inputs.push({
         name: `fuzz/${target}/${fileName}`,
+        filePath,
+        generatedFuzzSeed: true,
         data: fs.readFileSync(filePath),
       });
     }
@@ -171,6 +173,7 @@ function roundMb(value) {
 function summarizeMalformedInputs(inputs) {
   const generatedFuzzTargets = {};
   let generatedFuzzSeeds = 0;
+  let generatedFuzzFilePathSeeds = 0;
 
   for (const input of inputs) {
     if (!input.name.startsWith('fuzz/')) {
@@ -178,6 +181,9 @@ function summarizeMalformedInputs(inputs) {
     }
 
     generatedFuzzSeeds += 1;
+    if (input.generatedFuzzSeed && input.filePath) {
+      generatedFuzzFilePathSeeds += 1;
+    }
     const target = input.name.split('/')[1] || 'unknown';
     generatedFuzzTargets[target] = (generatedFuzzTargets[target] || 0) + 1;
   }
@@ -186,6 +192,7 @@ function summarizeMalformedInputs(inputs) {
     total: inputs.length,
     inline: inputs.length - generatedFuzzSeeds,
     generatedFuzzSeeds,
+    generatedFuzzFilePathSeeds,
     generatedFuzzTargets,
   };
 }
@@ -258,6 +265,19 @@ async function runMalformedRound(round, malformedInputs) {
   for (const input of malformedInputs) {
     await expectRejects(`malformed round ${round}: ${input.name}`, () => (
       ImageEngine.from(input.data)
+        .sanitize({ policy: 'strict' })
+        .resize({ width: 64, fit: 'inside' })
+        .toBufferWithMetrics('jpeg', 80)
+    ));
+  }
+
+  for (const input of malformedInputs) {
+    if (!input.generatedFuzzSeed || !input.filePath) {
+      continue;
+    }
+
+    await expectRejects(`malformed round ${round}: file ${input.name}`, () => (
+      ImageEngine.fromPath(input.filePath)
         .sanitize({ policy: 'strict' })
         .resize({ width: 64, fit: 'inside' })
         .toBufferWithMetrics('jpeg', 80)
@@ -363,6 +383,7 @@ function formatSummaryMarkdown(summary) {
     `- malformedRounds: ${summary.options.malformedRounds}`,
     `- malformedInputs: ${summary.malformedInputs.total}`,
     `- generatedFuzzSeeds: ${summary.malformedInputs.generatedFuzzSeeds}`,
+    `- generatedFuzzFilePathSeeds: ${summary.malformedInputs.generatedFuzzFilePathSeeds}`,
     `- peakRss: ${summary.memory.peakRssMb.toFixed(1)} MiB`,
     `- rssGrowth: ${summary.memory.growthRssMb.toFixed(1)} MiB`,
     `- rssGrowthLimit: ${summary.options.rssGrowthLimitMb.toFixed(1)} MiB`,
@@ -394,7 +415,7 @@ function writeSummaryArtifacts(summary, options) {
 async function main() {
   const options = parseOptions();
   const memorySamples = [];
-  const rootDir = resolveTemp('napi-boundary-stress');
+  const rootDir = resolveTemp(`napi-boundary-stress-${process.pid}`);
   fs.rmSync(rootDir, { recursive: true, force: true });
   fs.mkdirSync(rootDir, { recursive: true });
   const malformedInputs = buildMalformedInputs(rootDir);


### PR DESCRIPTION
Refs #646

## Summary
- replay generated malformed fuzz seeds through `ImageEngine.fromPath()` inside the NAPI boundary stress run, in addition to the existing buffer replay
- report `generatedFuzzFilePathSeeds` in the JSON/Markdown stress summary so CI artifacts show file-path coverage explicitly
- make the stress temp root PID-scoped to avoid collisions when short stress smokes run concurrently in one workspace

## Self-review
- Issue validity: #646 is still valid as an umbrella for v1.x reliability proof. The remaining high-value gap after #655 was ASan/NAPI stress coverage for generated malformed files through the file-path boundary.
- Implementation fit: production Rust/NAPI behavior is unchanged. The stress harness now exercises the same generated malformed seed corpus across both buffer and file inputs, and the summary exposes the covered seed count.
- Correctness check: each generated seed remains expected to reject with a structured lazy-image error. The temp-root change fixes an observed parallel-smoke collision instead of masking it.
- Risk: ASan stress does more malformed file-path calls per round. The CI stress setting is 10 malformed rounds, so the added cost is bounded and only affects reliability CI.

## Verification
- `node --check test/stress/napi-boundary.stress.js`
- `node --check test/integration/napi-stress-corpus.test.js`
- parallel smoke: `node test/integration/napi-stress-corpus.test.js` with `npm run test:stress:napi -- --iterations 1 --malformed-rounds 1 --rss-growth-limit-mb 0 --summary-json .tmp/napi-stress-file-path-smoke/summary.json --summary-md .tmp/napi-stress-file-path-smoke/summary.md`
- `git diff --check`
- `npm run build`
- `npm test`