### PR TITLE
bench: add jpegli matched target tuning

### DIFF
--- a/docs/BENCHMARK_OPERATIONS.md
+++ b/docs/BENCHMARK_OPERATIONS.md
@@ -64,10 +64,11 @@ Regression means "current metric value is higher than baseline by more than thre
 - Run manually before releases or after significant image pipeline/perf changes.
 - Run the Wasm upload benchmark before making browser/Edge upload-preflight claims. See [WASM_BENCHMARKING.md](./WASM_BENCHMARKING.md).
 - Run the JPEG backend bake-off before considering a mozjpeg-to-jpegli backend switch.
-  The harness compares current lazy-image MozJPEG output against `cjpegli` on the same resized PNG intermediate and records exact package/crate versions, settings, command shape, output bytes, encode time, SSIM, and PSNR.
+  The harness compares current lazy-image MozJPEG output against `cjpegli` on the same resized PNG intermediate and records exact package/crate versions, settings, command shape, output bytes, encode time, SSIM, PSNR, and matched-target distance tuning summaries.
 - The JPEG bake-off requires `cjpegli` from jpegli. Set `JPEGLI_CJPEGLI=/path/to/cjpegli` or pass `-- --cjpegli /path/to/cjpegli` when the binary is not on `PATH`.
 - Do not substitute JPEG XL's `cjxl` for `cjpegli`; `cjxl` produces JPEG XL output, while this bake-off is for JPEG-compatible jpegli output.
 - If `cjpegli --version` does not report an exact tag or commit, set `JPEGLI_VERSION=<tag-or-commit>` or pass `-- --jpegli-version <tag-or-commit>` so the artifact remains reproducible.
+- The JPEG bake-off sweeps `--distance-candidates` by default and reports both a matched-byte candidate (closest output size to MozJPEG) and a matched-quality candidate (closest SSIM to MozJPEG). Each case also includes its configured baseline distance if it is missing from the requested list. Override with `JPEGLI_DISTANCE_CANDIDATES=0.8,1,1.4,2.2,3.4,5.2,8` or `-- --distance-candidates ...` when tuning a narrower range. Use `--skip-distance-tuning` only for quick wiring smoke checks, not publishable jpegli evidence.
 - Cross-platform impact for this harness is limited to benchmark operation: lazy-image runtime and package contents are unchanged, and `cjpegli` is an operator-provided CLI. Any future backend switch proposal must attach macOS, Linux, and Windows build/package-size impact because that would introduce a production build dependency instead of an optional benchmark tool.
 - `JPEGLI_ALLOW_MISSING=1 npm run test:bench:jpegli` is only for smoke-checking script wiring in environments without jpegli. Do not use skip-mode output as benchmark evidence.
 - Run the AVIF backend bake-off before changing the production libavif backend away from the current rav1e feature.

--- a/test/benchmarks/jpegli-bakeoff.bench.js
+++ b/test/benchmarks/jpegli-bakeoff.bench.js
@@ -9,6 +9,14 @@ const {
   JPEG_BACKEND_BAKEOFF_CASES: CASES,
   buildBakeoffCorpusExpectations,
 } = require('../helpers/codec-bakeoff-cases');
+const {
+  DEFAULT_JPEGLI_DISTANCE_CANDIDATES,
+  buildDistanceCandidates,
+  buildTuningCandidate,
+  chooseMatchedBytesCandidate,
+  chooseMatchedQualityCandidate,
+  parseDistanceCandidateList,
+} = require('../helpers/jpegli-distance-tuning');
 const { buildPackageImpactMarkdown, collectBenchmarkPackageImpact } = require('../helpers/package-impact');
 const { ImageEngine } = require(resolveRoot('index'));
 
@@ -259,6 +267,68 @@ function runCjpegli(cjpegli, inputPath, outputPath, distance) {
   return { data: fs.readFileSync(outputPath), encodeMs };
 }
 
+async function runDistanceTuning({
+  testCase,
+  options,
+  referencePng,
+  pngPath,
+  mozjpegData,
+  mozjpegQuality,
+}) {
+  if (!options.tuneDistances) {
+    return {
+      enabled: false,
+      reason: 'disabled by --skip-distance-tuning or JPEGLI_SKIP_DISTANCE_TUNING=1',
+    };
+  }
+
+  const distanceCandidates = buildDistanceCandidates(testCase.jpegliDistance, options.distanceCandidates);
+  const candidates = [];
+
+  for (const distance of distanceCandidates) {
+    const outputPath = path.join(TEMP_DIR, `${testCase.label}-distance-${distance}.jpegli.jpg`);
+    const output = path.relative(resolveRoot(), outputPath);
+    const command = [
+      options.cjpegli,
+      path.relative(resolveRoot(), pngPath),
+      output,
+      '--distance',
+      String(distance),
+      '--quiet',
+    ].join(' ');
+    const encoded = runCjpegli(options.cjpegli, pngPath, outputPath, distance);
+    const quality = await calculateQualityMetrics(encoded.data, referencePng);
+
+    candidates.push({
+      ...buildTuningCandidate({
+        distance,
+        bytes: encoded.data.length,
+        encodeMs: encoded.encodeMs,
+        ssim: quality.ssim,
+        psnr: quality.psnr,
+        targetBytes: mozjpegData.length,
+        targetSsim: mozjpegQuality.ssim,
+        targetPsnr: mozjpegQuality.psnr,
+      }),
+      output,
+      command,
+    });
+  }
+
+  return {
+    enabled: true,
+    target: {
+      mozjpegBytes: mozjpegData.length,
+      mozjpegSsim: mozjpegQuality.ssim,
+      mozjpegPsnr: mozjpegQuality.psnr,
+    },
+    distanceCandidates,
+    candidates,
+    matchedBytes: chooseMatchedBytesCandidate(candidates),
+    matchedQuality: chooseMatchedQualityCandidate(candidates),
+  };
+}
+
 async function runCase(testCase, options) {
   const referencePng = await buildReferencePng(testCase);
   const pngPath = path.join(TEMP_DIR, `${testCase.label}.png`);
@@ -299,6 +369,14 @@ async function runCase(testCase, options) {
     calculateQualityMetrics(mozjpegData, referencePng),
     calculateQualityMetrics(jpegliData, referencePng),
   ]);
+  const tuning = await runDistanceTuning({
+    testCase,
+    options,
+    referencePng,
+    pngPath,
+    mozjpegData,
+    mozjpegQuality,
+  });
 
   return {
     corpusEntry,
@@ -340,6 +418,7 @@ async function runCase(testCase, options) {
         ssim: jpegliQuality.ssim - mozjpegQuality.ssim,
         psnr: jpegliQuality.psnr - mozjpegQuality.psnr,
       },
+      tuning,
     },
   };
 }
@@ -364,10 +443,26 @@ function buildMarkdown(report) {
     ...buildCorpusManifestMarkdown(report.corpus),
     '',
     'Command shape: `cjpegli INPUT OUTPUT --distance <distance> --quiet`',
-    '',
-    '| Case | Input | Width | MozJPEG q | jpegli distance | MozJPEG bytes | jpegli bytes | jpegli bytes delta | MozJPEG ms | jpegli ms | jpegli ms delta | MozJPEG SSIM | jpegli SSIM | SSIM delta | MozJPEG PSNR | jpegli PSNR | PSNR delta |',
-    '|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|',
+    `Distance tuning: ${report.tuning.enabled ? 'enabled' : 'disabled'}`,
   ];
+
+  if (report.tuning.enabled) {
+    lines.push(
+      `Requested distance candidates: ${report.tuning.requestedDistanceCandidates.join(', ')}`,
+      'Matched-byte target: minimize absolute byte delta against the MozJPEG output for the same resized reference PNG.',
+      'Matched-quality target: minimize absolute SSIM delta against the MozJPEG output for the same resized reference PNG.',
+      ''
+    );
+  } else if (report.tuning.reason) {
+    lines.push(`Distance tuning reason: ${report.tuning.reason}`, '');
+  } else {
+    lines.push('');
+  }
+
+  lines.push(
+    '| Case | Input | Width | MozJPEG q | jpegli distance | MozJPEG bytes | jpegli bytes | jpegli bytes delta | MozJPEG ms | jpegli ms | jpegli ms delta | MozJPEG SSIM | jpegli SSIM | SSIM delta | MozJPEG PSNR | jpegli PSNR | PSNR delta |',
+    '|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|'
+  );
 
   for (const result of report.results) {
     lines.push(
@@ -391,6 +486,31 @@ function buildMarkdown(report) {
         formatNumber(result.delta.psnr, 2),
       ].join(' | ').replace(/^/, '| ').replace(/$/, ' |')
     );
+  }
+
+  if (report.tuning.enabled) {
+    lines.push(
+      '',
+      '## Distance Tuning Summary',
+      '',
+      '| Case | Candidates | Matched-byte distance | Matched-byte bytes delta | Matched-byte SSIM delta | Matched-quality distance | Matched-quality bytes delta | Matched-quality SSIM delta |',
+      '|---|---:|---:|---:|---:|---:|---:|---:|'
+    );
+
+    for (const result of report.results) {
+      lines.push(
+        [
+          result.label,
+          result.tuning.distanceCandidates.length,
+          result.tuning.matchedBytes.distance,
+          formatPercent(result.tuning.matchedBytes.delta.bytesPercent),
+          formatNumber(result.tuning.matchedBytes.delta.ssim, 5),
+          result.tuning.matchedQuality.distance,
+          formatPercent(result.tuning.matchedQuality.delta.bytesPercent),
+          formatNumber(result.tuning.matchedQuality.delta.ssim, 5),
+        ].join(' | ').replace(/^/, '| ').replace(/$/, ' |')
+      );
+    }
   }
 
   lines.push(
@@ -423,6 +543,14 @@ async function main() {
     ),
     outputDir: path.resolve(getArg('--output-dir', resolveRoot('artifacts', 'benchmark'))),
     allowMissing: hasFlag('--allow-missing-jpegli') || process.env.JPEGLI_ALLOW_MISSING === '1',
+    tuneDistances: !hasFlag('--skip-distance-tuning') && process.env.JPEGLI_SKIP_DISTANCE_TUNING !== '1',
+    distanceCandidates: parseDistanceCandidateList(
+      getArg(
+        '--distance-candidates',
+        process.env.JPEGLI_DISTANCE_CANDIDATES || DEFAULT_JPEGLI_DISTANCE_CANDIDATES.join(',')
+      ),
+      '--distance-candidates'
+    ),
   };
 
   const probe = probeCjpegli(options.cjpegli, options.allowMissing);
@@ -437,6 +565,7 @@ async function main() {
   console.log('=== JPEG Backend Bake-Off ===');
   console.log(`cjpegli: ${options.cjpegli}`);
   console.log(`Iterations: ${options.iterations}`);
+  console.log(`Distance tuning: ${options.tuneDistances ? 'enabled' : 'disabled'}`);
   console.log(`Output directory: ${options.outputDir}\n`);
   if (!options.jpegliVersion && !probe.version) {
     console.log('Warning: cjpegli version is unknown. Set JPEGLI_VERSION=<tag-or-commit> for publishable evidence.');
@@ -473,6 +602,16 @@ async function main() {
       benchmarkTool: 'cjpegli',
       candidateBackend: 'jpegli',
     }),
+    tuning: {
+      enabled: options.tuneDistances,
+      reason: options.tuneDistances
+        ? null
+        : 'disabled by --skip-distance-tuning or JPEGLI_SKIP_DISTANCE_TUNING=1',
+      requestedDistanceCandidates: options.distanceCandidates,
+      runsPerCandidate: 1,
+      matchedBytesMetric: 'absolute output byte delta vs MozJPEG',
+      matchedQualityMetric: 'absolute SSIM delta vs MozJPEG',
+    },
     corpus,
     commandShape: 'cjpegli INPUT OUTPUT --distance <distance> --quiet',
     timingNote:
@@ -482,8 +621,8 @@ async function main() {
 
   const { jsonPath, mdPath } = writeReport(report, options.outputDir);
 
-  console.log('\n| Case | MozJPEG bytes | jpegli bytes | bytes delta | MozJPEG ms | jpegli ms | ms delta | jpegli SSIM delta |');
-  console.log('|---|---:|---:|---:|---:|---:|---:|---:|');
+  console.log('\n| Case | MozJPEG bytes | jpegli bytes | bytes delta | MozJPEG ms | jpegli ms | ms delta | jpegli SSIM delta | Matched-byte delta | Matched-quality byte delta |');
+  console.log('|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|');
   for (const result of results) {
     console.log(
       [
@@ -495,6 +634,8 @@ async function main() {
         formatNumber(result.jpegli.avgEncodeMs, 1),
         formatPercent(result.delta.encodeMsPercent),
         formatNumber(result.delta.ssim, 5),
+        result.tuning.enabled ? formatPercent(result.tuning.matchedBytes.delta.bytesPercent) : 'n/a',
+        result.tuning.enabled ? formatPercent(result.tuning.matchedQuality.delta.bytesPercent) : 'n/a',
       ].join(' | ').replace(/^/, '| ').replace(/$/, ' |')
     );
   }

--- a/test/helpers/jpegli-distance-tuning.js
+++ b/test/helpers/jpegli-distance-tuning.js
@@ -1,0 +1,113 @@
+const DEFAULT_JPEGLI_DISTANCE_CANDIDATES = Object.freeze([
+  0.8,
+  1.0,
+  1.2,
+  1.4,
+  1.8,
+  2.2,
+  2.8,
+  3.4,
+  4.2,
+  5.2,
+  6.4,
+  8.0,
+]);
+
+const DISTANCE_EPSILON = 1e-9;
+
+function parseDistanceCandidateList(value, name = '--distance-candidates') {
+  const tokens = String(value)
+    .split(',')
+    .map((token) => token.trim());
+
+  if (!tokens.length || tokens.some((token) => token.length === 0)) {
+    throw new Error(`${name} must be a comma-separated list of positive numbers`);
+  }
+
+  return tokens.map((token) => {
+    const parsed = Number(token);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      throw new Error(`${name} must only contain positive finite numbers`);
+    }
+    return parsed;
+  });
+}
+
+function buildDistanceCandidates(baseDistance, requestedCandidates = DEFAULT_JPEGLI_DISTANCE_CANDIDATES) {
+  const values = [...requestedCandidates, baseDistance];
+  const deduped = [];
+
+  for (const value of values) {
+    const distance = Number(value);
+    if (!Number.isFinite(distance) || distance <= 0) {
+      throw new Error('jpegli distance candidates must be positive finite numbers');
+    }
+
+    if (!deduped.some((existing) => Math.abs(existing - distance) < DISTANCE_EPSILON)) {
+      deduped.push(distance);
+    }
+  }
+
+  return deduped.sort((left, right) => left - right);
+}
+
+function percentDelta(value, baseline) {
+  return ((value - baseline) / Math.max(baseline, 1)) * 100;
+}
+
+function buildTuningCandidate({
+  distance,
+  bytes,
+  encodeMs,
+  ssim,
+  psnr,
+  targetBytes,
+  targetSsim,
+  targetPsnr,
+}) {
+  return {
+    distance,
+    bytes,
+    encodeMs,
+    ssim,
+    psnr,
+    delta: {
+      bytesPercent: percentDelta(bytes, targetBytes),
+      ssim: ssim - targetSsim,
+      psnr: psnr - targetPsnr,
+    },
+  };
+}
+
+function chooseMatchedBytesCandidate(candidates) {
+  return [...candidates].sort((left, right) => {
+    const byteDelta = Math.abs(left.delta.bytesPercent) - Math.abs(right.delta.bytesPercent);
+    if (byteDelta !== 0) return byteDelta;
+
+    const ssimDelta = right.ssim - left.ssim;
+    if (ssimDelta !== 0) return ssimDelta;
+
+    return left.encodeMs - right.encodeMs;
+  })[0] || null;
+}
+
+function chooseMatchedQualityCandidate(candidates) {
+  return [...candidates].sort((left, right) => {
+    const ssimDelta = Math.abs(left.delta.ssim) - Math.abs(right.delta.ssim);
+    if (ssimDelta !== 0) return ssimDelta;
+
+    const psnrDelta = Math.abs(left.delta.psnr) - Math.abs(right.delta.psnr);
+    if (psnrDelta !== 0) return psnrDelta;
+
+    return left.bytes - right.bytes;
+  })[0] || null;
+}
+
+module.exports = {
+  DEFAULT_JPEGLI_DISTANCE_CANDIDATES,
+  buildDistanceCandidates,
+  buildTuningCandidate,
+  chooseMatchedBytesCandidate,
+  chooseMatchedQualityCandidate,
+  parseDistanceCandidateList,
+};

--- a/test/integration/jpegli-distance-tuning.test.js
+++ b/test/integration/jpegli-distance-tuning.test.js
@@ -1,0 +1,81 @@
+/**
+ * Regression coverage for jpegli distance tuning decisions.
+ *
+ * The bake-off harness can be smoke-tested without cjpegli, but the
+ * matched-byte and matched-quality candidate selection rules must remain
+ * deterministic in normal CI.
+ */
+
+const assert = require('node:assert/strict');
+const {
+  buildDistanceCandidates,
+  buildTuningCandidate,
+  chooseMatchedBytesCandidate,
+  chooseMatchedQualityCandidate,
+  parseDistanceCandidateList,
+} = require('../helpers/jpegli-distance-tuning');
+
+let passed = 0;
+let failed = 0;
+
+function report(name, error) {
+  if (error) {
+    console.log(`not ok - ${name}`);
+    console.log(`   Error: ${error.message}`);
+    failed += 1;
+  } else {
+    console.log(`ok - ${name}`);
+    passed += 1;
+  }
+}
+
+function test(name, fn) {
+  try {
+    fn();
+    report(name);
+  } catch (error) {
+    report(name, error);
+  }
+}
+
+console.log('=== jpegli Distance Tuning Tests ===\n');
+
+test('parses and normalizes distance candidates with the case baseline included', () => {
+  const parsed = parseDistanceCandidateList('2.2, 1.0, 2.2');
+  const candidates = buildDistanceCandidates(1.4, parsed);
+
+  assert.deepEqual(candidates, [1.0, 1.4, 2.2]);
+});
+
+test('rejects invalid distance candidates', () => {
+  assert.throws(() => parseDistanceCandidateList('1.0,,2.0'), /comma-separated/);
+  assert.throws(() => parseDistanceCandidateList('1.0,0'), /positive finite/);
+  assert.throws(() => parseDistanceCandidateList('1.0,2abc'), /positive finite/);
+});
+
+test('selects the closest byte candidate and breaks ties by quality', () => {
+  const target = { targetBytes: 1000, targetSsim: 0.94, targetPsnr: 38 };
+  const candidates = [
+    buildTuningCandidate({ distance: 1.0, bytes: 1120, encodeMs: 5, ssim: 0.96, psnr: 39, ...target }),
+    buildTuningCandidate({ distance: 2.0, bytes: 880, encodeMs: 4, ssim: 0.97, psnr: 40, ...target }),
+    buildTuningCandidate({ distance: 3.0, bytes: 760, encodeMs: 3, ssim: 0.93, psnr: 36, ...target }),
+  ];
+
+  assert.equal(chooseMatchedBytesCandidate(candidates).distance, 2.0);
+});
+
+test('selects the closest SSIM candidate and breaks ties by bytes', () => {
+  const target = { targetBytes: 1000, targetSsim: 0.94, targetPsnr: 38 };
+  const candidates = [
+    buildTuningCandidate({ distance: 1.0, bytes: 1300, encodeMs: 5, ssim: 0.955, psnr: 39, ...target }),
+    buildTuningCandidate({ distance: 2.0, bytes: 1040, encodeMs: 4, ssim: 0.925, psnr: 37, ...target }),
+    buildTuningCandidate({ distance: 3.0, bytes: 900, encodeMs: 3, ssim: 0.90, psnr: 35, ...target }),
+  ];
+
+  assert.equal(chooseMatchedQualityCandidate(candidates).distance, 2.0);
+});
+
+console.log(`\nTests passed: ${passed}, failed: ${failed}`);
+if (failed > 0) {
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- extend the jpegli bake-off harness with default distance-candidate sweeps
- record matched-byte and matched-quality (SSIM) candidates, including per-candidate commands/output paths in JSON artifacts
- add deterministic selection tests for the tuning rules and document the benchmark operation knobs

## Notes
- This does not add a production jpegli backend or change runtime package contents.
- `cjpegli` is not installed in this local environment, so the real bake-off still needs an operator-provided binary for publishable evidence.

## Verification
- node --check test/benchmarks/jpegli-bakeoff.bench.js
- node test/integration/jpegli-distance-tuning.test.js
- JPEGLI_ALLOW_MISSING=1 npm run test:bench:jpegli
- npm run build
- npm test

Refs #638