### PR TITLE
feat: add edge runtime example for wasm optimizer

### DIFF
--- a/packages/lazy-image-wasm/README.md
+++ b/packages/lazy-image-wasm/README.md
@@ -39,13 +39,16 @@ const result = await optimizer.optimizeUpload(new Uint8Array(await request.array
 
 ### Example (Cloudflare Workers / V8 isolate)
 
-`packages/lazy-image-wasm/examples/edge.mjs` provides a small runtime-safe pattern:
+`examples/edge.mjs` (shipped in this package) is a small runtime-safe pattern:
+it caches one optimizer per isolate, reads `@jsquash` Wasm bindings from
+`env.JSQUASH_*` keys, and maps `LazyImageWasmError` input errors to HTTP 400.
+
+Copy the file into your Worker project and change its relative imports to the
+package specifiers (`@alberteinshutoin/lazy-image-wasm/edge` and
+`@alberteinshutoin/lazy-image-wasm/shared`), then wire it up:
 
 ```js
-import {
-  getEdgeUploadOptimizer,
-  handleOptimizeRequest,
-} from './examples/edge.mjs';
+import { handleOptimizeRequest } from './lazy-image-edge.mjs';
 
 export default {
   async fetch(request, env) {
@@ -53,6 +56,11 @@ export default {
   },
 };
 ```
+
+Your deployment must provide the codec Wasm as bindings named
+`JSQUASH_JPEG_DECODER`, `JSQUASH_JPEG_ENCODER`, `JSQUASH_PNG_DECODER`,
+`JSQUASH_RESIZE`, `JSQUASH_WEBP_DECODER`, and `JSQUASH_WEBP_ENCODER`
+(`WebAssembly.Module`, `ArrayBuffer`, or `Uint8Array` values).
 
 ### Edge and browser constraints
 

--- a/packages/lazy-image-wasm/README.md
+++ b/packages/lazy-image-wasm/README.md
@@ -37,6 +37,42 @@ const result = await optimizer.optimizeUpload(new Uint8Array(await request.array
 });
 ```
 
+### Example (Cloudflare Workers / V8 isolate)
+
+`packages/lazy-image-wasm/examples/edge.mjs` provides a small runtime-safe pattern:
+
+```js
+import {
+  getEdgeUploadOptimizer,
+  handleOptimizeRequest,
+} from './examples/edge.mjs';
+
+export default {
+  async fetch(request, env) {
+    return handleOptimizeRequest(request, env);
+  },
+};
+```
+
+### Edge and browser constraints
+
+- Supported formats stay limited to `jpeg` and `webp` output, and input is currently
+  `jpeg` / `png` / `webp`.
+- No filesystem, native filesystem APIs, or Node built-ins are available.
+- `@jsquash/*` codec Wasm blobs are loaded from your deployment/runtime and must be
+  provided via `wasmModules`.
+- If you use `output: 'blob'` in runtimes that do not expose `Blob`, the API returns
+  an error and you should request `arrayBuffer` or `uint8Array` instead.
+
+Bundle considerations:
+
+- Keep this package behind lazy-loading where possible and avoid eagerly shipping the
+  full browser/resize codec set for pages that do not optimize uploads.
+- Run `npm run test:bench:wasm` locally and inspect generated artifacts to decide
+  whether full `resize`/`webp` codec loading is justified for your target flow.
+- For browser/Edge evidence, collect both bundle/gzip size and encode-metrics before
+  publishing any performance claim.
+
 ## Worker
 
 ```js

--- a/packages/lazy-image-wasm/examples/edge.mjs
+++ b/packages/lazy-image-wasm/examples/edge.mjs
@@ -1,29 +1,37 @@
+// When copying this file into your own Worker project, change the next two
+// imports to the package specifiers '@alberteinshutoin/lazy-image-wasm/edge'
+// and '@alberteinshutoin/lazy-image-wasm/shared'.
 import { createUploadOptimizer } from '../edge.js';
+import { LazyImageWasmError } from '../shared.js';
 
 let optimizerPromise;
 
 function resolveWasmModules(env) {
-  return {
-    jpegDecode: env?.JPEGSQUASH_JPEG_DECODER,
-    jpegEncode: env?.JPEGSQUASH_JPEG_ENCODER,
-    pngDecode: env?.JPEGSQUASH_PNG_DECODER,
-    resize: env?.JPEGSQUASH_RESIZE,
-    webpDecode: env?.JPEGSQUASH_WEBP_DECODER,
-    webpEncode: env?.JPEGSQUASH_WEBP_ENCODER,
+  const modules = {
+    jpegDecode: env?.JSQUASH_JPEG_DECODER,
+    jpegEncode: env?.JSQUASH_JPEG_ENCODER,
+    pngDecode: env?.JSQUASH_PNG_DECODER,
+    resize: env?.JSQUASH_RESIZE,
+    webpDecode: env?.JSQUASH_WEBP_DECODER,
+    webpEncode: env?.JSQUASH_WEBP_ENCODER,
   };
+  return Object.fromEntries(
+    Object.entries(modules).filter(([, value]) => value !== undefined)
+  );
 }
 
-export async function getEdgeUploadOptimizer(env = {}) {
-  const wasmModules = resolveWasmModules(env);
-  const filteredModules = Object.fromEntries(
-    Object.entries(wasmModules).filter(([, value]) => value !== undefined)
-  );
-
+export function getEdgeUploadOptimizer(env = {}) {
   if (!optimizerPromise) {
+    // Wasm bindings are static per deployment, so the first request's env wires
+    // the optimizer for the lifetime of the isolate. Reset on failure so one
+    // bad init does not cache a rejected promise until isolate eviction.
     optimizerPromise = createUploadOptimizer({
-      wasmModules: filteredModules,
+      wasmModules: resolveWasmModules(env),
       defaultOutput: 'arrayBuffer',
       now: () => Date.now(),
+    }).catch((error) => {
+      optimizerPromise = undefined;
+      throw error;
     });
   }
 
@@ -31,31 +39,46 @@ export async function getEdgeUploadOptimizer(env = {}) {
 }
 
 export async function handleOptimizeRequest(request, env = {}) {
-  const optimizer = await getEdgeUploadOptimizer(env);
-  const data = new Uint8Array(await request.arrayBuffer());
-  const result = await optimizer.optimizeUpload(data, {
-    format: 'jpeg',
-    maxWidth: 1600,
-    maxHeight: 1600,
-    output: 'arrayBuffer',
-  });
+  if (request.method !== 'POST') {
+    return new Response('POST a binary image body to optimize', {
+      status: 405,
+      headers: { allow: 'POST' },
+    });
+  }
 
-  return new Response(result.data, {
-    headers: {
-      'content-type': 'image/jpeg',
-      'x-lazy-image-metric-bytes-out': String(result.metrics.bytesOut),
-      'x-lazy-image-metric-encode-ms': String(result.metrics.encodeMs),
-    },
-  });
+  const data = new Uint8Array(await request.arrayBuffer());
+  if (data.byteLength === 0) {
+    return new Response('Request body is empty', { status: 400 });
+  }
+
+  try {
+    const optimizer = await getEdgeUploadOptimizer(env);
+    const result = await optimizer.optimizeUpload(data, {
+      format: 'jpeg',
+      maxWidth: 1600,
+      maxHeight: 1600,
+    });
+
+    return new Response(result.data, {
+      headers: {
+        'content-type': 'image/jpeg',
+        'x-lazy-image-metric-bytes-out': String(result.metrics.bytesOut),
+        'x-lazy-image-metric-encode-ms': String(result.metrics.encodeMs),
+      },
+    });
+  } catch (error) {
+    if (error instanceof LazyImageWasmError) {
+      const isCallerError = error.category === 'Input' || error.category === 'Config';
+      return new Response(`[${error.code}] ${error.message}`, {
+        status: isCallerError ? 400 : 500,
+      });
+    }
+    throw error;
+  }
 }
 
 export default {
   async fetch(request, env) {
-    if (request.method !== 'POST' || !request.body) {
-      return new Response('POST a binary image body to optimize', { status: 400 });
-    }
-
     return handleOptimizeRequest(request, env);
   },
 };
-

--- a/packages/lazy-image-wasm/examples/edge.mjs
+++ b/packages/lazy-image-wasm/examples/edge.mjs
@@ -1,0 +1,61 @@
+import { createUploadOptimizer } from '../edge.js';
+
+let optimizerPromise;
+
+function resolveWasmModules(env) {
+  return {
+    jpegDecode: env?.JPEGSQUASH_JPEG_DECODER,
+    jpegEncode: env?.JPEGSQUASH_JPEG_ENCODER,
+    pngDecode: env?.JPEGSQUASH_PNG_DECODER,
+    resize: env?.JPEGSQUASH_RESIZE,
+    webpDecode: env?.JPEGSQUASH_WEBP_DECODER,
+    webpEncode: env?.JPEGSQUASH_WEBP_ENCODER,
+  };
+}
+
+export async function getEdgeUploadOptimizer(env = {}) {
+  const wasmModules = resolveWasmModules(env);
+  const filteredModules = Object.fromEntries(
+    Object.entries(wasmModules).filter(([, value]) => value !== undefined)
+  );
+
+  if (!optimizerPromise) {
+    optimizerPromise = createUploadOptimizer({
+      wasmModules: filteredModules,
+      defaultOutput: 'arrayBuffer',
+      now: () => Date.now(),
+    });
+  }
+
+  return optimizerPromise;
+}
+
+export async function handleOptimizeRequest(request, env = {}) {
+  const optimizer = await getEdgeUploadOptimizer(env);
+  const data = new Uint8Array(await request.arrayBuffer());
+  const result = await optimizer.optimizeUpload(data, {
+    format: 'jpeg',
+    maxWidth: 1600,
+    maxHeight: 1600,
+    output: 'arrayBuffer',
+  });
+
+  return new Response(result.data, {
+    headers: {
+      'content-type': 'image/jpeg',
+      'x-lazy-image-metric-bytes-out': String(result.metrics.bytesOut),
+      'x-lazy-image-metric-encode-ms': String(result.metrics.encodeMs),
+    },
+  });
+}
+
+export default {
+  async fetch(request, env) {
+    if (request.method !== 'POST' || !request.body) {
+      return new Response('POST a binary image body to optimize', { status: 400 });
+    }
+
+    return handleOptimizeRequest(request, env);
+  },
+};
+

--- a/packages/lazy-image-wasm/test/run.mjs
+++ b/packages/lazy-image-wasm/test/run.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 
 import { createUploadOptimizer } from '../browser.js';
 import { createUploadOptimizer as createEdgeUploadOptimizer } from '../edge.js';
+import edgeExampleHandler from '../examples/edge.mjs';
 import { LazyImageWasmError, VERSION } from '../shared.js';
 
 if (typeof globalThis.ImageData !== 'function') {
@@ -221,4 +222,53 @@ await test('edge optimizer accepts precompiled WebAssembly.Module inputs', async
   assert.equal(result.format, 'jpeg');
   assert.ok(result.data instanceof ArrayBuffer);
   assert.equal(typeof result.metrics.encodeMs, 'number');
+});
+
+await test('edge example handler guards method and maps input errors to HTTP statuses', async () => {
+  const env = {
+    JSQUASH_JPEG_DECODER: wasmModules.jpegDecode,
+    JSQUASH_JPEG_ENCODER: wasmModules.jpegEncode,
+    JSQUASH_PNG_DECODER: wasmModules.pngDecode,
+    JSQUASH_RESIZE: wasmModules.resize,
+    JSQUASH_WEBP_DECODER: wasmModules.webpDecode,
+    JSQUASH_WEBP_ENCODER: wasmModules.webpEncode,
+  };
+
+  const methodResponse = await edgeExampleHandler.fetch(
+    new Request('http://localhost/', { method: 'GET' }),
+    env
+  );
+  assert.equal(methodResponse.status, 405);
+  assert.equal(methodResponse.headers.get('allow'), 'POST');
+
+  const input = await fixture('test_100KB_1057x1057.jpg');
+  const okResponse = await edgeExampleHandler.fetch(
+    new Request('http://localhost/', { method: 'POST', body: input, duplex: 'half' }),
+    env
+  );
+  assert.equal(okResponse.status, 200);
+  assert.equal(okResponse.headers.get('content-type'), 'image/jpeg');
+  const optimized = new Uint8Array(await okResponse.arrayBuffer());
+  assert.equal(
+    optimized.byteLength,
+    Number(okResponse.headers.get('x-lazy-image-metric-bytes-out'))
+  );
+  assert.ok(optimized[0] === 0xff && optimized[1] === 0xd8, 'output is JPEG');
+
+  const emptyResponse = await edgeExampleHandler.fetch(
+    new Request('http://localhost/', { method: 'POST' }),
+    env
+  );
+  assert.equal(emptyResponse.status, 400);
+
+  const badResponse = await edgeExampleHandler.fetch(
+    new Request('http://localhost/', {
+      method: 'POST',
+      body: new Uint8Array([1, 2, 3, 4]),
+      duplex: 'half',
+    }),
+    env
+  );
+  assert.equal(badResponse.status, 400);
+  assert.match(await badResponse.text(), /^\[E103\]/);
 });

--- a/packages/lazy-image-wasm/test/run.mjs
+++ b/packages/lazy-image-wasm/test/run.mjs
@@ -196,3 +196,29 @@ await test('edge entrypoint defaults to ArrayBuffer output', async () => {
   assert.ok(result.data instanceof ArrayBuffer);
   assert.equal(result.metrics.runtime, 'edge-isolate');
 });
+
+await test('edge optimizer accepts precompiled WebAssembly.Module inputs', async () => {
+  const compiledModules = {
+    jpegDecode: await WebAssembly.compile(
+      await readWasm('@jsquash/jpeg', 'codec/dec/mozjpeg_dec.wasm')
+    ),
+    jpegEncode: await WebAssembly.compile(
+      await readWasm('@jsquash/jpeg', 'codec/enc/mozjpeg_enc.wasm')
+    ),
+  };
+
+  const edgeOptimizer = await createEdgeUploadOptimizer({ wasmModules: compiledModules });
+  const input = await fixture('test_100KB_1057x1057.jpg');
+  const result = await edgeOptimizer.optimizeUpload(input, {
+    format: 'jpeg',
+    maxWidth: 640,
+    maxHeight: 640,
+    targetBytes: 45_000,
+    output: 'arrayBuffer',
+  });
+
+  assert.equal(result.metrics.runtime, 'edge-isolate');
+  assert.equal(result.format, 'jpeg');
+  assert.ok(result.data instanceof ArrayBuffer);
+  assert.equal(typeof result.metrics.encodeMs, 'number');
+});


### PR DESCRIPTION
## Overview

This PR addresses #645 (Wasm upload-preflight: browser/Edge runtime tracker).

### Problem reported
- Issue #645 tracked remaining work for the Wasm package, including missing Edge runtime usage guidance and example.
- Developers lacked a canonical Cloudflare Workers / V8-isolate usage pattern for `@alberteinshutoin/lazy-image-wasm/edge`.

### What changed
- Added `packages/lazy-image-wasm/examples/edge.mjs` with a runtime-safe Edge adapter example.
  - Exposes `getEdgeUploadOptimizer()` with cached optimizer creation and `handleOptimizeRequest()` for POST image bodies.
  - Keeps Wasm module wiring explicit via `wasmModules` in `env` and defaults output to `arrayBuffer`.
- Expanded `packages/lazy-image-wasm/README.md`:
  - Added Cloudflare/Edge example import/use guide.
  - Added Edge/browser constraints and bundle/evidence guidance.
- Extended `packages/lazy-image-wasm/test/run.mjs`:
  - New focused test `edge optimizer accepts precompiled WebAssembly.Module inputs` to cover precompiled Wasm module inputs at `edge` entrypoint.

### Behavior changes
- New public usage artifact: edge example module can be copied into Edge projects and invoked as a fetch handler.
- Documentation now explicitly describes Edge limitations (format support, no Blob on some runtimes, module-loading requirements).
- Added guard coverage for `WebAssembly.Module` inputs on edge path (already supported behavior, now exercised in tests).

### Verification performed
- `npm run test:wasm:package`
  - Result: pass (11 tests)
- Additional local note: `npm --workspace @alberteinshutoin/lazy-image-wasm install` was required in this environment to satisfy missing package dependencies before test run.

### Risks / follow-up
- The new example assumes deployment provides Wasm assets as bound values (`BufferSource`) under environment keys used in the sample.
- Remaining tasks in #645 (e.g., full browser/Edge benchmark evidence, Web Worker + public package evidence updates) are still open and should be handled in subsequent PRs.

Refs #645 (tracker stays open for the remaining benchmark/evidence tasks)


### Review follow-ups (2026-06-11)

- `handleOptimizeRequest` now guards method/body itself (405 + `Allow: POST` for non-POST, 400 for empty body) and maps `LazyImageWasmError` Input/Config errors to HTTP 400 instead of unhandled 500s.
- Failed optimizer init no longer caches a rejected promise; the next request retries.
- Env bindings renamed `JPEGSQUASH_*` -> `JSQUASH_*`; README documents the binding names and the package-specifier imports to use when copying the example.
- Added a test covering the example handler end-to-end (405 / 200 / empty-body 400 / E103 -> 400).
