### PR TITLE
chore: require native target-bytes binding

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -98,64 +98,13 @@ function normalizeTargetBytesOptions(format, options = {}) {
   };
 }
 
-async function encodeWithinByteBudget(engine, format, options) {
-  const config = normalizeTargetBytesOptions(format, options);
-  let low = config.minQuality;
-  let high = config.maxQuality;
-  let bestUnder = null;
-  let bestOver = null;
-
-  while (low <= high) {
-    const quality = Math.floor((low + high) / 2);
-    const result = await engine.toBufferWithMetrics(config.format, quality, config.fastMode);
-    const candidate = {
-      data: result.data,
-      metrics: result.metrics,
-      quality,
-      bytesOut: result.metrics?.bytesOut ?? result.data.length,
-    };
-
-    if (candidate.bytesOut <= config.targetBytes) {
-      bestUnder = candidate;
-      low = quality + 1;
-    } else {
-      if (
-        !bestOver ||
-        candidate.bytesOut < bestOver.bytesOut ||
-        (candidate.bytesOut === bestOver.bytesOut && quality > bestOver.quality)
-      ) {
-        bestOver = candidate;
-      }
-      high = quality - 1;
-    }
-  }
-
-  const chosen = bestUnder || bestOver;
-  if (!chosen) {
-    throw new Error('Failed to encode any candidate while searching for target bytes');
-  }
-
-  const budgetMet = chosen.bytesOut <= config.targetBytes;
-  if (!budgetMet && config.qualityFloorPolicy === 'strict') {
-    throw new Error(`Unable to meet targetBytes=${config.targetBytes} within quality range ${config.minQuality}-${config.maxQuality}`);
-  }
-
-  return {
-    ...chosen,
-    budgetMet,
-    targetBytes: config.targetBytes,
-    format: config.format,
-    fastMode: config.fastMode,
-    qualityFloorPolicy: config.qualityFloorPolicy,
-  };
-}
-
 /**
- * Shared target-bytes search that handles the Rust-native vs JS-fallback
- * decision.  Both toBufferTargetBytes and toFileTargetBytes delegate here
- * so the binary-search preference logic lives in one place.
+ * Shared target-bytes search used by toBufferTargetBytes and toFileTargetBytes.
+ * Implementation now requires a native binding that exposes
+ * `toBufferTargetBytesNative`; when it is missing we fail fast with an
+ * actionable message to force a version-aligned reinstall.
  *
- * @param {object} engine  – ImageEngine instance (must have toBufferTargetBytesNative or toBufferWithMetrics)
+ * @param {object} engine  – ImageEngine instance (must have toBufferTargetBytesNative)
  * @param {string} format  – output format (jpeg/webp/avif)
  * @param {object} options – TargetBytesOptions
  * @returns {Promise<{data: Buffer, quality: number, bytesOut: number, budgetMet: boolean, targetBytes: number, metrics: object}>}
@@ -163,7 +112,6 @@ async function encodeWithinByteBudget(engine, format, options) {
 async function runTargetBytesSearch(engine, format, options) {
   const config = normalizeTargetBytesOptions(format, options);
 
-  // Prefer Rust-native binary search (eliminates ~7 JS↔NAPI round-trips)
   if (typeof engine.toBufferTargetBytesNative === 'function') {
     const result = await engine.toBufferTargetBytesNative(
       config.format,
@@ -183,16 +131,10 @@ async function runTargetBytesSearch(engine, format, options) {
     };
   }
 
-  // Fallback: JS-side binary search (for older native bindings)
-  const result = await encodeWithinByteBudget(engine, format, options);
-  return {
-    data: result.data,
-    quality: result.quality,
-    bytesOut: result.bytesOut,
-    budgetMet: result.budgetMet,
-    targetBytes: result.targetBytes,
-    metrics: result.metrics,
-  };
+  throw new Error(
+    'toBufferTargetBytes requires a native binding with toBufferTargetBytesNative. ' +
+      'Reinstall @alberteinshutoin/lazy-image so the JS and native versions match.',
+  );
 }
 
 /** Resolve an encode-profile name into concrete quality/fastMode settings. */

--- a/test/unit/targetbytes.test.js
+++ b/test/unit/targetbytes.test.js
@@ -1,0 +1,76 @@
+const assert = require('node:assert/strict');
+
+const { runTargetBytesSearch } = require('../../lib/helpers');
+
+async function runTest(name, fn) {
+  try {
+    await fn();
+    console.log(`ok - ${name}`);
+  } catch (error) {
+    console.error(`not ok - ${name}`);
+    throw error;
+  }
+}
+
+async function run() {
+  await runTest('runTargetBytesSearch uses native toBufferTargetBytesNative when available', async () => {
+    const nativeResult = {
+      data: Buffer.from('abc'),
+      quality: 87,
+      bytesOut: 3,
+      budgetMet: true,
+      targetBytes: 2000,
+      metrics: { totalMs: 12 },
+    };
+
+    let called = false;
+    const engine = {
+      toBufferTargetBytesNative: async (...args) => {
+        called = true;
+        assert.equal(args[0], 'jpeg');
+        assert.equal(args[1], 2000);
+        assert.equal(args[2], 40);
+        assert.equal(args[3], 90);
+        assert.equal(args[4], true);
+        assert.equal(args[5], false);
+        return nativeResult;
+      },
+    };
+
+    const result = await runTargetBytesSearch(engine, 'jpeg', {
+      targetBytes: 2000,
+      minQuality: 40,
+      maxQuality: 90,
+      fastMode: true,
+      qualityFloorPolicy: 'best-effort',
+    });
+
+    assert.equal(called, true);
+    assert.deepEqual(result, nativeResult);
+  });
+
+  await runTest('runTargetBytesSearch rejects when toBufferTargetBytesNative is missing', async () => {
+    const engine = {
+      toBufferWithMetrics: async () => ({
+        data: Buffer.from('noop'),
+        metrics: { bytesOut: 999 },
+      }),
+    };
+
+    await assert.rejects(
+      () =>
+        runTargetBytesSearch(engine, 'jpeg', {
+          targetBytes: 2000,
+          minQuality: 40,
+          maxQuality: 90,
+        }),
+      /Reinstall @alberteinshutoin\/lazy-image so the JS and native versions match/,
+      'runTargetBytesSearch should explain native-binding mismatch explicitly',
+    );
+  });
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## 何が問題だったか
- `runTargetBytesSearch` は `toBufferTargetBytesNative` が利用不可な場合に JS 側の手動二分探索 (`encodeWithinByteBudget`) を実行していました。
- しかし本体実装と `helpers.js` の JS フォールバックは実装整合が取りづらく、ネイティブ側未対応時の挙動が不透明でした。

## 変更内容
- `lib/helpers.js`
  - `encodeWithinByteBudget` を削除し、`runTargetBytesSearch` をネイティブ実装のみで動作するように変更。
  - `toBufferTargetBytesNative` が存在する場合のみ利用。
  - 非対応環境では、再インストールを明示する明確なエラーメッセージを投げるように変更。
- `test/unit/targetbytes.test.js` 追加
  - ネイティブ経路で呼び出されることを検証。
  - `toBufferTargetBytesNative` 未実装時に上記エラー文言で失敗することを検証。

## 挙動の変更
- 以前: `toBufferTargetBytesNative` が無くても JS fallback で一応計算を継続していた。
- 変更後: `toBufferTargetBytesNative` のみ対応（フォールバックなし）とし、未対応環境では明示エラーで速やかに通知。
- これにより、JS/Native の版ズレを検知しやすくし、想定外の品質探索挙動を排除します。

## 検証
- `node --test test/unit/targetbytes.test.js`
- `npm run build`

## 残課題 / フォローアップ
- 現象的には非推奨フォールバックを除去しただけで、既存のネイティブ実装の可用性前提を強める変更です。
- 将来的には、ネイティブ経路を利用できない実行環境向けに代替 UX を別 Issue として検討すると安全性が高まります。

Closes #693
