### PR TITLE
chore(develop): sync 0.16.0 from release

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -754,6 +754,14 @@ jobs:
               if ! grep -q '"publishConfig"' package.json; then
                 echo "⚠️  Warning: publishConfig not found in package.json"
               fi
+
+              full_pkg_name=$(node -p "require('./package.json').name")
+              pkg_version=$(node -p "require('./package.json').version")
+              if npm view "$full_pkg_name@$pkg_version" version >/dev/null 2>&1; then
+                echo "✅ $full_pkg_name@$pkg_version already exists; skipping publish."
+                cd ../..
+                continue
+              fi
               
               # Try to publish with provenance (works with OIDC or NPM_TOKEN)
               if npm publish --access public --provenance 2>&1; then

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -198,6 +198,9 @@ jobs:
       - name: Verify npm pack contract
         run: npm run test:pack-contract
 
+      - name: Verify Wasm workspace pack contract
+        run: npm --workspace @alberteinshutoin/lazy-image-wasm pack --dry-run
+
   test:
     name: Test (Node ${{ matrix.node }})
     needs: build
@@ -794,6 +797,25 @@ jobs:
             echo "4. Try publishing manually: cd npm/<platform> && npm publish --access public"
             exit 1
           fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish Wasm package
+        if: ${{ github.event_name != 'workflow_dispatch' || !inputs.dry_run }}
+        run: |
+          pkg_name="@alberteinshutoin/lazy-image-wasm"
+          pkg_version="$(node -p "require('./packages/lazy-image-wasm/package.json').version")"
+
+          if npm view "$pkg_name@$pkg_version" version >/dev/null 2>&1; then
+            echo "$pkg_name@$pkg_version already exists; skipping publish."
+            exit 0
+          fi
+
+          npm publish \
+            --workspace "$pkg_name" \
+            --access public \
+            --provenance \
+            --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,31 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-> **Release policy:** This section currently contains a breaking behavior change.
-> Per `docs/SEMVER_POLICY.md`, the next release that includes it must use a
-> major boundary (currently `1.0.0`) unless maintainers explicitly reclassify
-> the entry as a bug-fix clarification before cutting the release.
+---
 
-### Changed (BREAKING)
-- **PNG + quality is now rejected instead of silently ignored.** Passing a `quality`
-  to a PNG output (e.g. `toBuffer('png', 50)`, `toFile`, `processBatch`, or the
-  `encode({ format: 'png', quality })` options object) now throws a recoverable
-  `UserError` with code **`E400`** (`InvalidArgument`) and an actionable message,
-  rather than discarding the value. PNG is lossless and has no quality knob; the
-  previous silent-ignore behavior masked the caller's mistake. **Migration:** omit
-  `quality` for PNG. (Encode profiles via `toBufferProfile`/`encode` automatically
-  skip quality for PNG, so no change is needed there.)
+## [0.16.0] - 2026-06-06
+
+### Added
+- **Wasm upload-preflight workspace package**: added `@alberteinshutoin/lazy-image-wasm`
+  with browser, Edge, shared policy, and worker entrypoints for upload-safe
+  resizing, metadata stripping, target-byte search, and metrics.
+- **Wasm strategy and benchmark docs**: added package API, strategy, and browser /
+  Edge benchmark guidance so runtime claims stay evidence-backed.
+- **Codec bake-off harnesses**: added reproducible JPEG jpegli and AVIF backend
+  bake-off tooling, corpus manifests, package-impact reporting, and tracked
+  benchmark evidence.
+- **Reliability hardening coverage**: expanded malformed-input seed corpus,
+  benchmark/fuzz alignment, and NAPI boundary stress coverage across clone,
+  malformed corpus, and target-byte paths.
+
+### Changed
+- **Benchmark claims are narrower and evidence-backed**: README and benchmark docs
+  now scope size claims to measured JPEG workloads and keep AVIF/WebP claims
+  workload-specific.
+- **Release publishing now includes the Wasm package**: tag releases publish
+  platform packages, `@alberteinshutoin/lazy-image-wasm`, and then the main
+  package.
+- **Release policy is guarded**: `npm run release:check` rejects non-major
+  releases that contain `BREAKING` or `Removed` changelog entries.
 
 ### Internal
-- Release policy guard: `npm run release:check` now rejects non-major releases
-  that contain `BREAKING` or `Removed` changelog entries.
 - Rust engineering hardening: `Quality` newtype (1..=100 enforced at construction),
   `RotationAngle` enum, `MetadataPolicy` sum type (makes "keep GPS without EXIF"
   unrepresentable), `OutputFormat` parsing now returns the typed `LazyImageError`
   (correct error codes at the NAPI boundary), crate-wide
   `#![deny(unsafe_op_in_unsafe_fn)]` with documented SAFETY contracts, a shared
-  work-steal batch helper, and assorted allocation/concurrency cleanups. No public
-  API change beyond the PNG behavior above.
+  work-steal batch helper, and assorted allocation/concurrency cleanups.
+
+### Fixed
+- Kept in-range PNG `quality` arguments accepted and ignored for 0.x compatibility
+  while preserving `E400` validation for out-of-range quality values.
 
 ---
 
@@ -522,7 +535,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[Unreleased]: https://github.com/albert-einshutoin/lazy-image/compare/v0.15.0...HEAD
+[Unreleased]: https://github.com/albert-einshutoin/lazy-image/compare/v0.16.0...HEAD
+[0.16.0]: https://github.com/albert-einshutoin/lazy-image/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/albert-einshutoin/lazy-image/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/albert-einshutoin/lazy-image/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/albert-einshutoin/lazy-image/compare/v0.12.0...v0.13.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "lazy-image"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "bitflags",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lazy-image"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "Web image optimization engine - smaller JPEG outputs in simple canonical benchmarks, powered by Rust + mozjpeg"
 license = "MIT"

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -72,6 +72,7 @@ The files below need to move from the current version to the new one. Skipping a
 | `package.json` | `version` field | Manual edit |
 | `package.json` | All entries under `optionalDependencies` (6 platform packages) | Manual edit |
 | `packages/lazy-image-wasm/package.json` | `version` field | Manual edit |
+| `packages/lazy-image-wasm/shared.js` | Exported `VERSION` constant | Manual edit |
 | `package-lock.json` | Root `version`, root `packages[""]` block, workspace package entry, and the six `@alberteinshutoin/lazy-image-*` optional dependency entries for the new version. Before publish, npm may keep the platform package lock entries as optional placeholders because the new packages are not in the registry yet. | `npm install --package-lock-only --ignore-scripts` |
 | `Cargo.toml` | `[package].version` | Manual edit |
 | `Cargo.lock` | `lazy-image` entry | `cargo update -p lazy-image` |
@@ -108,7 +109,7 @@ node scripts/check-release-policy.js 0.16.0  # expected to fail if breaking entr
 #### Commit and push
 
 ```bash
-git add package.json packages/lazy-image-wasm/package.json package-lock.json Cargo.toml Cargo.lock index.js CHANGELOG.md
+git add package.json packages/lazy-image-wasm/package.json packages/lazy-image-wasm/shared.js package-lock.json Cargo.toml Cargo.lock index.js CHANGELOG.md
 git commit -m "chore(release): prepare X.Y.Z"
 git push -u origin release/X.Y.Z
 ```
@@ -224,17 +225,21 @@ done
 
 # 3. Wasm package
 npm view @alberteinshutoin/lazy-image-wasm version
+# → should print X.Y.Z
 
 # 4. GitHub Release exists
 gh release view vX.Y.Z --json name,tagName,isDraft,isPrerelease,url
 ```
 
-Smoke test the published package:
+Smoke test the published packages:
 ```bash
 mkdir /tmp/lazy-image-smoke && cd /tmp/lazy-image-smoke
 npm init -y
 npm install @alberteinshutoin/lazy-image@X.Y.Z
 node -e "const li = require('@alberteinshutoin/lazy-image'); console.log(Object.keys(li))"
+
+npm install @alberteinshutoin/lazy-image-wasm@X.Y.Z
+node --input-type=module -e "import { VERSION } from '@alberteinshutoin/lazy-image-wasm/shared'; console.log(VERSION)"
 ```
 
 ---
@@ -322,7 +327,7 @@ git push -u origin chore/sync-package-lock-X.Y.Z
 gh pr create --base develop --title "chore: sync package-lock.json to X.Y.Z"
 ```
 
-**Prevention:** Update `package-lock.json` in Phase 1, alongside `package.json` / `packages/lazy-image-wasm/package.json` / `Cargo.toml` / `Cargo.lock` / `index.js` / `CHANGELOG.md`. Run `npm install --package-lock-only --ignore-scripts` after bumping `package.json`'s `optionalDependencies`.
+**Prevention:** Update `package-lock.json` in Phase 1, alongside `package.json` / `packages/lazy-image-wasm/package.json` / `packages/lazy-image-wasm/shared.js` / `Cargo.toml` / `Cargo.lock` / `index.js` / `CHANGELOG.md`. Run `npm install --package-lock-only --ignore-scripts` after bumping `package.json`'s `optionalDependencies`.
 
 ---
 
@@ -352,6 +357,8 @@ For quick reference, the canonical set of files updated for a routine version bu
 
 ```
 package.json        # version + optionalDependencies (×6)
+packages/lazy-image-wasm/package.json  # workspace package version
+packages/lazy-image-wasm/shared.js     # exported VERSION constant
 package-lock.json   # root version + workspace + 6 lazy-image-* optional entries (via `npm install --package-lock-only --ignore-scripts`)
 Cargo.toml          # [package].version
 Cargo.lock          # lazy-image entry (via `cargo update -p lazy-image`)

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -65,20 +65,22 @@ git checkout -b release/X.Y.Z
 
 #### Files that must be updated
 
-All four files below need to move from the current version to the new one. Skipping any of them will fail CI or break consumers.
+The files below need to move from the current version to the new one. Skipping any of them will fail CI or break consumers.
 
 | File | What changes | How |
 |------|--------------|-----|
 | `package.json` | `version` field | Manual edit |
 | `package.json` | All entries under `optionalDependencies` (6 platform packages) | Manual edit |
-| `package-lock.json` | Root `version`, root `packages[""]` block, and the six `@alberteinshutoin/lazy-image-*` entries (version + resolved + integrity) | `npm install --package-lock-only --ignore-scripts` |
+| `packages/lazy-image-wasm/package.json` | `version` field | Manual edit |
+| `package-lock.json` | Root `version`, root `packages[""]` block, workspace package entry, and the six `@alberteinshutoin/lazy-image-*` optional dependency entries for the new version. Before publish, npm may keep the platform package lock entries as optional placeholders because the new packages are not in the registry yet. | `npm install --package-lock-only --ignore-scripts` |
 | `Cargo.toml` | `[package].version` | Manual edit |
 | `Cargo.lock` | `lazy-image` entry | `cargo update -p lazy-image` |
+| `index.js` | Generated native loader version checks | `npm run build` |
 | `CHANGELOG.md` | Add new `[X.Y.Z]` section under `[Unreleased]` | Manual edit |
 
 > ⚠️ **`Cargo.lock` is required.** The Supply Chain CI job runs `cargo metadata --locked` and will fail if `Cargo.lock` does not match `Cargo.toml`. This is the most common release-time failure.
 >
-> ⚠️ **`package-lock.json` is required, even though it may pass CI on the release PR itself.** The release PR can pass `npm ci` even with an out-of-sync lock file because the new 0.15.0 platform packages don't exist on npm yet — npm silently skips the optional-deps check. Once the publish job runs on the `vX.Y.Z` tag, every subsequent PR's `npm ci` will fail with `Invalid: lock file's @alberteinshutoin/lazy-image-*@<prev> does not satisfy @alberteinshutoin/lazy-image-*@<new>`. See [Pitfall 6](#6-package-lockjson-not-bumped--every-post-release-pr-breaks) below.
+> ⚠️ **`package-lock.json` is required, even though it may pass CI on the release PR itself.** The release PR can pass `npm ci` even with an out-of-sync lock file because the new platform packages don't exist on npm yet — npm silently skips the optional-deps check. Once the publish job runs on the `vX.Y.Z` tag, every subsequent PR's `npm ci` will fail with `Invalid: lock file's @alberteinshutoin/lazy-image-*@<prev> does not satisfy @alberteinshutoin/lazy-image-*@<new>`. See [Pitfall 6](#6-package-lockjson-not-bumped--every-post-release-pr-breaks) below.
 
 Optional helper:
 ```bash
@@ -106,7 +108,7 @@ node scripts/check-release-policy.js 0.16.0  # expected to fail if breaking entr
 #### Commit and push
 
 ```bash
-git add package.json package-lock.json Cargo.toml Cargo.lock CHANGELOG.md
+git add package.json packages/lazy-image-wasm/package.json package-lock.json Cargo.toml Cargo.lock index.js CHANGELOG.md
 git commit -m "chore(release): prepare X.Y.Z"
 git push -u origin release/X.Y.Z
 ```
@@ -170,8 +172,9 @@ git push origin vX.Y.Z
 Pushing the `vX.Y.Z` tag triggers the `Publish to npm` job in [CI.yml](../.github/workflows/CI.yml). The job:
 1. Downloads the prebuilt `.node` artifacts for all 6 platforms
 2. Publishes each platform package (`@alberteinshutoin/lazy-image-{platform}`)
-3. Publishes the main package
-4. Creates a GitHub Release with auto-generated notes
+3. Publishes the Wasm workspace package (`@alberteinshutoin/lazy-image-wasm`)
+4. Publishes the main package
+5. Creates a GitHub Release with auto-generated notes
 
 ---
 
@@ -219,7 +222,10 @@ for pkg in darwin-arm64 darwin-x64 linux-x64-gnu linux-x64-musl linux-arm64-gnu 
   echo "$pkg: $(npm view @alberteinshutoin/lazy-image-$pkg version)"
 done
 
-# 3. GitHub Release exists
+# 3. Wasm package
+npm view @alberteinshutoin/lazy-image-wasm version
+
+# 4. GitHub Release exists
 gh release view vX.Y.Z --json name,tagName,isDraft,isPrerelease,url
 ```
 
@@ -316,7 +322,7 @@ git push -u origin chore/sync-package-lock-X.Y.Z
 gh pr create --base develop --title "chore: sync package-lock.json to X.Y.Z"
 ```
 
-**Prevention:** Update `package-lock.json` in Phase 1, alongside `package.json` / `Cargo.toml` / `Cargo.lock` / `CHANGELOG.md`. Run `npm install --package-lock-only --ignore-scripts` after bumping `package.json`'s `optionalDependencies`.
+**Prevention:** Update `package-lock.json` in Phase 1, alongside `package.json` / `packages/lazy-image-wasm/package.json` / `Cargo.toml` / `Cargo.lock` / `index.js` / `CHANGELOG.md`. Run `npm install --package-lock-only --ignore-scripts` after bumping `package.json`'s `optionalDependencies`.
 
 ---
 
@@ -346,9 +352,10 @@ For quick reference, the canonical set of files updated for a routine version bu
 
 ```
 package.json        # version + optionalDependencies (×6)
-package-lock.json   # root version + 6 lazy-image-* entries (via `npm install --package-lock-only --ignore-scripts`)
+package-lock.json   # root version + workspace + 6 lazy-image-* optional entries (via `npm install --package-lock-only --ignore-scripts`)
 Cargo.toml          # [package].version
 Cargo.lock          # lazy-image entry (via `cargo update -p lazy-image`)
+index.js            # generated native loader version checks (via `npm run build`)
 CHANGELOG.md        # new [X.Y.Z] section
 ```
 

--- a/index.js
+++ b/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-android-arm64')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-android-arm-eabi')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-win32-x64-gnu')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-win32-x64-msvc')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-win32-ia32-msvc')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-win32-arm64-msvc')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@alberteinshutoin/lazy-image-darwin-universal')
       const bindingPackageVersion = require('@alberteinshutoin/lazy-image-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-darwin-x64')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-darwin-arm64')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-freebsd-x64')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-freebsd-arm64')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-x64-musl')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-x64-gnu')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-arm64-musl')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-arm64-gnu')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-arm-musleabihf')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-loong64-musl')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-loong64-gnu')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-riscv64-musl')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-riscv64-gnu')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-linux-ppc64-gnu')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-linux-s390x-gnu')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-openharmony-arm64')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-openharmony-x64')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-openharmony-arm')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.15.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.15.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alberteinshutoin/lazy-image",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@alberteinshutoin/lazy-image",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "MIT",
       "workspaces": [
         "packages/lazy-image-wasm"
@@ -22,113 +22,41 @@
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "@alberteinshutoin/lazy-image-darwin-arm64": "0.15.0",
-        "@alberteinshutoin/lazy-image-darwin-x64": "0.15.0",
-        "@alberteinshutoin/lazy-image-linux-arm64-gnu": "0.15.0",
-        "@alberteinshutoin/lazy-image-linux-x64-gnu": "0.15.0",
-        "@alberteinshutoin/lazy-image-linux-x64-musl": "0.15.0",
-        "@alberteinshutoin/lazy-image-win32-x64-msvc": "0.15.0"
+        "@alberteinshutoin/lazy-image-darwin-arm64": "0.16.0",
+        "@alberteinshutoin/lazy-image-darwin-x64": "0.16.0",
+        "@alberteinshutoin/lazy-image-linux-arm64-gnu": "0.16.0",
+        "@alberteinshutoin/lazy-image-linux-x64-gnu": "0.16.0",
+        "@alberteinshutoin/lazy-image-linux-x64-musl": "0.16.0",
+        "@alberteinshutoin/lazy-image-win32-x64-msvc": "0.16.0"
       }
     },
     "node_modules/@alberteinshutoin/lazy-image-darwin-arm64": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-darwin-arm64/-/lazy-image-darwin-arm64-0.15.0.tgz",
-      "integrity": "sha512-xelpffrjY3ALdU/ywEHshhdwrnM6H1PNH1vN3RCpwu/CEdYeNtbIL17uyZcOJ3YYtNsL5dNpgHx6QNvCU7ThHg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
       "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 18"
-      }
+      "version": "0.16.0"
     },
     "node_modules/@alberteinshutoin/lazy-image-darwin-x64": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-darwin-x64/-/lazy-image-darwin-x64-0.15.0.tgz",
-      "integrity": "sha512-oSHl8iBLMP6PcSLZsCuRdV6se8EDFK8BxMd/MwECekKAs/OfcFuQyQgVVaSq0utozDKdmQapk8t1A6SdzxM5JQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
       "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 18"
-      }
+      "version": "0.16.0"
     },
     "node_modules/@alberteinshutoin/lazy-image-linux-arm64-gnu": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-linux-arm64-gnu/-/lazy-image-linux-arm64-gnu-0.15.0.tgz",
-      "integrity": "sha512-CqKZhwY/9fvRZt+UY8tZz0t8Vrv+bvGiq1TAz/XKDQSg4rLtp8Tm5w+zXKZgVO+eolqgnBlDEqNFyO+C5Yz+6Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
       "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 18"
-      }
+      "version": "0.16.0"
     },
     "node_modules/@alberteinshutoin/lazy-image-linux-x64-gnu": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-linux-x64-gnu/-/lazy-image-linux-x64-gnu-0.15.0.tgz",
-      "integrity": "sha512-TBCXBynmLCxXcdKiB1jq0CCc/VXrtS5i79XcxkUgXOADXOVDP5yrer1wOxUJwokVDmqPocQHvztC236kXSpSBg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
       "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 18"
-      }
+      "version": "0.16.0"
     },
     "node_modules/@alberteinshutoin/lazy-image-linux-x64-musl": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-linux-x64-musl/-/lazy-image-linux-x64-musl-0.15.0.tgz",
-      "integrity": "sha512-vt3TjTDU11CbbV9mrywiY2S+XcdFaKAjvtGEm1ITe/YBOSwi05AvfTJPsdxJF/VaphlQ9NIAbQl4jZArYxyH2Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
       "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 18"
-      }
+      "version": "0.16.0"
     },
     "node_modules/@alberteinshutoin/lazy-image-wasm": {
       "resolved": "packages/lazy-image-wasm",
       "link": true
     },
     "node_modules/@alberteinshutoin/lazy-image-win32-x64-msvc": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@alberteinshutoin/lazy-image-win32-x64-msvc/-/lazy-image-win32-x64-msvc-0.15.0.tgz",
-      "integrity": "sha512-tP1mnOlMAUZxQB7mKad98kQ7jXJs/Tw03WPeytONeVr/tdWJjLJ1ttoiasGrv/Mze8xKLLlVuZZdHlZqK3N3ew==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
       "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 18"
-      }
+      "version": "0.16.0"
     },
     "node_modules/@emnapi/core": {
       "version": "1.8.1",
@@ -2618,7 +2546,7 @@
     },
     "packages/lazy-image-wasm": {
       "name": "@alberteinshutoin/lazy-image-wasm",
-      "version": "0.1.0",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
         "@jsquash/jpeg": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alberteinshutoin/lazy-image",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Web image optimization engine for Node.js - smaller JPEG files in simple canonical benchmarks, powered by Rust + mozjpeg",
   "main": "index.js",
   "exports": {
@@ -94,12 +94,12 @@
     ]
   },
   "optionalDependencies": {
-    "@alberteinshutoin/lazy-image-darwin-arm64": "0.15.0",
-    "@alberteinshutoin/lazy-image-darwin-x64": "0.15.0",
-    "@alberteinshutoin/lazy-image-linux-x64-gnu": "0.15.0",
-    "@alberteinshutoin/lazy-image-linux-x64-musl": "0.15.0",
-    "@alberteinshutoin/lazy-image-linux-arm64-gnu": "0.15.0",
-    "@alberteinshutoin/lazy-image-win32-x64-msvc": "0.15.0"
+    "@alberteinshutoin/lazy-image-darwin-arm64": "0.16.0",
+    "@alberteinshutoin/lazy-image-darwin-x64": "0.16.0",
+    "@alberteinshutoin/lazy-image-linux-x64-gnu": "0.16.0",
+    "@alberteinshutoin/lazy-image-linux-x64-musl": "0.16.0",
+    "@alberteinshutoin/lazy-image-linux-arm64-gnu": "0.16.0",
+    "@alberteinshutoin/lazy-image-win32-x64-msvc": "0.16.0"
   },
   "engines": {
     "node": ">= 18"

--- a/packages/lazy-image-wasm/package.json
+++ b/packages/lazy-image-wasm/package.json
@@ -46,6 +46,14 @@
   "engines": {
     "node": ">= 18"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/albert-einshutoin/lazy-image"
+  },
+  "bugs": {
+    "url": "https://github.com/albert-einshutoin/lazy-image/issues"
+  },
+  "homepage": "https://github.com/albert-einshutoin/lazy-image#readme",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/lazy-image-wasm/package.json
+++ b/packages/lazy-image-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alberteinshutoin/lazy-image-wasm",
-  "version": "0.1.0",
+  "version": "0.16.0",
   "description": "Browser and Edge upload-preflight optimizer for lazy-image policy APIs",
   "type": "module",
   "sideEffects": false,

--- a/packages/lazy-image-wasm/shared.js
+++ b/packages/lazy-image-wasm/shared.js
@@ -1,4 +1,4 @@
-export const VERSION = '0.1.0';
+export const VERSION = '0.16.0';
 
 export const ERROR_CATEGORIES = {
   Input: 'Input',

--- a/packages/lazy-image-wasm/test/run.mjs
+++ b/packages/lazy-image-wasm/test/run.mjs
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url';
 
 import { createUploadOptimizer } from '../browser.js';
 import { createUploadOptimizer as createEdgeUploadOptimizer } from '../edge.js';
-import { LazyImageWasmError } from '../shared.js';
+import { LazyImageWasmError, VERSION } from '../shared.js';
 
 if (typeof globalThis.ImageData !== 'function') {
   globalThis.ImageData = class ImageData {
@@ -22,6 +22,7 @@ const require = createRequire(import.meta.url);
 const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const repoRoot = path.resolve(packageRoot, '..', '..');
 const fixtureRoot = path.join(repoRoot, 'test', 'fixtures');
+const packageJson = JSON.parse(await fs.readFile(path.join(packageRoot, 'package.json'), 'utf8'));
 
 function packageFile(packageName, relativePath) {
   return path.join(path.dirname(require.resolve(`${packageName}/package.json`)), relativePath);
@@ -60,6 +61,10 @@ const wasmModules = await loadWasmModules();
 const optimizer = await createUploadOptimizer({
   wasmModules,
   defaultOutput: 'arrayBuffer',
+});
+
+await test('exports the workspace package version', async () => {
+  assert.equal(VERSION, packageJson.version);
 });
 
 await test('optimizes JPEG input to JPEG with a target byte budget', async () => {

--- a/src/engine/api/batch_ops.rs
+++ b/src/engine/api/batch_ops.rs
@@ -168,8 +168,8 @@ impl ImageEngine {
         let concurrency =
             validation::sanitize_concurrency(concurrency).map_err(|e| napi_err(&env, e))?;
 
-        // Propagate the real parse error (E400 for PNG+quality, E111 for an
-        // unknown format) rather than flattening to unsupported_format.
+        // Propagate the real parse error for unknown formats rather than
+        // flattening to unsupported_format.
         let output_format = OutputFormat::from_str_with_options(&format, quality, fast_mode)
             .map_err(|e| napi_err(&env, e))?;
         let ops = self.ops.clone();
@@ -232,8 +232,8 @@ impl ImageEngine {
         let concurrency =
             validation::sanitize_concurrency(concurrency).map_err(|e| napi_err(&env, e))?;
 
-        // Propagate the real parse error (E400 for PNG+quality, E111 for an
-        // unknown format) rather than flattening to unsupported_format.
+        // Propagate the real parse error for unknown formats rather than
+        // flattening to unsupported_format.
         let output_format = OutputFormat::from_str_with_options(&format, quality, fast_mode)
             .map_err(|e| napi_err(&env, e))?;
         let ops = self.ops.clone();

--- a/src/engine/api/output_ops.rs
+++ b/src/engine/api/output_ops.rs
@@ -103,8 +103,8 @@ impl ImageEngine {
     ) -> Result<AsyncTask<EncodeTask>> {
         let fast_mode = fast_mode.unwrap_or(false);
         let quality = validation::sanitize_quality(quality).map_err(|e| napi_err(&env, e))?;
-        // Propagate the real parse error (e.g. E400 InvalidArgument for PNG+quality,
-        // E111 UnsupportedFormat for an unknown format) instead of flattening
+        // Propagate the real parse error (e.g. E111 UnsupportedFormat for an
+        // unknown format) instead of flattening
         // everything to unsupported_format.
         let output_format = OutputFormat::from_str_with_options(&format, quality, fast_mode)
             .map_err(|e| napi_err(&env, e))?;
@@ -172,8 +172,8 @@ impl ImageEngine {
     ) -> Result<AsyncTask<EncodeWithMetricsTask>> {
         let fast_mode = fast_mode.unwrap_or(false);
         let quality = validation::sanitize_quality(quality).map_err(|e| napi_err(&env, e))?;
-        // Propagate the real parse error (e.g. E400 InvalidArgument for PNG+quality,
-        // E111 UnsupportedFormat for an unknown format) instead of flattening
+        // Propagate the real parse error (e.g. E111 UnsupportedFormat for an
+        // unknown format) instead of flattening
         // everything to unsupported_format.
         let output_format = OutputFormat::from_str_with_options(&format, quality, fast_mode)
             .map_err(|e| napi_err(&env, e))?;
@@ -338,8 +338,8 @@ impl ImageEngine {
         let quality = validation::sanitize_quality(quality).map_err(|e| napi_err(&env, e))?;
         validation::validate_output_path(&path).map_err(|e| napi_err(&env, e))?;
 
-        // Propagate the real parse error (e.g. E400 InvalidArgument for PNG+quality,
-        // E111 UnsupportedFormat for an unknown format) instead of flattening
+        // Propagate the real parse error (e.g. E111 UnsupportedFormat for an
+        // unknown format) instead of flattening
         // everything to unsupported_format.
         let output_format = OutputFormat::from_str_with_options(&format, quality, fast_mode)
             .map_err(|e| napi_err(&env, e))?;
@@ -368,8 +368,8 @@ impl ImageEngine {
         let quality = validation::sanitize_quality(quality).map_err(|e| napi_err(&env, e))?;
         validation::validate_output_path(&path).map_err(|e| napi_err(&env, e))?;
 
-        // Propagate the real parse error (e.g. E400 InvalidArgument for PNG+quality,
-        // E111 UnsupportedFormat for an unknown format) instead of flattening
+        // Propagate the real parse error (e.g. E111 UnsupportedFormat for an
+        // unknown format) instead of flattening
         // everything to unsupported_format.
         let output_format = OutputFormat::from_str_with_options(&format, quality, fast_mode)
             .map_err(|e| napi_err(&env, e))?;

--- a/src/engine/pipeline/color_state.rs
+++ b/src/engine/pipeline/color_state.rs
@@ -117,7 +117,7 @@ pub(super) fn update_color_state(mut state: ColorState, op: &Operation) -> Color
         Operation::Resize { .. }
         | Operation::Extract { .. }
         | Operation::Crop { .. }
-        | Operation::Rotate { .. }
+        | Operation::Rotate(_)
         | Operation::FlipH
         | Operation::FlipV
         | Operation::AutoOrient { .. } => {}

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -338,17 +338,9 @@ impl OutputFormat {
                 })
             }
             "png" => {
-                // PNG is lossless and has no quality knob. Reject an explicit
-                // quality instead of silently discarding it — a discarded value
-                // is a footgun (the caller believes it took effect). This is a
-                // recoverable UserError (E400), not an unsupported-format error.
-                if let Some(q) = quality {
-                    return Err(LazyImageError::invalid_argument(
-                        "quality",
-                        q.to_string(),
-                        "PNG is lossless and does not accept a quality value; omit quality for PNG",
-                    ));
-                }
+                // PNG is lossless and has no quality knob. Keep accepting and
+                // ignoring an in-range quality for 0.x compatibility; invalid
+                // quality values are rejected before this parser is called.
                 Ok(Self::Png)
             }
             "webp" => {
@@ -603,12 +595,9 @@ mod tests {
         }
 
         #[test]
-        fn test_png_rejects_quality() {
-            let err = OutputFormat::from_str("png", Some(50)).unwrap_err();
-            assert!(err.to_string().contains("does not accept"));
-            // Must be a recoverable UserError (E400 InvalidArgument), not an
-            // unsupported-format CodecError (E111).
-            assert_eq!(err.code().as_str(), "E400");
+        fn test_png_ignores_quality_for_compatibility() {
+            let format = OutputFormat::from_str("png", Some(50)).unwrap();
+            assert!(matches!(format, OutputFormat::Png));
         }
 
         #[test]

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -220,7 +220,7 @@ impl Operation {
                 OperationRequirement::DECODED_PIXELS | OperationRequirement::COLOR_STATE,
                 OperationEffect::MUTATES_PIXELS | OperationEffect::CHANGES_GEOMETRY,
             ),
-            Operation::Rotate { .. } => OperationContract::new(
+            Operation::Rotate(_) => OperationContract::new(
                 "rotate",
                 OperationRequirement::DECODED_PIXELS | OperationRequirement::COLOR_STATE,
                 OperationEffect::MUTATES_PIXELS | OperationEffect::CHANGES_GEOMETRY,

--- a/test/integration/error-codes.test.js
+++ b/test/integration/error-codes.test.js
@@ -1,7 +1,7 @@
 /**
  * Error code matrix tests — covers previously untested error codes.
  *
- * Targets: E111, E121, E123, E130, E131, E204, E402, E900
+ * Targets: E111, E121, E123, E130, E131, E204, E400, E402, E900
  * (E122 PixelCountExceedsLimit is skipped — requires a real image whose
  *  decoded pixel count exceeds the limit, which cannot be synthesised cheaply.)
  *
@@ -63,28 +63,27 @@ async function asyncTest(name, fn) {
     });
 
     // ---------------------------------------------------------------
-    // E400 InvalidArgument — PNG is lossless and rejects an explicit quality.
-    // Behavioral change: previously the quality was silently ignored; it now
-    // returns a recoverable UserError so the footgun is visible. Must NOT be
-    // E111 (UnsupportedFormat / CodecError) — PNG itself is supported.
+    // E400 InvalidArgument — quality values must be in range.
+    // PNG remains compatibility-preserving for 0.x: an in-range quality is
+    // accepted and ignored because PNG is lossless. Out-of-range values are
+    // rejected before format-specific parsing.
     // ---------------------------------------------------------------
-    await asyncTest('E400: InvalidArgument when a quality is passed to PNG', async () => {
+    await asyncTest('E400: InvalidArgument from out-of-range quality', async () => {
         let threw = false;
         try {
-            await ImageEngine.from(BUFFER).toBuffer('png', 50);
+            await ImageEngine.from(BUFFER).toBuffer('jpeg', 0);
         } catch (e) {
             threw = true;
             assert.strictEqual(e.errorCode, 'E400', `expected E400, got ${e.errorCode}`);
             const category = getErrorCategory(e);
-            assert.strictEqual(category, ErrorCategory.UserError, 'PNG+quality should be a UserError');
-            assert(/png/i.test(e.message), 'message should mention PNG');
+            assert.strictEqual(category, ErrorCategory.UserError, 'invalid quality should be a UserError');
+            assert(/quality/i.test(e.message), 'message should mention quality');
             assert(typeof e.recoveryHint === 'string' && e.recoveryHint.length > 0, 'recoveryHint should be present');
         }
-        assert(threw, 'passing a quality to PNG should throw');
+        assert(threw, 'quality 0 should throw');
 
-        // And PNG without a quality must still succeed.
-        const ok = await ImageEngine.from(BUFFER).toBuffer('png');
-        assert(ok.length > 0, 'PNG without quality should encode');
+        const png = await ImageEngine.from(BUFFER).toBuffer('png', 50);
+        assert(png.length > 0, 'PNG with in-range quality remains accepted for 0.x compatibility');
     });
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
Sync v0.16.0 release commits, Wasm package publish metadata, and publish recovery fixes back to develop.