### PR TITLE
docs: sync ERROR_CODES with src error codes

### DIFF
--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -157,20 +157,20 @@ An I/O error occurred while reading the file.
 
 ---
 
-#### E110: Invalid Image Format
-**Recoverable**: No
+#### E102: Memory Map Failed
+**Recoverable**: Yes
 
-The file format is not recognized or is invalid.
+The input image could not be memory-mapped.
 
 **Common causes:**
-- File is corrupted
-- File is not an image
-- File extension doesn't match content
+- System memory pressure
+- File system limitations
+- Large memory-mapped read requests
 
 **How to fix:**
-- Verify the file is a valid image
-- Check if the file is corrupted
-- Try opening the file in an image viewer
+- Retry after freeing memory
+- Reduce concurrent workload
+- Use a smaller image
 
 ---
 
@@ -187,18 +187,6 @@ The image format is recognized but not supported by lazy-image.
 **How to fix:**
 - Convert the image to a supported format
 - Use a different image processing library for unsupported formats
-
----
-
-#### E120: Image Too Large
-**Recoverable**: No
-
-The image exceeds size limits (file size or memory constraints).
-
-**How to fix:**
-- Resize or compress the image before processing
-- Process the image in smaller chunks
-- Increase available memory
 
 ---
 
@@ -221,6 +209,18 @@ Total pixel count (width × height) exceeds the maximum allowed.
 **How to fix:**
 - Resize the image to reduce pixel count
 - Process smaller images or use batch processing
+
+---
+
+#### E123: Firewall Violation
+**Recoverable**: Yes
+
+A firewall policy rejected the image input based on bytes, pixels, metadata, or timeout limits.
+
+**How to fix:**
+- Review configured `limits()` policy values
+- Retry with a less restrictive policy
+- Reduce image size or complexity before processing
 
 ---
 
@@ -272,7 +272,18 @@ Crop coordinates exceed image dimensions.
 
 ---
 
-#### E201: Invalid Rotation Angle
+#### E201: Invalid Crop Dimensions
+**Recoverable**: Yes
+
+Crop dimensions are invalid (negative or out-of-range values).
+
+**How to fix:**
+- Ensure crop dimensions are valid
+- Validate crop bounds against image dimensions before calling resize/crop
+
+---
+
+#### E202: Invalid Rotation Angle
 **Recoverable**: Yes
 
 Rotation angle is not a multiple of 90 degrees.
@@ -287,7 +298,7 @@ Rotation angle is not a multiple of 90 degrees.
 
 ---
 
-#### E202: Invalid Resize Dimensions
+#### E203: Invalid Resize Dimensions
 **Recoverable**: Yes
 
 Resize dimensions are invalid (e.g., both width and height are None).
@@ -296,6 +307,17 @@ Resize dimensions are invalid (e.g., both width and height are None).
 - Provide at least one valid dimension (width or height)
 - Ensure dimensions are positive integers
 - Use `None` for one dimension to maintain aspect ratio
+
+---
+
+#### E204: Invalid Resize Fit
+**Recoverable**: Yes
+
+Unsupported resize fit value was provided.
+
+**How to fix:**
+- Use one of the documented fit values
+- Keep the value null/undefined if default fit should be used
 
 ---
 
@@ -358,28 +380,16 @@ An I/O error occurred while writing the output file.
 
 ---
 
-#### E302: Output Path Invalid
-**Recoverable**: Yes
-
-The output file path is invalid or inaccessible.
-
-**How to fix:**
-- Verify the output directory exists
-- Check path format (no invalid characters)
-- Ensure write permissions for the directory
-
----
-
 ### Configuration Errors (E4xx)
 
-#### E400: Invalid Quality Value
+#### E400: Invalid Argument
 **Recoverable**: Yes
 
-Quality parameter is out of valid range (typically 1-100).
+An invalid argument value was provided (format, quality, preset, policy, etc.).
 
 **How to fix:**
-- Use a quality value between 1 and 100
-- Check format-specific quality requirements
+- Check API arguments are valid for the target image and format
+- Use values within documented ranges
 
 ---
 
@@ -396,7 +406,18 @@ The specified preset name is not recognized.
 
 **How to fix:**
 - Use one of the available preset names
-- Check preset names are case-insensitive
+- Use `encode({ preset })` in current API usage
+
+---
+
+#### E402: Invalid Firewall Policy
+**Recoverable**: Yes
+
+An unknown or unsupported firewall policy was provided.
+
+**How to fix:**
+- Use a documented policy value
+- Check the requested policy format
 
 ---
 
@@ -471,7 +492,7 @@ match result {
 import { ImageEngine, ErrorCode } from '@alberteinshutoin/lazy-image';
 
 try {
-    const result = await ImageEngine.fromFile('input.jpg')
+    const result = await ImageEngine.fromPath('input.jpg')
         .resize(800)
         .toBuffer('jpeg', 85);
 } catch (error) {

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -332,15 +332,15 @@ The requested color space conversion is not supported.
 
 ---
 
-#### E299: Operation Failed
-**Recoverable**: Depends
+#### E299: Resize Failed
+**Recoverable**: No
 
-A general processing operation failed.
+The resize operation failed after validation due to a codec or processing error.
 
 **How to fix:**
 - Check the error message for specific details
-- Verify input parameters
-- Try a different approach
+- Try different resize parameters
+- Re-encode the input before resizing if the source image is unusual
 
 ---
 

--- a/test/integration/error-codes.test.js
+++ b/test/integration/error-codes.test.js
@@ -31,12 +31,14 @@ function extractErrorCodesFromDocs() {
 function extractErrorMetadataFromRust() {
     const rustSource = fs.readFileSync(resolveRoot('src/error.rs'), 'utf8');
     const codeMatches = [...rustSource.matchAll(/ErrorCode::(\w+) => "(E\d{3})"/g)];
-    const categoryBlock = rustSource.match(/pub fn category\(&self\) -> ErrorCategory \{\s*match self \{([\s\S]*?)\n        \}\n    \}/);
-    assert(categoryBlock, 'could not find ErrorCode::category() match block');
-
     const variantToCategory = new Map(
-        [...categoryBlock[1].matchAll(/ErrorCode::(\w+) => ErrorCategory::(\w+),/g)]
+        [...rustSource.matchAll(/ErrorCode::(\w+) => ErrorCategory::(\w+),/g)]
             .map((match) => [match[1], match[2]])
+    );
+    assert.strictEqual(
+        variantToCategory.size,
+        codeMatches.length,
+        'ErrorCode::category() must map every ErrorCode variant exactly once'
     );
 
     return new Map(codeMatches.map((match) => {

--- a/test/integration/error-codes.test.js
+++ b/test/integration/error-codes.test.js
@@ -1,7 +1,7 @@
 /**
  * Error code matrix tests — covers previously untested error codes.
  *
- * Targets: E111, E121, E123, E130, E131, E204, E400, E402, E900
+ * Targets: E102, E111, E121, E123, E130, E131, E201, E202, E203, E204, E400, E402, E900
  * (E122 PixelCountExceedsLimit is skipped — requires a real image whose
  *  decoded pixel count exceeds the limit, which cannot be synthesised cheaply.)
  *
@@ -15,6 +15,18 @@ const { ImageEngine, ErrorCategory, getErrorCategory } = require(resolveRoot('in
 
 const TEST_IMAGE = resolveFixture('test_input.jpg');
 const BUFFER = fs.readFileSync(TEST_IMAGE);
+
+function extractErrorCodesFromRust() {
+    const rustSource = fs.readFileSync(resolveRoot('src/error.rs'), 'utf8');
+    const matches = [...rustSource.matchAll(/ErrorCode::\w+ => "(E\d{3})"/g)];
+    return new Set(matches.map((match) => match[1]));
+}
+
+function extractErrorCodesFromDocs() {
+    const docSource = fs.readFileSync(resolveRoot('docs/ERROR_CODES.md'), 'utf8');
+    const matches = [...docSource.matchAll(/^#### (E\d{3}):/gm)];
+    return new Set(matches.map((match) => match[1]));
+}
 
 let passed = 0;
 let failed = 0;
@@ -235,6 +247,19 @@ async function asyncTest(name, fn) {
             );
         }
         assert(threw, 'should throw for invalid firewall policy');
+    });
+
+    await asyncTest('Docs and Rust error code tables are synchronized', async () => {
+        const rustCodes = extractErrorCodesFromRust();
+        const docCodes = extractErrorCodesFromDocs();
+        assert.deepStrictEqual(
+            [...docCodes].sort(),
+            [...rustCodes].sort(),
+            'Error code headings in docs/ERROR_CODES.md must match src/error.rs as_str() mapping'
+        );
+
+        const docs = fs.readFileSync(resolveRoot('docs/ERROR_CODES.md'), 'utf8');
+        assert.ok(!docs.includes('fromFile('), 'fromFile should be replaced with fromPath in docs examples');
     });
 
     // ---------------------------------------------------------------

--- a/test/integration/error-codes.test.js
+++ b/test/integration/error-codes.test.js
@@ -1,7 +1,7 @@
 /**
  * Error code matrix tests — covers previously untested error codes.
  *
- * Targets: E102, E111, E121, E123, E130, E131, E201, E202, E203, E204, E400, E402, E900
+ * Targets: E102, E111, E121, E123, E130, E131, E201, E202, E203, E204, E299, E400, E402, E900
  * (E122 PixelCountExceedsLimit is skipped — requires a real image whose
  *  decoded pixel count exceeds the limit, which cannot be synthesised cheaply.)
  *
@@ -26,6 +26,37 @@ function extractErrorCodesFromDocs() {
     const docSource = fs.readFileSync(resolveRoot('docs/ERROR_CODES.md'), 'utf8');
     const matches = [...docSource.matchAll(/^#### (E\d{3}):/gm)];
     return new Set(matches.map((match) => match[1]));
+}
+
+function extractErrorMetadataFromRust() {
+    const rustSource = fs.readFileSync(resolveRoot('src/error.rs'), 'utf8');
+    const codeMatches = [...rustSource.matchAll(/ErrorCode::(\w+) => "(E\d{3})"/g)];
+    const categoryBlock = rustSource.match(/pub fn category\(&self\) -> ErrorCategory \{\s*match self \{([\s\S]*?)\n        \}\n    \}/);
+    assert(categoryBlock, 'could not find ErrorCode::category() match block');
+
+    const variantToCategory = new Map(
+        [...categoryBlock[1].matchAll(/ErrorCode::(\w+) => ErrorCategory::(\w+),/g)]
+            .map((match) => [match[1], match[2]])
+    );
+
+    return new Map(codeMatches.map((match) => {
+        const variant = match[1];
+        const code = match[2];
+        const category = variantToCategory.get(variant);
+        assert(category, `missing category mapping for ${variant}`);
+
+        return [code, {
+            variant,
+            category,
+            recoverable: category === 'UserError' || category === 'ResourceLimit',
+        }];
+    }));
+}
+
+function extractErrorRecoverabilityFromDocs() {
+    const docSource = fs.readFileSync(resolveRoot('docs/ERROR_CODES.md'), 'utf8');
+    const matches = [...docSource.matchAll(/^#### (E\d{3}):[^\n]*\n\*\*Recoverable\*\*: (Yes|No)\s*$/gm)];
+    return new Map(matches.map((match) => [match[1], match[2] === 'Yes']));
 }
 
 let passed = 0;
@@ -260,6 +291,24 @@ async function asyncTest(name, fn) {
 
         const docs = fs.readFileSync(resolveRoot('docs/ERROR_CODES.md'), 'utf8');
         assert.ok(!docs.includes('fromFile('), 'fromFile should be replaced with fromPath in docs examples');
+    });
+
+    await asyncTest('Docs and Rust error recoverability flags are synchronized', async () => {
+        const rustMetadata = extractErrorMetadataFromRust();
+        const docRecoverability = extractErrorRecoverabilityFromDocs();
+        assert.deepStrictEqual(
+            [...docRecoverability.keys()].sort(),
+            [...rustMetadata.keys()].sort(),
+            'Each documented error code must include a Yes/No recoverable flag'
+        );
+
+        for (const [code, metadata] of rustMetadata) {
+            assert.strictEqual(
+                docRecoverability.get(code),
+                metadata.recoverable,
+                `${code} (${metadata.variant}) recoverability must match ${metadata.category}`
+            );
+        }
     });
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
## Problem
- Issue #674 reports that `docs/ERROR_CODES.md` is out of sync with `src/error.rs`, including missing / mismatched codes and stale examples.

## Changes
- Updated `docs/ERROR_CODES.md` to match `src/error.rs` `ErrorCode::as_str()` mapping:
  - Replaced obsolete sections (`E110`, `E120`, `E302`) and documented `E102`, `E123`, `E203`, `E204`.
  - Corrected section meanings for `E201`..`E204`.
  - Corrected `E400` to `Invalid Argument` and added `E402`.
  - Replaced the example API usage from `ImageEngine.fromFile()` to `ImageEngine.fromPath()`.
- Added sync/test coverage in `test/integration/error-codes.test.js`:
  - New check that `#### Exxx` headings in `docs/ERROR_CODES.md` match `src/error.rs` `as_str()` code set.
  - Added guard that `fromFile(` is no longer documented in `docs/ERROR_CODES.md`.

## Behavior changes
- No runtime behavior changes.
- Error code contract documentation now reflects actual native implementation semantics and avoids mismatched guidance.

## Verification
- `npm install`
- `npm run build`
- `node test/integration/error-codes.test.js`

## Remaining risk / follow-up
- This issue is docs+tests-only; no functional behavior changes were required.
- If Rust error code mapping changes in future workstreams, keep this sync test as a guard.
