### PR TITLE
test: expand malformed metadata seed coverage

### DIFF
--- a/scripts/fuzz/write-seed-corpus.mjs
+++ b/scripts/fuzz/write-seed-corpus.mjs
@@ -56,6 +56,47 @@ function jpegWithTruncatedAppSegment(marker) {
   ]);
 }
 
+const EXIF_ID = Buffer.from('Exif\0\0', 'binary');
+const ICC_ID = Buffer.from('ICC_PROFILE\0', 'binary');
+
+function jpegWithExifSegment(payload, options = {}) {
+  const segmentLength = options.declaredSegmentLength
+    ?? (2 + EXIF_ID.byteLength + payload.byteLength);
+  return Buffer.concat([
+    Buffer.from([0xff, 0xd8, 0xff, 0xe1]),
+    Buffer.from([(segmentLength >> 8) & 0xff, segmentLength & 0xff]),
+    EXIF_ID,
+    payload,
+    options.omitEoi ? Buffer.alloc(0) : Buffer.from([0xff, 0xd9]),
+  ]);
+}
+
+function jpegWithIccSegment(payload) {
+  const segmentPayload = Buffer.concat([
+    ICC_ID,
+    Buffer.from([0x01, 0x01]),
+    payload,
+  ]);
+  const segmentLength = 2 + segmentPayload.byteLength;
+  return Buffer.concat([
+    Buffer.from([0xff, 0xd8, 0xff, 0xe2]),
+    Buffer.from([(segmentLength >> 8) & 0xff, segmentLength & 0xff]),
+    segmentPayload,
+    Buffer.from([0xff, 0xd9]),
+  ]);
+}
+
+function iccPayloadWithSizeMismatch() {
+  const payload = Buffer.alloc(128);
+  payload.writeUInt32BE(256, 0);
+  payload.write('TEST', 4, 'ascii');
+  payload[8] = 2;
+  payload.write('mntr', 12, 'ascii');
+  payload.write('RGB ', 16, 'ascii');
+  payload.write('XYZ ', 20, 'ascii');
+  return payload;
+}
+
 function jpegWithInvalidSegmentLength() {
   return Buffer.from([
     0xff, 0xd8,
@@ -110,10 +151,28 @@ const seedsByTarget = {
   inspect_header: headerMalformedSeeds,
   icc_profile: {
     'jpeg-truncated-icc-app2.bin': jpegWithTruncatedAppSegment(0xe2),
+    'jpeg-icc-profile-header-only-app2.bin': jpegWithIccSegment(Buffer.alloc(0)),
+    'jpeg-icc-profile-size-mismatch-app2.bin': jpegWithIccSegment(iccPayloadWithSizeMismatch()),
     'jpeg-invalid-segment-length.bin': jpegWithInvalidSegmentLength(),
   },
   exif_parse: {
     'jpeg-truncated-exif-app1.bin': jpegWithTruncatedAppSegment(0xe1),
+    'jpeg-exif-empty-tiff-app1.bin': jpegWithExifSegment(Buffer.alloc(0)),
+    'jpeg-exif-truncated-ifd-app1.bin': jpegWithExifSegment(
+      Buffer.from([
+        0x49, 0x49,
+        0x2a, 0x00,
+        0x08, 0x00, 0x00, 0x00,
+        0x02, 0x00,
+      ]),
+    ),
+    'jpeg-exif-overstated-length-app1.bin': jpegWithExifSegment(
+      Buffer.from([
+        0x49, 0x49,
+        0x2a, 0x00,
+      ]),
+      { declaredSegmentLength: 0x20, omitEoi: true },
+    ),
     'little-endian-tiff-header-only.bin': Buffer.from('II*\0', 'binary'),
     'big-endian-tiff-header-only.bin': Buffer.from('MM\0*', 'binary'),
   },

--- a/test/helpers/codec-bakeoff-cases.js
+++ b/test/helpers/codec-bakeoff-cases.js
@@ -13,9 +13,11 @@ const FUZZ_TARGET_SEED_COVERAGE = {
     'webp-truncated-riff.bin',
   ],
   exif_parse: [
+    'jpeg-exif-truncated-ifd-app1.bin',
     'jpeg-truncated-exif-app1.bin',
   ],
   icc_profile: [
+    'jpeg-icc-profile-size-mismatch-app2.bin',
     'jpeg-truncated-icc-app2.bin',
   ],
   inspect_header: [

--- a/test/integration/fuzz-seed-corpus.test.js
+++ b/test/integration/fuzz-seed-corpus.test.js
@@ -62,8 +62,10 @@ try {
 
     test('dry-run validates the full malformed seed catalog', () => {
         const stdout = runSeedScript(['--dry-run']);
-        assert.match(stdout, /validated 20 malformed fuzz seed\(s\)/);
+        assert.match(stdout, /validated 25 malformed fuzz seed\(s\)/);
         assert.match(stdout, /avif-ftyp-only\.bin/);
+        assert.match(stdout, /jpeg-exif-truncated-ifd-app1\.bin/);
+        assert.match(stdout, /jpeg-icc-profile-size-mismatch-app2\.bin/);
         assert.match(stdout, /jpeg-truncated-exif-app1\.bin/);
         assert.match(stdout, /png-huge-ihdr\.bin/);
     });
@@ -106,6 +108,31 @@ try {
 
         assert.match(stdout, /no malformed seed corpus configured for target: firewall_bypass/);
         assert.equal(fs.existsSync(path.join(TEST_ROOT, 'firewall_bypass')), false);
+    });
+
+    test('metadata targets include EXIF and ICC marker-bearing malformed seeds', () => {
+        let stdout = runSeedScript([
+            '--target',
+            'exif_parse',
+            '--corpus-root',
+            TEST_ROOT,
+        ]);
+
+        assert.match(stdout, /wrote 6 malformed fuzz seed\(s\)/);
+        assert.equal(fileSize('exif_parse', 'jpeg-exif-empty-tiff-app1.bin'), 14);
+        assert.equal(fileSize('exif_parse', 'jpeg-exif-truncated-ifd-app1.bin'), 24);
+        assert.equal(fileSize('exif_parse', 'jpeg-exif-overstated-length-app1.bin'), 16);
+
+        stdout = runSeedScript([
+            '--target',
+            'icc_profile',
+            '--corpus-root',
+            TEST_ROOT,
+        ]);
+
+        assert.match(stdout, /wrote 4 malformed fuzz seed\(s\)/);
+        assert.equal(fileSize('icc_profile', 'jpeg-icc-profile-header-only-app2.bin'), 22);
+        assert.equal(fileSize('icc_profile', 'jpeg-icc-profile-size-mismatch-app2.bin'), 150);
     });
 } finally {
     resetTestRoot();

--- a/test/integration/malformed-corpus-replay.test.js
+++ b/test/integration/malformed-corpus-replay.test.js
@@ -53,7 +53,7 @@ function generateCorpus() {
   });
 
   assert.equal(result.status, 0, result.stderr || result.stdout);
-  assert.match(result.stdout, /wrote 20 malformed fuzz seed\(s\)/);
+  assert.match(result.stdout, /wrote 25 malformed fuzz seed\(s\)/);
 }
 
 function collectCorpusFiles() {
@@ -107,7 +107,7 @@ console.log('=== Malformed Corpus Replay Tests ===\n');
     const files = collectCorpusFiles();
 
     await asyncTest('generated corpus keeps the expected target coverage', async () => {
-      assert.equal(files.length, 20);
+      assert.equal(files.length, 25);
       assert.deepEqual(
         Array.from(new Set(files.map((file) => file.target))).sort(),
         ['decode_avif', 'decode_from_buffer', 'exif_parse', 'icc_profile', 'inspect_header'],

--- a/test/integration/napi-stress-corpus.test.js
+++ b/test/integration/napi-stress-corpus.test.js
@@ -63,7 +63,7 @@ test('stress smoke includes generated malformed fuzz seeds and writes summaries'
   });
 
   assert.equal(result.status, 0, result.stderr || result.stdout);
-  assert.match(`${result.stdout}\n${result.stderr}`, /malformedInputs=25/);
+  assert.match(`${result.stdout}\n${result.stderr}`, /malformedInputs=30/);
 
   const summary = JSON.parse(fs.readFileSync(summaryJsonPath, 'utf8'));
   assert.equal(summary.tool, 'napi-boundary-stress');
@@ -74,10 +74,10 @@ test('stress smoke includes generated malformed fuzz seeds and writes summaries'
   assert.equal(summary.boundaryCoverage.cloneMultiOutputRounds, 1);
   assert.equal(summary.boundaryCoverage.targetBytesSearchRounds, 1);
   assert.equal(summary.boundaryCoverage.targetBytesSearches, 2);
-  assert.equal(summary.malformedInputs.total, 25);
+  assert.equal(summary.malformedInputs.total, 30);
   assert.equal(summary.malformedInputs.inline, 5);
-  assert.equal(summary.malformedInputs.generatedFuzzSeeds, 20);
-  assert.equal(summary.malformedInputs.generatedFuzzFilePathSeeds, 20);
+  assert.equal(summary.malformedInputs.generatedFuzzSeeds, 25);
+  assert.equal(summary.malformedInputs.generatedFuzzFilePathSeeds, 25);
   assert.equal(summary.memory.sampleCount, 2);
   assert.ok(summary.memory.peakRssMb > 0);
   assert.ok(summary.memory.samples.some((sample) => sample.phase === 'iteration-0'));
@@ -87,8 +87,8 @@ test('stress smoke includes generated malformed fuzz seeds and writes summaries'
   assert.match(markdown, /targetBytesRounds: 1/);
   assert.match(markdown, /cloneMultiOutputRounds: 1/);
   assert.match(markdown, /targetBytesSearches: 2/);
-  assert.match(markdown, /generatedFuzzSeeds: 20/);
-  assert.match(markdown, /generatedFuzzFilePathSeeds: 20/);
+  assert.match(markdown, /generatedFuzzSeeds: 25/);
+  assert.match(markdown, /generatedFuzzFilePathSeeds: 25/);
 });
 
 console.log(`\nTests passed: ${passed}, failed: ${failed}`);


### PR DESCRIPTION
## Summary
- add malformed EXIF APP1 and ICC APP2 marker-bearing seeds to the generated fuzz corpus
- keep benchmark/fuzz alignment expectations pinned to the new metadata seed families
- expand NAPI replay and stress smoke expectations from 20 to 25 generated seeds

Advances #646.

## Verification
- node test/integration/fuzz-seed-corpus.test.js
- node test/integration/malformed-corpus-replay.test.js
- node test/integration/napi-stress-corpus.test.js
- npm run build
- npm test