### PR TITLE
chore(release): fix wasm package provenance metadata

### DIFF
--- a/packages/lazy-image-wasm/package.json
+++ b/packages/lazy-image-wasm/package.json
@@ -46,6 +46,14 @@
   "engines": {
     "node": ">= 18"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/albert-einshutoin/lazy-image"
+  },
+  "bugs": {
+    "url": "https://github.com/albert-einshutoin/lazy-image/issues"
+  },
+  "homepage": "https://github.com/albert-einshutoin/lazy-image#readme",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary
- add repository, bugs, and homepage metadata to @alberteinshutoin/lazy-image-wasm
- unblock npm provenance validation for v0.16.0 publish

## Verification
- npm run build
- npm test
- node scripts/check-release-policy.js 0.16.0
- npm --workspace @alberteinshutoin/lazy-image-wasm test
- npm --workspace @alberteinshutoin/lazy-image-wasm pack --dry-run

## Release recovery
The first v0.16.0 tag run published platform packages, then failed on the Wasm package with npm E422 because package.json repository.url was missing. Root package publication was skipped. After this PR lands, move v0.16.0 to the fixed main commit and rerun the tag workflow; existing platform packages should be skipped and Wasm/root publishing should continue.