### PR TITLE
ci: bump codecov-action to v5.5.5 for keybase key fix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -400,7 +400,7 @@ jobs:
         run: cargo llvm-cov --no-default-features --lcov --output-path lcov.info
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           files: lcov.info
           fail_ci_if_error: true


### PR DESCRIPTION
## Overview

Every **Coverage** job since 2026-06-07 fails repo-wide (all branches and PRs) at the **Upload to Codecov** step, while coverage generation itself succeeds:

```
gpg: no valid OpenPGP data found.
gpg: Can't check signature: No public key
==> Could not verify signature. Please contact Codecov if problem continues
```

### Root cause
The pinned `codecov/codecov-action@75cd1169 # v5` downloads Codecov's PGP public key from **keybase.io**, which no longer serves it, so CLI signature verification fails and `fail_ci_if_error: true` fails the job. Upstream issue: codecov/codecov-action#1956.

Timeline evidence:
- Last green run: 2026-06-06 (main / release/0.16.0 / v0.16.0)
- All runs since 2026-06-07 fail, and only on Coverage (fix/646, two dependabot PRs, #672 twice)
- Codecov published **v5.5.5 on 2026-06-09** containing only the keybase.io fix

### What changed
One line: bump the pin to `0fb7174895f61a3b6b78fc075e0cd60383518dac` (dereferenced commit of tag `v5.5.5`). Staying on the v5 line — v6/v7 are major jumps and unnecessary for this fix.

## Test plan
- [ ] Coverage job on this PR passes (pull_request runs use the merge ref, so this PR's own run exercises the new pin)
- [ ] After merge: update open PRs from develop and confirm their Coverage jobs go green (re-run alone is not enough — re-runs reuse the original workflow snapshot)