### PR TITLE
docs: improve npm discovery metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,10 @@
 name = "lazy-image"
 version = "0.16.0"
 edition = "2021"
-description = "Web image optimization engine for Node.js focused on smaller browser-facing JPEG outputs and secure defaults with Rust + mozjpeg"
+description = "Web image optimization engine for Node.js focused on smaller browser-facing JPEG outputs and secure upload defaults with Rust + mozjpeg"
 license = "MIT"
 repository = "https://github.com/albert-einshutoin/lazy-image"
-keywords = ["image", "resize", "jpeg", "webp", "optimization"]
+keywords = ["image", "resize", "jpeg", "avif", "optimization"]
 categories = ["multimedia::images", "compression"]
 rust-version = "1.88"
 exclude = [".github", "test", "docs", "fuzz", "npm"]

--- a/README.ja.md
+++ b/README.ja.md
@@ -16,12 +16,6 @@ console.log(`Wrote ${bytesWritten} bytes`);
 
 英語版では簡潔なクイックスタートと README 構成の要点を先に示しており、同じ順序を維持しています。
 
-## Architecture Overview
-
-- `ImageEngine` は「構成 → キュー投入 → エンコード実行」の遅延実行モデル
-- 小〜中サイズ画像は V8 ヒープ経由を避け、ネイティブ側の Rust バッファ優先の処理
-- メタデータはデフォルトで除去、`keepMetadata()` で明示維持
-
 ## Choose lazy-image if / Choose sharp if
 
 **採用したい場合**
@@ -47,6 +41,17 @@ console.log(`Wrote ${bytesWritten} bytes`);
 ```bash
 npm install @alberteinshutoin/lazy-image
 ```
+
+| 配布経路 | 補足 |
+|---|---|
+| npm optional binaries | macOS arm64/x64、Linux x64/arm64 GNU、Linux x64 musl、Windows x64 |
+| ソースビルド | Node.js 18+、Rust 1.88+、ネイティブ codec toolchain が必要 |
+
+## Architecture Overview
+
+- `ImageEngine` は「構成 → キュー投入 → エンコード実行」の遅延実行モデル
+- 小〜中サイズ画像は V8 ヒープ経由を避け、ネイティブ側の Rust バッファ優先の処理
+- メタデータはデフォルトで除去、`keepMetadata()` で明示維持
 
 ## Basic Usage
 
@@ -83,4 +88,3 @@ MIT
 ## Credits
 
 [mozjpeg](https://github.com/mozilla/mozjpeg), [libwebp](https://chromium.googlesource.com/webm/libwebp), [libavif](https://github.com/AOMediaCodec/libavif), [napi-rs](https://napi.rs/)
-

--- a/README.md
+++ b/README.md
@@ -34,36 +34,6 @@ const bytesWritten = await ImageEngine.fromPath('input.png')
 console.log(`Wrote ${bytesWritten} bytes`);
 ```
 
----
-
-## Architecture Overview
-
-```
-src/                        # selected high-level Rust core modules
-├── engine/
-│   ├── api/                # ImageEngine public API + NAPI-facing operations
-│   ├── pipeline/           # Operation application, color state, capabilities, optimization
-│   ├── tasks/              # NAPI async task contexts and encode/batch/write execution
-│   ├── memory/             # Cgroup detection, memory estimates, weighted semaphore
-│   ├── io/                 # File sources, mmap, ICC/EXIF extraction and embedding
-│   ├── resize.rs           # Dimension calc, fast_image_resize dispatch
-│   ├── encoder.rs          # JPEG/PNG/WebP/AVIF encoding + ICC/EXIF embedding
-│   ├── decoder.rs          # Format detection + decoding
-│   ├── firewall.rs         # Input sanitization policies
-│   ├── metadata.rs         # Metadata policy and preservation state
-│   └── validation.rs       # Input, operation, and output validation helpers
-├── ops.rs                  # Operation enum, presets, output formats
-├── error.rs                # 4-tier error taxonomy (E1xx–E9xx)
-└── codecs/avif_safe.rs     # Safe libavif FFI wrappers
-
-lib/helpers.js              # Encoding profiles, target-bytes binary search
-streaming/pipeline.js       # Disk-backed bounded-memory streaming
-```
-
-**Key design decisions:** lazy execution (ops queue until output), file-path inputs bypass the V8 heap (read-into-memory for ≤ 256 MB, mmap with advisory locks for > 256 MB), memory-bounded concurrency via weighted semaphore, panic guards on all codec entry points. See [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) for details.
-
----
-
 ## Choose lazy-image if / Choose sharp if
 
 | **Choose lazy-image if** | **Choose sharp if** |
@@ -132,6 +102,39 @@ npm install @alberteinshutoin/lazy-image
 ```
 
 Platform-specific binaries (~6–9 MB per platform) are installed automatically. Build from source: `npm run build`. See [docs/PERFORMANCE.md](./docs/PERFORMANCE.md#serverless) for package size comparison with sharp.
+
+| Distribution path | Notes |
+|---|---|
+| npm optional binaries | macOS arm64/x64, Linux x64/arm64 GNU, Linux x64 musl, Windows x64 |
+| Source build | Node.js 18+, Rust 1.88+, and the native codec toolchain documented in [CONTRIBUTING.md](./CONTRIBUTING.md) |
+
+---
+
+## Architecture Overview
+
+```
+src/                        # selected high-level Rust core modules
+├── engine/
+│   ├── api/                # ImageEngine public API + NAPI-facing operations
+│   ├── pipeline/           # Operation application, color state, capabilities, optimization
+│   ├── tasks/              # NAPI async task contexts and encode/batch/write execution
+│   ├── memory/             # Cgroup detection, memory estimates, weighted semaphore
+│   ├── io/                 # File sources, mmap, ICC/EXIF extraction and embedding
+│   ├── resize.rs           # Dimension calc, fast_image_resize dispatch
+│   ├── encoder.rs          # JPEG/PNG/WebP/AVIF encoding + ICC/EXIF embedding
+│   ├── decoder.rs          # Format detection + decoding
+│   ├── firewall.rs         # Input sanitization policies
+│   ├── metadata.rs         # Metadata policy and preservation state
+│   └── validation.rs       # Input, operation, and output validation helpers
+├── ops.rs                  # Operation enum, presets, output formats
+├── error.rs                # 4-tier error taxonomy (E1xx–E9xx)
+└── codecs/avif_safe.rs     # Safe libavif FFI wrappers
+
+lib/helpers.js              # Encoding profiles, target-bytes binary search
+streaming/pipeline.js       # Disk-backed bounded-memory streaming
+```
+
+**Key design decisions:** lazy execution (ops queue until output), file-path inputs bypass the V8 heap (read-into-memory for ≤ 256 MB, mmap with advisory locks for > 256 MB), memory-bounded concurrency via weighted semaphore, panic guards on all codec entry points. See [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) for details.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@alberteinshutoin/lazy-image",
   "version": "0.16.0",
-  "description": "Web image optimization engine for Node.js focused on smaller browser-facing JPEG outputs, security defaults, and low-memory workflows powered by Rust + mozjpeg",
+  "description": "Web image optimization engine for Node.js focused on smaller browser-facing JPEG outputs, built-in upload sanitization (Image Firewall), and low-memory Rust workflows",
   "main": "index.js",
   "exports": {
     ".": {
@@ -28,14 +28,13 @@
     "avif",
     "image-optimization",
     "image-processing",
-    "compression",
     "compress",
     "thumbnail",
     "exif",
+    "mozjpeg",
     "sharp",
     "rust",
-    "napi",
-    "mozjpeg"
+    "napi"
   ],
   "author": "albert-einshutoin",
   "license": "MIT",

--- a/test/integration/package-metadata.test.js
+++ b/test/integration/package-metadata.test.js
@@ -25,30 +25,64 @@ function containsQuickStart(markdown) {
   return markdown.split('\n').slice(0, 80).some((line) => line.includes('Quick Start'));
 }
 
+function headingIndex(markdown, heading) {
+  return markdown.split('\n').findIndex((line) => line.trim() === heading);
+}
+
+function parseCargoKeywords(manifest) {
+  const match = manifest.match(/^keywords\s*=\s*\[([^\]]+)\]/m);
+  assert(match, 'Cargo.toml should define package keywords');
+  return match[1]
+    .split(',')
+    .map((value) => value.trim().replace(/^"|"$/g, ''))
+    .filter(Boolean);
+}
+
 const packageJson = require(path.join(ROOT_DIR, 'package.json'));
 
 test('package metadata and README structure', () => {
   assert(Array.isArray(packageJson.keywords), 'package.json.keywords should be an array');
-  assert(
-    packageJson.keywords.includes('avif'),
-    'package.json keywords should include avif',
-  );
-  assert(
-    packageJson.keywords.includes('image-optimization'),
-    'package.json keywords should include image-optimization',
-  );
+  for (const keyword of ['avif', 'image-optimization', 'image-processing', 'compress', 'thumbnail', 'exif']) {
+    assert(
+      packageJson.keywords.includes(keyword),
+      `package.json keywords should include ${keyword}`,
+    );
+  }
   assert(
     packageJson.description.length >= 80 && packageJson.description.length <= 250,
     `package.json description length must be 80-250 chars (actual: ${packageJson.description.length})`,
   );
+  assert(
+    packageJson.description.includes('Image Firewall'),
+    'package.json description should mention Image Firewall',
+  );
+
+  const cargoToml = readText('Cargo.toml');
+  const cargoKeywords = parseCargoKeywords(cargoToml);
+  assert(cargoKeywords.includes('avif'), 'Cargo.toml keywords should include avif');
 
   const readmeEn = readText('README.md');
   const readmeJa = readText('README.ja.md');
 
   assert(containsQuickStart(readmeEn), 'README.md should include "Quick Start" within first 80 lines');
   assert(
+    headingIndex(readmeEn, '## Quick Start (5 lines)') < headingIndex(readmeEn, '## Choose lazy-image if / Choose sharp if'),
+    'README.md should place the chooser after Quick Start',
+  );
+  assert(
+    headingIndex(readmeEn, '## Choose lazy-image if / Choose sharp if') < headingIndex(readmeEn, '## Architecture Overview'),
+    'README.md should place adoption guidance before architecture details',
+  );
+  assert(
+    headingIndex(readmeJa, '## Quick Start (5 lines)') < headingIndex(readmeJa, '## Choose lazy-image if / Choose sharp if'),
+    'README.ja.md should place the chooser after Quick Start',
+  );
+  assert(
+    headingIndex(readmeJa, '## Choose lazy-image if / Choose sharp if') < headingIndex(readmeJa, '## Architecture Overview'),
+    'README.ja.md should place adoption guidance before architecture details',
+  );
+  assert(
     countHeadings(readmeEn) === countHeadings(readmeJa),
     `README heading count mismatch: README.md=${countHeadings(readmeEn)} README.ja.md=${countHeadings(readmeJa)}`,
   );
 });
-

--- a/test/integration/package-metadata.test.js
+++ b/test/integration/package-metadata.test.js
@@ -26,7 +26,9 @@ function containsQuickStart(markdown) {
 }
 
 function headingIndex(markdown, heading) {
-  return markdown.split('\n').findIndex((line) => line.trim() === heading);
+  const index = markdown.split('\n').findIndex((line) => line.trim() === heading);
+  assert(index >= 0, `${heading} should exist`);
+  return index;
 }
 
 function parseCargoKeywords(manifest) {


### PR DESCRIPTION
Closes #701

## Problem
#701 reported that the package discovery path was weaker than the product surface: npm keywords missed important search terms such as AVIF/image optimization, the package description did not call out the security/upload-sanitization story, and the README above-the-fold flow put architecture details before adoption guidance.

## Changes
- Updated root `package.json` description and keywords to include AVIF, image optimization/processing, thumbnail, EXIF, mozjpeg, and the Image Firewall positioning.
- Aligned `Cargo.toml` metadata within crates.io keyword limits by adding `avif` and tightening the description around secure upload defaults.
- Reordered `README.md` and `README.ja.md` so Quick Start leads directly into the lazy-image vs sharp chooser, with install/platform details before architecture internals.
- Strengthened `test/integration/package-metadata.test.js` to lock key discovery terms, Image Firewall copy, Cargo AVIF metadata, and README section ordering.

## Behavior After This PR
New users see the adoption decision path earlier, npm/crates metadata better reflects the AVIF and upload-safety surface, and future drift in metadata or README above-the-fold ordering is caught by the JS integration test suite. Runtime code is unchanged.

## Verification
- `node test/integration/package-metadata.test.js`
- `npm run build`
- `npm test`
- `npm pack --dry-run`
- `node -e "const p=require('./package.json'); console.log(p.keywords.join(', ')); console.log(p.description)"`
- `git diff --check`

## Remaining Risks / Follow-up
No known runtime risk; changes are docs/package metadata/test only. `npm run build` reapplied an unrelated generated `index.js` postbuild diff locally, and I reverted that generated diff so this PR keeps runtime/index files untouched as requested.