### PR TITLE
refactor: remove small redundant wrappers

### DIFF
--- a/src/engine/decoder.rs
+++ b/src/engine/decoder.rs
@@ -240,7 +240,7 @@ const _: () = assert!(
 pub fn decode_png_zune(data: &[u8]) -> DecoderResult<DynamicImage> {
     run_with_panic_policy("decode:png", || {
         // Try to read dimensions from PNG header without full decode
-        if let Ok((width, height)) = read_png_dimensions(data) {
+        if let Some((width, height)) = read_png_dimensions(data) {
             // Global safety check (avoid decompression bombs)
             check_dimensions(width, height)?;
 
@@ -316,20 +316,17 @@ pub fn decode_png_zune(data: &[u8]) -> DecoderResult<DynamicImage> {
 }
 
 /// Read PNG dimensions from header without full decode.
-/// Returns (width, height) or error if header is invalid.
-fn read_png_dimensions(data: &[u8]) -> Result<(u32, u32), ()> {
+/// Returns (width, height) if the header is valid.
+fn read_png_dimensions(data: &[u8]) -> Option<(u32, u32)> {
     // PNG signature: 89 50 4E 47 0D 0A 1A 0A
     if data.len() < 24 || &data[0..8] != b"\x89PNG\r\n\x1a\n" {
-        return Err(());
+        return None;
     }
     // First chunk (IHDR) starts at offset 8
     // Width: bytes 16-19, Height: bytes 20-23 (big-endian)
-    if data.len() < 24 {
-        return Err(());
-    }
     let width = u32::from_be_bytes([data[16], data[17], data[18], data[19]]);
     let height = u32::from_be_bytes([data[20], data[21], data[22], data[23]]);
-    Ok((width, height))
+    Some((width, height))
 }
 
 /// Decode WebP using libwebp (via webp crate). Falls back to image crate for animated WebP.
@@ -434,7 +431,7 @@ pub fn ensure_dimensions_safe(bytes: &[u8]) -> DecoderResult<()> {
     }
 
     // PNG: read header directly when available to avoid full decode.
-    if let Ok((width, height)) = read_png_dimensions(bytes) {
+    if let Some((width, height)) = read_png_dimensions(bytes) {
         return check_dimensions(width, height);
     }
 

--- a/src/engine/encoder.rs
+++ b/src/engine/encoder.rs
@@ -45,15 +45,7 @@ fn validate_buffer_len(
 }
 
 fn validate_lossy_quality(quality: u8) -> EncoderResult<u8> {
-    if (1..=100).contains(&quality) {
-        Ok(quality)
-    } else {
-        Err(LazyImageError::invalid_argument(
-            "quality",
-            quality.to_string(),
-            "must be 1-100",
-        ))
-    }
+    crate::ops::Quality::new(quality).map(|quality| quality.get())
 }
 
 /// Single source of truth for mapping quality (1-100) to per-format encoder knobs.

--- a/src/engine/resize.rs
+++ b/src/engine/resize.rs
@@ -151,7 +151,7 @@ pub fn fast_resize(
         }
     };
 
-    fast_resize_internal_with_options(
+    fast_resize_internal_impl(
         src_width,
         src_height,
         src_pixels,
@@ -159,21 +159,6 @@ pub fn fast_resize(
         dst_width,
         dst_height,
         default_resize_options(),
-    )
-}
-
-/// Internal resize implementation (shared by both owned and reference versions)
-pub fn fast_resize_internal_with_options(
-    src_width: u32,
-    src_height: u32,
-    src_pixels: Vec<u8>,
-    pixel_type: PixelType,
-    dst_width: u32,
-    dst_height: u32,
-    options: ResizeOptions,
-) -> std::result::Result<DynamicImage, String> {
-    fast_resize_internal_impl(
-        src_width, src_height, src_pixels, pixel_type, dst_width, dst_height, options,
     )
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,7 +125,7 @@ pub fn inspect(env: Env, buffer: Buffer) -> Result<ImageMetadata> {
     let metadata = match inspect_header_from_bytes(buffer.as_ref()) {
         Ok(metadata) => metadata,
         Err(err) => {
-            return Err(crate::error::napi_error_with_code(&env, err.clone())?);
+            return Err(crate::error::napi_error_with_code(&env, err)?);
         }
     };
     Ok(metadata.into())
@@ -147,7 +147,7 @@ pub fn inspect_file(env: Env, path: String) -> Result<ImageMetadata> {
     let metadata = match inspect_header_from_path(&path) {
         Ok(metadata) => metadata,
         Err(err) => {
-            return Err(crate::error::napi_error_with_code(&env, err.clone())?);
+            return Err(crate::error::napi_error_with_code(&env, err)?);
         }
     };
     Ok(metadata.into())
@@ -161,40 +161,26 @@ pub fn version() -> String {
 }
 
 #[cfg(feature = "napi")]
+const BASE_FORMATS: &[&str] = &["jpeg", "jpg", "png", "webp"];
+
+#[cfg(feature = "napi")]
 /// Get supported input formats
 #[napi]
 pub fn supported_input_formats() -> Vec<String> {
-    vec![
-        "jpeg".to_string(),
-        "jpg".to_string(),
-        "png".to_string(),
-        "webp".to_string(),
-    ]
+    BASE_FORMATS
+        .iter()
+        .map(|format| format.to_string())
+        .collect()
 }
 
 #[cfg(feature = "napi")]
 /// Get supported output formats
 #[napi]
 pub fn supported_output_formats() -> Vec<String> {
+    let mut formats = supported_input_formats();
     #[cfg(feature = "avif")]
-    {
-        vec![
-            "jpeg".to_string(),
-            "jpg".to_string(),
-            "png".to_string(),
-            "webp".to_string(),
-            "avif".to_string(),
-        ]
-    }
-    #[cfg(not(feature = "avif"))]
-    {
-        vec![
-            "jpeg".to_string(),
-            "jpg".to_string(),
-            "png".to_string(),
-            "webp".to_string(),
-        ]
-    }
+    formats.push("avif".to_string());
+    formats
 }
 
 /// Metrics payload version. Keep in sync with docs/metrics-schema.json

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -299,10 +299,6 @@ pub enum OutputFormat {
 }
 
 impl OutputFormat {
-    fn validate_quality(quality: u8) -> Result<Quality, LazyImageError> {
-        Quality::new(quality)
-    }
-
     /// Create OutputFormat from string with format-specific default quality.
     ///
     /// Default quality by format (when quality is None):
@@ -329,7 +325,7 @@ impl OutputFormat {
         match format.to_lowercase().as_str() {
             "jpeg" | "jpg" => {
                 let q = quality
-                    .map(Self::validate_quality)
+                    .map(Quality::new)
                     .transpose()?
                     .unwrap_or(Quality::unchecked(85)); // JPEG default: 85
                 Ok(Self::Jpeg {
@@ -345,7 +341,7 @@ impl OutputFormat {
             }
             "webp" => {
                 let q = quality
-                    .map(Self::validate_quality)
+                    .map(Quality::new)
                     .transpose()?
                     .unwrap_or(Quality::unchecked(80)); // WebP default: 80
                 Ok(Self::WebP { quality: q })
@@ -353,7 +349,7 @@ impl OutputFormat {
             #[cfg(feature = "avif")]
             "avif" => {
                 let q = quality
-                    .map(Self::validate_quality)
+                    .map(Quality::new)
                     .transpose()?
                     .unwrap_or(Quality::unchecked(60)); // AVIF default: 60 (high compression efficiency)
                 Ok(Self::Avif { quality: q })

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -10,7 +10,7 @@
 
 #[cfg(feature = "napi")]
 mod tests {
-    use lazy_image::ImageEngine;
+    use lazy_image::{supported_input_formats, supported_output_formats, ImageEngine};
     use napi::bindgen_prelude::*;
 
     // Helper to create a minimal test image buffer
@@ -32,6 +32,35 @@ mod tests {
     // without requiring a real Node.js runtime in cargo test.
     fn dummy_env() -> Env {
         unsafe { Env::from_raw(std::ptr::null_mut()) }
+    }
+
+    #[test]
+    fn test_supported_format_lists_keep_public_order() {
+        assert_eq!(
+            supported_input_formats(),
+            ["jpeg", "jpg", "png", "webp"]
+                .into_iter()
+                .map(String::from)
+                .collect::<Vec<_>>()
+        );
+
+        let expected_output = {
+            #[cfg(feature = "avif")]
+            {
+                ["jpeg", "jpg", "png", "webp", "avif"]
+            }
+            #[cfg(not(feature = "avif"))]
+            {
+                ["jpeg", "jpg", "png", "webp"]
+            }
+        };
+        assert_eq!(
+            supported_output_formats(),
+            expected_output
+                .into_iter()
+                .map(String::from)
+                .collect::<Vec<_>>()
+        );
     }
 
     #[test]


### PR DESCRIPTION
Resolves #684.

## Problem

Issue #684 reported a cluster of small readability and maintenance problems: redundant pass-through helpers, owned error clones, `Result<_, ()>` for a failure-without-reason path, and duplicated supported-format list construction. Each item is intended to preserve behavior while removing noise that could encourage more duplication.

## Changes

- Removed unnecessary `LazyImageError` clones in `inspect` / `inspectFile` before converting to N-API errors.
- Replaced `OutputFormat::validate_quality` call sites with direct `Quality::new` usage.
- Delegated encoder lossy quality validation to `Quality::new` so the error contract has one source of truth.
- Changed PNG header dimension probing from `Result<(u32, u32), ()>` to `Option<(u32, u32)>` and removed the duplicate length check.
- Removed `fast_resize_internal_with_options` and called `fast_resize_internal_impl` directly.
- Centralized the N-API base format list and added a focused regression test for public input/output format ordering.

## Behavior

No public API or runtime behavior is intended to change. Supported format output remains:

```text
["jpeg", "jpg", "png", "webp"]
["jpeg", "jpg", "png", "webp", "avif"]
```

`index.js` and `index.d.ts` were regenerated by `npm run build` and have no diff.

## Verification

- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo clippy --no-default-features -- -D warnings`
- `cargo test --no-default-features`
- `cargo test --features napi test_supported_format_lists_keep_public_order`
- `npm run build`
- `npm test`
- `node -e "const li = require('./index.js'); console.log(JSON.stringify([li.supportedInputFormats(), li.supportedOutputFormats()]))"`
- `git diff --check`

## Risks / follow-up

Risk is low: this is a scoped cleanup with tests covering the observable format-list behavior and full JS/Rust test suites passing. The NAPI focused Rust test emits existing warning noise from test-only code, but the targeted test passes.
