### PR TITLE
bench: report codec bakeoff package impact

### DIFF
--- a/test/benchmarks/avif-backend-bakeoff.bench.js
+++ b/test/benchmarks/avif-backend-bakeoff.bench.js
@@ -5,6 +5,7 @@ const { spawn, spawnSync } = require('child_process');
 const sharp = require('sharp');
 const { resolveFixture, resolveRoot, resolveTemp } = require('../helpers/paths');
 const { calculateQualityMetrics } = require('../helpers/quality');
+const { buildPackageImpactMarkdown, collectBenchmarkPackageImpact } = require('../helpers/package-impact');
 const { ImageEngine } = require(resolveRoot('index'));
 
 const DEFAULT_ITERATIONS = 2;
@@ -526,6 +527,8 @@ function buildMarkdown(report) {
     `lazy-image AVIF threads: ${report.settings.lazyImageThreads}`,
     `Iterations: ${report.iterations}`,
     '',
+    ...buildPackageImpactMarkdown(report.packageImpact),
+    '',
     'Command shape: `avifenc --codec <backend> --qcolor <quality> --qalpha <quality> --speed <speed> --jobs <jobs> --yuv 420 --range full INPUT OUTPUT`',
     'Quality/CQ mapping: `qcolor` and `qalpha` use the libavif 0..100 quality scale; codec-specific quantizer mapping remains inside libavif/avifenc.',
     `Tune settings: ${report.settings.tune}`,
@@ -696,6 +699,10 @@ async function main() {
     },
     iterations: options.iterations,
     codecs: options.codecs,
+    packageImpact: collectBenchmarkPackageImpact({
+      benchmarkTool: 'avifenc',
+      candidateBackend: 'libavif backend matrix',
+    }),
     commandShape:
       'avifenc --codec <backend> --qcolor <quality> --qalpha <quality> --speed <speed> --jobs <jobs> --yuv 420 --range full INPUT OUTPUT',
     timingNote:

--- a/test/benchmarks/jpegli-bakeoff.bench.js
+++ b/test/benchmarks/jpegli-bakeoff.bench.js
@@ -4,6 +4,7 @@ const { spawnSync } = require('child_process');
 const sharp = require('sharp');
 const { resolveFixture, resolveRoot, resolveTemp } = require('../helpers/paths');
 const { calculateQualityMetrics } = require('../helpers/quality');
+const { buildPackageImpactMarkdown, collectBenchmarkPackageImpact } = require('../helpers/package-impact');
 const { ImageEngine } = require(resolveRoot('index'));
 
 const DEFAULT_ITERATIONS = 3;
@@ -243,6 +244,8 @@ function buildMarkdown(report) {
     `cjpegli probe: ${report.tools.cjpegliProbe || 'unknown'}`,
     `Iterations: ${report.iterations}`,
     '',
+    ...buildPackageImpactMarkdown(report.packageImpact),
+    '',
     'Command shape: `cjpegli INPUT OUTPUT --distance <distance> --quiet`',
     '',
     '| Case | Input | Width | MozJPEG q | jpegli distance | MozJPEG bytes | jpegli bytes | jpegli bytes delta | MozJPEG ms | jpegli ms | jpegli ms delta | MozJPEG SSIM | jpegli SSIM | SSIM delta | MozJPEG PSNR | jpegli PSNR | PSNR delta |',
@@ -346,6 +349,10 @@ async function main() {
       cjpegliProbe: probe.help,
     },
     iterations: options.iterations,
+    packageImpact: collectBenchmarkPackageImpact({
+      benchmarkTool: 'cjpegli',
+      candidateBackend: 'jpegli',
+    }),
     commandShape: 'cjpegli INPUT OUTPUT --distance <distance> --quiet',
     timingNote:
       'MozJPEG time measures in-process encode from the resized reference PNG buffer; jpegli time measures cjpegli process wall time from the same resized reference PNG file.',

--- a/test/helpers/package-impact.js
+++ b/test/helpers/package-impact.js
@@ -1,0 +1,70 @@
+const fs = require('node:fs');
+const { resolveRoot } = require('./paths');
+
+function readPackageJson() {
+  return JSON.parse(fs.readFileSync(resolveRoot('package.json'), 'utf8'));
+}
+
+function collectBenchmarkPackageImpact({ benchmarkTool, candidateBackend }) {
+  const pkg = readPackageJson();
+  const optionalDependencyPackages = Object.keys(pkg.optionalDependencies || {}).sort();
+  const nativeTargets = Array.isArray(pkg.napi?.targets) ? [...pkg.napi.targets].sort() : [];
+
+  return {
+    packageName: pkg.name,
+    packageVersion: pkg.version,
+    npmFiles: Array.isArray(pkg.files) ? [...pkg.files] : [],
+    optionalDependencyPackages,
+    optionalDependencyCount: optionalDependencyPackages.length,
+    nativeTargets,
+    nativeTargetCount: nativeTargets.length,
+    publicApiChanged: false,
+    runtimePackageChanged: false,
+    productionBuildDependencyChanged: false,
+    benchmarkTool,
+    candidateBackend,
+    benchmarkToolingScope:
+      `${benchmarkTool} is an operator-provided benchmark CLI and is not linked into lazy-image native packages.`,
+    crossPlatformImpact: {
+      macos: 'unchanged by this benchmark harness',
+      linux: 'unchanged by this benchmark harness',
+      windows: 'unchanged by this benchmark harness',
+    },
+    futureProductionSwitchRequires: [
+      `Measure macOS, Linux, and Windows native package size after linking ${candidateBackend}.`,
+      `Measure CI build time after adding ${candidateBackend} as a production build dependency.`,
+      'Keep npm package files and optional platform packages stable unless the backend switch PR explicitly changes them.',
+    ],
+  };
+}
+
+function buildPackageImpactMarkdown(packageImpact) {
+  const targets = packageImpact.nativeTargets.length ? packageImpact.nativeTargets.join(', ') : 'none';
+  const npmFiles = packageImpact.npmFiles.length ? packageImpact.npmFiles.join(', ') : 'none';
+
+  return [
+    '## Package / Build Impact',
+    '',
+    `Package: ${packageImpact.packageName}@${packageImpact.packageVersion}`,
+    `Benchmark tool: ${packageImpact.benchmarkTool}`,
+    `Candidate backend: ${packageImpact.candidateBackend}`,
+    `Runtime package changed: ${packageImpact.runtimePackageChanged ? 'yes' : 'no'}`,
+    `Production build dependency changed: ${packageImpact.productionBuildDependencyChanged ? 'yes' : 'no'}`,
+    `Public API changed: ${packageImpact.publicApiChanged ? 'yes' : 'no'}`,
+    `NAPI targets (${packageImpact.nativeTargetCount}): ${targets}`,
+    `Optional platform packages: ${packageImpact.optionalDependencyCount}`,
+    `npm files allowlist: ${npmFiles}`,
+    `macOS impact: ${packageImpact.crossPlatformImpact.macos}`,
+    `Linux impact: ${packageImpact.crossPlatformImpact.linux}`,
+    `Windows impact: ${packageImpact.crossPlatformImpact.windows}`,
+    `Tooling scope: ${packageImpact.benchmarkToolingScope}`,
+    '',
+    'Future production switch evidence required:',
+    ...packageImpact.futureProductionSwitchRequires.map((item) => `- ${item}`),
+  ];
+}
+
+module.exports = {
+  buildPackageImpactMarkdown,
+  collectBenchmarkPackageImpact,
+};

--- a/test/integration/benchmark-package-impact.test.js
+++ b/test/integration/benchmark-package-impact.test.js
@@ -1,0 +1,77 @@
+/**
+ * Regression coverage for benchmark package/build-impact metadata.
+ *
+ * Backend bake-off artifacts should make it clear whether a benchmark harness
+ * changed the production package contract or only used operator-provided tools.
+ */
+
+const assert = require('node:assert/strict');
+const {
+  buildPackageImpactMarkdown,
+  collectBenchmarkPackageImpact,
+} = require('../helpers/package-impact');
+
+let passed = 0;
+let failed = 0;
+
+function report(name, error) {
+  if (error) {
+    console.log(`not ok - ${name}`);
+    console.log(`   Error: ${error.message}`);
+    failed += 1;
+  } else {
+    console.log(`ok - ${name}`);
+    passed += 1;
+  }
+}
+
+function test(name, fn) {
+  try {
+    fn();
+    report(name);
+  } catch (error) {
+    report(name, error);
+  }
+}
+
+console.log('=== Benchmark Package Impact Metadata Tests ===\n');
+
+test('collects native package contract metadata for backend bake-offs', () => {
+  const impact = collectBenchmarkPackageImpact({
+    benchmarkTool: 'cjpegli',
+    candidateBackend: 'jpegli',
+  });
+
+  assert.equal(impact.packageName, '@alberteinshutoin/lazy-image');
+  assert.equal(impact.runtimePackageChanged, false);
+  assert.equal(impact.productionBuildDependencyChanged, false);
+  assert.equal(impact.publicApiChanged, false);
+  assert.equal(impact.optionalDependencyCount, 6);
+  assert.equal(impact.nativeTargetCount, 6);
+  assert(impact.npmFiles.includes('index.js'));
+  assert(impact.npmFiles.includes('README.md'));
+  assert(impact.nativeTargets.includes('x86_64-pc-windows-msvc'));
+  assert.match(impact.benchmarkToolingScope, /operator-provided benchmark CLI/);
+});
+
+test('renders cross-platform impact into Markdown artifacts', () => {
+  const markdown = buildPackageImpactMarkdown(
+    collectBenchmarkPackageImpact({
+      benchmarkTool: 'avifenc',
+      candidateBackend: 'libavif backend matrix',
+    })
+  ).join('\n');
+
+  assert.match(markdown, /## Package \/ Build Impact/);
+  assert.match(markdown, /Runtime package changed: no/);
+  assert.match(markdown, /Production build dependency changed: no/);
+  assert.match(markdown, /macOS impact: unchanged by this benchmark harness/);
+  assert.match(markdown, /Linux impact: unchanged by this benchmark harness/);
+  assert.match(markdown, /Windows impact: unchanged by this benchmark harness/);
+  assert.match(markdown, /Future production switch evidence required:/);
+});
+
+console.log(`\nTests passed: ${passed}, failed: ${failed}`);
+if (failed > 0) {
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add shared benchmark package/build-impact metadata for codec bake-off artifacts
- include package impact sections in JPEG/jpegli and AVIF backend bake-off Markdown reports
- add integration coverage for package-impact metadata collected from package.json

## Issue validity self-review
- #638 and #639 are valid P1 tasks because backend replacement decisions need benchmark artifacts that cover more than bytes/time/quality. Package files, NAPI targets, optional platform packages, and cross-platform build impact are part of the acceptance criteria before promoting jpegli or a different libavif backend.
- This PR does not claim a backend winner and does not change production codec behavior. It closes a reproducibility gap in the artifact shape.

## Implementation self-review
- The new helper reads the existing package contract from package.json and records that these harnesses use operator-provided CLIs instead of linking new production build dependencies.
- Both bake-off reports now emit the same JSON/Markdown package-impact evidence, keeping JPEG and AVIF decision artifacts aligned.
- The integration test locks the expected native target count, optional package count, and cross-platform Markdown fields so future package contract drift is visible.

## Verification
- node --check test/helpers/package-impact.js && node --check test/integration/benchmark-package-impact.test.js && node --check test/benchmarks/jpegli-bakeoff.bench.js && node --check test/benchmarks/avif-backend-bakeoff.bench.js
- node test/integration/benchmark-package-impact.test.js
- JPEGLI_ALLOW_MISSING=1 npm run test:bench:jpegli -- --output-dir .tmp/jpegli-package-impact-smoke
- AVIF_BACKEND_ALLOW_MISSING=1 npm run test:bench:avif-backends -- --output-dir .tmp/avif-package-impact-smoke
- git diff --check
- npm run build
- npm test

## Notes
- cjpegli and avifenc were not installed in this local environment, so no publishable codec bake-off result was generated here.
- Refs #638
- Refs #639