### PR TITLE
ci(release): skip existing platform packages

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -754,6 +754,14 @@ jobs:
               if ! grep -q '"publishConfig"' package.json; then
                 echo "⚠️  Warning: publishConfig not found in package.json"
               fi
+
+              full_pkg_name=$(node -p "require('./package.json').name")
+              pkg_version=$(node -p "require('./package.json').version")
+              if npm view "$full_pkg_name@$pkg_version" version >/dev/null 2>&1; then
+                echo "✅ $full_pkg_name@$pkg_version already exists; skipping publish."
+                cd ../..
+                continue
+              fi
               
               # Try to publish with provenance (works with OIDC or NPM_TOKEN)
               if npm publish --access public --provenance 2>&1; then


### PR DESCRIPTION
## Summary
- make the release publish job skip platform packages that already exist on npm
- allow v0.16.0 recovery runs to continue to Wasm and root package publishing after platform packages were already published

## Verification
- node scripts/check-release-policy.js 0.16.0
- npm run build
- npm test

## Release recovery
The second v0.16.0 tag run reached publish but failed because all six platform packages already exist at 0.16.0. This patch makes the platform publish loop idempotent by checking npm before publishing each generated platform package.