### PR TITLE
bench: record bakeoff corpus manifests

### DIFF
--- a/test/benchmarks/avif-backend-bakeoff.bench.js
+++ b/test/benchmarks/avif-backend-bakeoff.bench.js
@@ -5,6 +5,7 @@ const { spawn, spawnSync } = require('child_process');
 const sharp = require('sharp');
 const { resolveFixture, resolveRoot, resolveTemp } = require('../helpers/paths');
 const { calculateQualityMetrics } = require('../helpers/quality');
+const { buildCorpusManifestMarkdown, describeReferenceCorpusEntry } = require('../helpers/benchmark-corpus');
 const { buildPackageImpactMarkdown, collectBenchmarkPackageImpact } = require('../helpers/package-impact');
 const { ImageEngine } = require(resolveRoot('index'));
 
@@ -470,6 +471,28 @@ async function runCase(testCase, options) {
     iterations: options.iterations,
     speed: lazyImageAvifSpeed(testCase.quality),
   };
+  const corpusEntry = await describeReferenceCorpusEntry({
+    label: testCase.label,
+    sourcePath: testCase.input || null,
+    sourceKind: testCase.source || 'fixture',
+    generatedBy: testCase.input ? null : testCase.source,
+    referencePng,
+    referencePngPath,
+    settings: {
+      width: testCase.width,
+      height: testCase.height ?? null,
+      quality: testCase.quality,
+      speed: lazyCase.speed,
+      yuv: '420',
+      range: 'full',
+      qalpha: testCase.quality,
+      jobs: String(options.jobs),
+    },
+    expectations: {
+      alpha: Boolean(testCase.expectAlpha),
+      icc: Boolean(testCase.expectIcc),
+    },
+  });
   const baseline = await encodeLazyImage(referencePng, lazyCase);
   const backends = {};
   const deltas = {};
@@ -482,31 +505,34 @@ async function runCase(testCase, options) {
   }
 
   return {
-    label: testCase.label,
-    source: testCase.source,
-    input: testCase.input ? path.relative(resolveRoot(), testCase.input) : testCase.source,
-    width: testCase.width,
-    height: testCase.height ?? null,
-    settings: {
-      quality: testCase.quality,
-      speed: lazyCase.speed,
-      yuv: '420',
-      range: 'full',
-      qalpha: testCase.quality,
-      jobs: String(options.jobs),
-      lazyImageThreads: lazyImageAvifThreads(),
+    corpusEntry,
+    result: {
+      label: testCase.label,
+      source: testCase.source,
+      input: testCase.input ? path.relative(resolveRoot(), testCase.input) : testCase.source,
+      width: testCase.width,
+      height: testCase.height ?? null,
+      settings: {
+        quality: testCase.quality,
+        speed: lazyCase.speed,
+        yuv: '420',
+        range: 'full',
+        qalpha: testCase.quality,
+        jobs: String(options.jobs),
+        lazyImageThreads: lazyImageAvifThreads(),
+      },
+      expectations: {
+        alpha: Boolean(testCase.expectAlpha),
+        icc: Boolean(testCase.expectIcc),
+      },
+      commands: {
+        lazyImage: `ImageEngine.from(referencePng).toBufferWithMetrics('avif', ${testCase.quality})`,
+        avifenc: `avifenc --codec <backend> --qcolor ${testCase.quality} --qalpha ${testCase.quality} --speed ${lazyCase.speed} --jobs ${options.jobs} --yuv 420 --range full INPUT OUTPUT`,
+      },
+      lazyImage: baseline,
+      backends,
+      deltas,
     },
-    expectations: {
-      alpha: Boolean(testCase.expectAlpha),
-      icc: Boolean(testCase.expectIcc),
-    },
-    commands: {
-      lazyImage: `ImageEngine.from(referencePng).toBufferWithMetrics('avif', ${testCase.quality})`,
-      avifenc: `avifenc --codec <backend> --qcolor ${testCase.quality} --qalpha ${testCase.quality} --speed ${lazyCase.speed} --jobs ${options.jobs} --yuv 420 --range full INPUT OUTPUT`,
-    },
-    lazyImage: baseline,
-    backends,
-    deltas,
   };
 }
 
@@ -528,6 +554,8 @@ function buildMarkdown(report) {
     `Iterations: ${report.iterations}`,
     '',
     ...buildPackageImpactMarkdown(report.packageImpact),
+    '',
+    ...buildCorpusManifestMarkdown(report.corpus),
     '',
     'Command shape: `avifenc --codec <backend> --qcolor <quality> --qalpha <quality> --speed <speed> --jobs <jobs> --yuv 420 --range full INPUT OUTPUT`',
     'Quality/CQ mapping: `qcolor` and `qalpha` use the libavif 0..100 quality scale; codec-specific quantizer mapping remains inside libavif/avifenc.',
@@ -665,9 +693,12 @@ async function main() {
   console.log(`Output directory: ${options.outputDir}\n`);
 
   const results = [];
+  const corpus = [];
   for (const testCase of CASES) {
     console.log(`- ${testCase.label}`);
-    results.push(await runCase(testCase, options));
+    const { result, corpusEntry } = await runCase(testCase, options);
+    results.push(result);
+    corpus.push(corpusEntry);
   }
 
   const report = {
@@ -703,6 +734,7 @@ async function main() {
       benchmarkTool: 'avifenc',
       candidateBackend: 'libavif backend matrix',
     }),
+    corpus,
     commandShape:
       'avifenc --codec <backend> --qcolor <quality> --qalpha <quality> --speed <speed> --jobs <jobs> --yuv 420 --range full INPUT OUTPUT',
     timingNote:

--- a/test/benchmarks/jpegli-bakeoff.bench.js
+++ b/test/benchmarks/jpegli-bakeoff.bench.js
@@ -4,6 +4,7 @@ const { spawnSync } = require('child_process');
 const sharp = require('sharp');
 const { resolveFixture, resolveRoot, resolveTemp } = require('../helpers/paths');
 const { calculateQualityMetrics } = require('../helpers/quality');
+const { buildCorpusManifestMarkdown, describeReferenceCorpusEntry } = require('../helpers/benchmark-corpus');
 const { buildPackageImpactMarkdown, collectBenchmarkPackageImpact } = require('../helpers/package-impact');
 const { ImageEngine } = require(resolveRoot('index'));
 
@@ -166,6 +167,18 @@ async function runCase(testCase, options) {
   const referencePng = await buildReferencePng(testCase);
   const pngPath = path.join(TEMP_DIR, `${testCase.label}.png`);
   fs.writeFileSync(pngPath, referencePng);
+  const corpusEntry = await describeReferenceCorpusEntry({
+    label: testCase.label,
+    sourcePath: testCase.input,
+    sourceKind: 'fixture',
+    referencePng,
+    referencePngPath: pngPath,
+    settings: {
+      width: testCase.width,
+      mozjpegQuality: testCase.mozjpegQuality,
+      jpegliDistance: testCase.jpegliDistance,
+    },
+  });
 
   const mozjpegTimes = [];
   const jpegliTimes = [];
@@ -189,42 +202,45 @@ async function runCase(testCase, options) {
   ]);
 
   return {
-    label: testCase.label,
-    input: path.relative(resolveRoot(), testCase.input),
-    width: testCase.width,
-    settings: {
-      mozjpegQuality: testCase.mozjpegQuality,
-      jpegliDistance: testCase.jpegliDistance,
-    },
-    commands: {
-      mozjpeg: `ImageEngine.from(referencePng).toBuffer('jpeg', ${testCase.mozjpegQuality})`,
-      jpegli: [
-        options.cjpegli,
-        path.relative(resolveRoot(), pngPath),
-        path.relative(resolveRoot(), path.join(TEMP_DIR, `${testCase.label}-<iteration>.jpegli.jpg`)),
-        '--distance',
-        String(testCase.jpegliDistance),
-        '--quiet',
-      ].join(' '),
-    },
-    mozjpeg: {
-      bytes: mozjpegData.length,
-      avgEncodeMs: average(mozjpegTimes),
-      ssim: mozjpegQuality.ssim,
-      psnr: mozjpegQuality.psnr,
-    },
-    jpegli: {
-      bytes: jpegliData.length,
-      avgEncodeMs: average(jpegliTimes),
-      ssim: jpegliQuality.ssim,
-      psnr: jpegliQuality.psnr,
-    },
-    delta: {
-      bytesPercent: ((jpegliData.length - mozjpegData.length) / Math.max(mozjpegData.length, 1)) * 100,
-      encodeMsPercent:
-        ((average(jpegliTimes) - average(mozjpegTimes)) / Math.max(average(mozjpegTimes), 0.001)) * 100,
-      ssim: jpegliQuality.ssim - mozjpegQuality.ssim,
-      psnr: jpegliQuality.psnr - mozjpegQuality.psnr,
+    corpusEntry,
+    result: {
+      label: testCase.label,
+      input: path.relative(resolveRoot(), testCase.input),
+      width: testCase.width,
+      settings: {
+        mozjpegQuality: testCase.mozjpegQuality,
+        jpegliDistance: testCase.jpegliDistance,
+      },
+      commands: {
+        mozjpeg: `ImageEngine.from(referencePng).toBuffer('jpeg', ${testCase.mozjpegQuality})`,
+        jpegli: [
+          options.cjpegli,
+          path.relative(resolveRoot(), pngPath),
+          path.relative(resolveRoot(), path.join(TEMP_DIR, `${testCase.label}-<iteration>.jpegli.jpg`)),
+          '--distance',
+          String(testCase.jpegliDistance),
+          '--quiet',
+        ].join(' '),
+      },
+      mozjpeg: {
+        bytes: mozjpegData.length,
+        avgEncodeMs: average(mozjpegTimes),
+        ssim: mozjpegQuality.ssim,
+        psnr: mozjpegQuality.psnr,
+      },
+      jpegli: {
+        bytes: jpegliData.length,
+        avgEncodeMs: average(jpegliTimes),
+        ssim: jpegliQuality.ssim,
+        psnr: jpegliQuality.psnr,
+      },
+      delta: {
+        bytesPercent: ((jpegliData.length - mozjpegData.length) / Math.max(mozjpegData.length, 1)) * 100,
+        encodeMsPercent:
+          ((average(jpegliTimes) - average(mozjpegTimes)) / Math.max(average(mozjpegTimes), 0.001)) * 100,
+        ssim: jpegliQuality.ssim - mozjpegQuality.ssim,
+        psnr: jpegliQuality.psnr - mozjpegQuality.psnr,
+      },
     },
   };
 }
@@ -245,6 +261,8 @@ function buildMarkdown(report) {
     `Iterations: ${report.iterations}`,
     '',
     ...buildPackageImpactMarkdown(report.packageImpact),
+    '',
+    ...buildCorpusManifestMarkdown(report.corpus),
     '',
     'Command shape: `cjpegli INPUT OUTPUT --distance <distance> --quiet`',
     '',
@@ -326,9 +344,12 @@ async function main() {
   }
 
   const results = [];
+  const corpus = [];
   for (const testCase of CASES) {
     console.log(`- ${testCase.label}`);
-    results.push(await runCase(testCase, options));
+    const { result, corpusEntry } = await runCase(testCase, options);
+    results.push(result);
+    corpus.push(corpusEntry);
   }
 
   const report = {
@@ -353,6 +374,7 @@ async function main() {
       benchmarkTool: 'cjpegli',
       candidateBackend: 'jpegli',
     }),
+    corpus,
     commandShape: 'cjpegli INPUT OUTPUT --distance <distance> --quiet',
     timingNote:
       'MozJPEG time measures in-process encode from the resized reference PNG buffer; jpegli time measures cjpegli process wall time from the same resized reference PNG file.',

--- a/test/helpers/benchmark-corpus.js
+++ b/test/helpers/benchmark-corpus.js
@@ -1,0 +1,118 @@
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+const sharp = require('sharp');
+const { resolveRoot } = require('./paths');
+
+function sha256(buffer) {
+  return crypto.createHash('sha256').update(buffer).digest('hex');
+}
+
+function relativeRoot(filePath) {
+  return path.relative(resolveRoot(), filePath);
+}
+
+function describeSource({ sourcePath, sourceKind, generatedBy }) {
+  if (!sourcePath) {
+    return {
+      kind: sourceKind || 'generated',
+      generator: generatedBy || sourceKind || 'unknown',
+      path: null,
+      bytes: null,
+      sha256: null,
+    };
+  }
+
+  const data = fs.readFileSync(sourcePath);
+  return {
+    kind: sourceKind || 'fixture',
+    path: relativeRoot(sourcePath),
+    bytes: data.length,
+    sha256: sha256(data),
+  };
+}
+
+async function describeReferenceCorpusEntry({
+  label,
+  sourcePath = null,
+  sourceKind = 'fixture',
+  generatedBy = null,
+  referencePng,
+  referencePngPath,
+  settings = {},
+  expectations = {},
+}) {
+  const metadata = await sharp(referencePng).metadata();
+
+  return {
+    label,
+    source: describeSource({ sourcePath, sourceKind, generatedBy }),
+    referencePng: {
+      path: relativeRoot(referencePngPath),
+      bytes: referencePng.length,
+      sha256: sha256(referencePng),
+      width: metadata.width ?? null,
+      height: metadata.height ?? null,
+      channels: metadata.channels ?? null,
+      hasAlpha: Boolean(metadata.hasAlpha),
+      iccBytes: metadata.icc ? metadata.icc.length : 0,
+    },
+    settings,
+    expectations,
+  };
+}
+
+function formatKeyValues(value) {
+  const entries = Object.entries(value || {});
+  if (entries.length === 0) return 'n/a';
+  return entries.map(([key, item]) => `${key}=${item}`).join(', ');
+}
+
+function markdownCell(value) {
+  return String(value ?? 'n/a').replace(/\|/g, '\\|').replace(/\s+/g, ' ').trim();
+}
+
+function shortSha(value) {
+  return value ? value.slice(0, 12) : 'n/a';
+}
+
+function sourceLabel(source) {
+  if (source.path) return source.path;
+  return source.generator || source.kind || 'generated';
+}
+
+function buildCorpusManifestMarkdown(corpus) {
+  const lines = [
+    '## Corpus Manifest',
+    '',
+    '| Case | Source | Source bytes | Source SHA-256 | Reference PNG | Reference size | Reference SHA-256 | Settings | Expectations |',
+    '|---|---|---:|---|---|---|---|---|---|',
+  ];
+
+  for (const entry of corpus) {
+    lines.push(
+      [
+        entry.label,
+        sourceLabel(entry.source),
+        entry.source.bytes ?? 'n/a',
+        shortSha(entry.source.sha256),
+        entry.referencePng.path,
+        `${entry.referencePng.width}x${entry.referencePng.height}`,
+        shortSha(entry.referencePng.sha256),
+        formatKeyValues(entry.settings),
+        formatKeyValues(entry.expectations),
+      ]
+        .map(markdownCell)
+        .join(' | ')
+        .replace(/^/, '| ')
+        .replace(/$/, ' |')
+    );
+  }
+
+  return lines;
+}
+
+module.exports = {
+  buildCorpusManifestMarkdown,
+  describeReferenceCorpusEntry,
+};

--- a/test/helpers/benchmark-corpus.js
+++ b/test/helpers/benchmark-corpus.js
@@ -9,7 +9,7 @@ function sha256(buffer) {
 }
 
 function relativeRoot(filePath) {
-  return path.relative(resolveRoot(), filePath);
+  return path.relative(resolveRoot(), filePath).replace(/\\/g, '/');
 }
 
 function describeSource({ sourcePath, sourceKind, generatedBy }) {

--- a/test/integration/benchmark-corpus-manifest.test.js
+++ b/test/integration/benchmark-corpus-manifest.test.js
@@ -125,6 +125,7 @@ async function main() {
     assert.match(markdown, /## Corpus Manifest/);
     assert.match(markdown, /markdown-case/);
     assert.match(markdown, /test\/fixtures\/test_38kb_input\.jpg/);
+    assert.doesNotMatch(markdown, /test\\fixtures\\test_38kb_input\.jpg/);
     assert.match(markdown, /width=32, mozjpegQuality=80/);
     assert.match(markdown, /[a-f0-9]{12}/);
   });

--- a/test/integration/benchmark-corpus-manifest.test.js
+++ b/test/integration/benchmark-corpus-manifest.test.js
@@ -1,0 +1,141 @@
+/**
+ * Regression coverage for benchmark corpus manifests.
+ *
+ * Backend bake-off artifacts should identify the exact input corpus and the
+ * resized reference PNGs used for codec comparison.
+ */
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const sharp = require('sharp');
+const {
+  buildCorpusManifestMarkdown,
+  describeReferenceCorpusEntry,
+} = require('../helpers/benchmark-corpus');
+const { resolveFixture, resolveTemp } = require('../helpers/paths');
+
+let passed = 0;
+let failed = 0;
+
+function report(name, error) {
+  if (error) {
+    console.log(`not ok - ${name}`);
+    console.log(`   Error: ${error.message}`);
+    failed += 1;
+  } else {
+    console.log(`ok - ${name}`);
+    passed += 1;
+  }
+}
+
+async function test(name, fn) {
+  try {
+    await fn();
+    report(name);
+  } catch (error) {
+    report(name, error);
+  }
+}
+
+console.log('=== Benchmark Corpus Manifest Tests ===\n');
+
+const outputDir = resolveTemp('integration', 'benchmark-corpus-manifest');
+fs.mkdirSync(outputDir, { recursive: true });
+
+async function main() {
+  await test('records fixture source and resized reference PNG digests', async () => {
+    const sourcePath = resolveFixture('test_38kb_input.jpg');
+    const referencePng = await sharp(sourcePath).resize(64, null, { withoutEnlargement: true }).png().toBuffer();
+    const referencePngPath = path.join(outputDir, 'fixture-reference.png');
+    fs.writeFileSync(referencePngPath, referencePng);
+
+    const entry = await describeReferenceCorpusEntry({
+      label: 'fixture-case',
+      sourcePath,
+      referencePng,
+      referencePngPath,
+      settings: {
+        width: 64,
+        quality: 80,
+      },
+    });
+
+    assert.equal(entry.label, 'fixture-case');
+    assert.equal(entry.source.kind, 'fixture');
+    assert.equal(entry.source.bytes, fs.statSync(sourcePath).size);
+    assert.match(entry.source.sha256, /^[a-f0-9]{64}$/);
+    assert.match(entry.referencePng.sha256, /^[a-f0-9]{64}$/);
+    assert.equal(entry.referencePng.width, 64);
+    assert.equal(entry.referencePng.bytes, referencePng.length);
+    assert.equal(entry.settings.quality, 80);
+  });
+
+  await test('records generated corpus entries without pretending they are fixtures', async () => {
+    const referencePng = await sharp({
+      create: {
+        width: 12,
+        height: 8,
+        channels: 4,
+        background: { r: 255, g: 0, b: 0, alpha: 0.5 },
+      },
+    })
+      .png()
+      .toBuffer();
+    const referencePngPath = path.join(outputDir, 'generated-reference.png');
+    fs.writeFileSync(referencePngPath, referencePng);
+
+    const entry = await describeReferenceCorpusEntry({
+      label: 'generated-case',
+      sourceKind: 'generated-alpha-gradient',
+      generatedBy: 'generated-alpha-gradient',
+      referencePng,
+      referencePngPath,
+      expectations: {
+        alpha: true,
+        icc: false,
+      },
+    });
+
+    assert.equal(entry.source.kind, 'generated-alpha-gradient');
+    assert.equal(entry.source.path, null);
+    assert.equal(entry.source.sha256, null);
+    assert.equal(entry.referencePng.hasAlpha, true);
+    assert.equal(entry.expectations.alpha, true);
+  });
+
+  await test('renders corpus manifest markdown with compact digests and settings', async () => {
+    const sourcePath = resolveFixture('test_38kb_input.jpg');
+    const referencePng = await sharp(sourcePath).resize(32, null, { withoutEnlargement: true }).png().toBuffer();
+    const referencePngPath = path.join(outputDir, 'markdown-reference.png');
+    fs.writeFileSync(referencePngPath, referencePng);
+
+    const entry = await describeReferenceCorpusEntry({
+      label: 'markdown-case',
+      sourcePath,
+      referencePng,
+      referencePngPath,
+      settings: {
+        width: 32,
+        mozjpegQuality: 80,
+      },
+    });
+    const markdown = buildCorpusManifestMarkdown([entry]).join('\n');
+
+    assert.match(markdown, /## Corpus Manifest/);
+    assert.match(markdown, /markdown-case/);
+    assert.match(markdown, /test\/fixtures\/test_38kb_input\.jpg/);
+    assert.match(markdown, /width=32, mozjpegQuality=80/);
+    assert.match(markdown, /[a-f0-9]{12}/);
+  });
+
+  console.log(`\nTests passed: ${passed}, failed: ${failed}`);
+  if (failed > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add a benchmark corpus manifest helper that records fixture/generated sources, resized reference PNG metadata, byte counts, and SHA-256 digests.
- Include the corpus manifest in both JPEG jpegli and AVIF backend bake-off JSON/Markdown reports.
- Add integration coverage for fixture-backed and generated corpus entries.

## Self-review
- Issue validity: #638 and #639 are still valid P1 items because backend replacement decisions need reproducible evidence, not only bytes/time/quality tables. The previous harnesses had versions, settings, commands, and package impact, but the exact corpus identity was only implicit in per-result input labels.
- Implementation fit: this PR does not change production codec behavior, public API, package files, or backend selection. It only makes benchmark artifacts more audit-ready by recording source/reference digests and generated-input provenance.
- Scope boundary: this is not a published jpegli/AVIF decision artifact. `cjpegli` and `avifenc` are still required locally to produce actual codec comparison results.

## Verification
- `node --check test/helpers/benchmark-corpus.js && node --check test/integration/benchmark-corpus-manifest.test.js && node --check test/benchmarks/jpegli-bakeoff.bench.js && node --check test/benchmarks/avif-backend-bakeoff.bench.js && node test/integration/benchmark-corpus-manifest.test.js && git diff --check`
- `JPEGLI_ALLOW_MISSING=1 npm run test:bench:jpegli -- --output-dir .tmp/jpegli-corpus-manifest-smoke`
- `AVIF_BACKEND_ALLOW_MISSING=1 npm run test:bench:avif-backends -- --output-dir .tmp/avif-corpus-manifest-smoke`
- `npm run build && npm test`

Refs #638
Refs #639
