### PR TITLE
feat: add chunked batch progress helper

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -62,6 +62,7 @@ const bytes = await ImageEngine.fromPath('photo.jpg').toFileWithPreset('thumb.we
 | `.toFileProfile(path, format, profile, quality?)` | Profile-based file encode. |
 | `.processBatch(inputs, outDir, { format, quality?, fastMode?, concurrency? })` | Process multiple images in parallel. Returns array of `BatchResult`. `concurrency`: workers (0 = CPU cores). |
 | `.processBatchWithMetrics(inputs, outDir, { format, quality?, fastMode?, concurrency? })` | Batch processing with per-item metrics and a summary. |
+| `processBatchChunked(inputs, outDir, { format, quality?, fastMode?, concurrency?, chunkSize?, onProgress?, signal? })` | Top-level batch helper that splits inputs into native `processBatch()` chunks. Reports progress after each chunk and checks `AbortSignal` before starting the next chunk. |
 | `.clone()` | Clone the engine for multi-output (e.g. same pipeline to JPEG + WebP + AVIF). |
 
 ## Utilities
@@ -74,6 +75,38 @@ const bytes = await ImageEngine.fromPath('photo.jpg').toFileWithPreset('thumb.we
 | `.hasIccProfile()` | Returns ICC profile size in bytes, or null if none |
 | `resolveEncodeProfile(format, profile, quality?)` | Resolve profile into concrete `{ format, quality, fastMode }` options. |
 | `createStreamingPipeline({ format, quality, ops, onMetrics? })` | Disk-backed bounded-memory pipeline. Not a true chunk-by-chunk transform stream. Optional `onMetrics` callback receives `ProcessingMetrics` after file output completes. |
+
+---
+
+## Chunked Batch Progress
+
+Use `processBatchChunked()` when a large build-time batch needs chunk-level
+progress or a safe stop point between native batch calls:
+
+```javascript
+const { processBatchChunked } = require('@alberteinshutoin/lazy-image');
+
+const controller = new AbortController();
+const results = await processBatchChunked(files, './optimized', {
+  format: 'webp',
+  quality: 80,
+  concurrency: 4,
+  chunkSize: 16,
+  signal: controller.signal,
+  onProgress: ({ completed, total, failed }) => {
+    console.log(`${completed}/${total} complete (${failed} failed)`);
+  },
+});
+```
+
+`chunkSize` defaults to `16`. For long-running native batches, start with roughly
+`concurrency * 2` to `concurrency * 4`; very small chunks add synchronization
+overhead and can leave native workers idle.
+
+`signal.aborted` is checked only before each chunk starts. Aborting does not
+cancel work already running inside native `processBatch()`, and files written by
+completed chunks remain on disk. If `onProgress` throws, lazy-image logs the
+callback error and continues processing the next chunk.
 
 ---
 

--- a/examples/batch-processing.mjs
+++ b/examples/batch-processing.mjs
@@ -5,7 +5,7 @@
  *   node examples/batch-processing.mjs
  */
 
-import { ImageEngine } from '@alberteinshutoin/lazy-image';
+import { ImageEngine, processBatchChunked } from '@alberteinshutoin/lazy-image';
 import { readdirSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -48,3 +48,20 @@ console.log(`  Concurrency: ${summary.effectiveConcurrency} (auto: ${summary.aut
 console.log(`  Total in: ${(summary.totalBytesIn / 1024).toFixed(0)} KB`);
 console.log(`  Total out: ${(summary.totalBytesOut / 1024).toFixed(0)} KB`);
 console.log(`  Wall time: ${summary.totalWallMs.toFixed(0)} ms`);
+
+// ── 3. Chunked batch with progress and AbortSignal ─────────────────
+const controller = new AbortController();
+const chunkedResults = await processBatchChunked(files, outputDir, {
+  format: 'webp',
+  quality: 80,
+  concurrency: 4,
+  chunkSize: 16,
+  signal: controller.signal,
+  onProgress: ({ completed, total, failed }) => {
+    const percent = Math.round((completed / total) * 100);
+    process.stdout.write(`\r${completed}/${total} (${percent}%) complete, ${failed} failed`);
+  },
+});
+
+process.stdout.write('\n');
+console.log(`Chunked batch complete: ${chunkedResults.length} results`);

--- a/index.d.ts
+++ b/index.d.ts
@@ -582,6 +582,32 @@ export interface EncodeOptionsInput {
 
 export declare function getErrorCategory(err: unknown): ErrorCategory | null
 
+export interface BatchProgressEvent {
+  /** Completed file count after the latest chunk finishes */
+  completed: number
+  /** Total input file count */
+  total: number
+  /** Results returned by the latest processBatch chunk */
+  lastChunk: BatchResult[]
+  /** Cumulative failed result count through the latest chunk */
+  failed: number
+}
+
+export interface ProcessBatchChunkedOptions extends BatchOptions {
+  /** Number of files per native processBatch call. Default: 16. */
+  chunkSize?: number
+  /** Called after each chunk. Throwing is logged and does not stop processing. */
+  onProgress?: (event: BatchProgressEvent) => void
+  /** Checked before each chunk starts. Aborted signals reject with AbortError. */
+  signal?: AbortSignal
+}
+
+export declare function processBatchChunked(
+  inputs: string[],
+  outputDir: string,
+  options: ProcessBatchChunkedOptions,
+): Promise<BatchResult[]>
+
 export declare function createStreamingPipeline(options: {
   format?: OutputFormat
   quality?: number

--- a/index.js
+++ b/index.js
@@ -590,7 +590,9 @@ module.exports.version = nativeBinding.version
 const { createStreamingPipeline } = require('./streaming/pipeline')
 const helpers = require('./lib/helpers')
 const _getErrorCategory = helpers.createGetErrorCategory(nativeBinding.ErrorCategory, nativeBinding.ErrorCode)
+const _processBatchChunked = helpers.createProcessBatchChunked(nativeBinding.ImageEngine)
 module.exports.getErrorCategory = _getErrorCategory
+module.exports.processBatchChunked = _processBatchChunked
 module.exports.createStreamingPipeline = createStreamingPipeline
 module.exports.resolveEncodeProfile = helpers.resolveEncodeProfile
 if (nativeBinding && nativeBinding.ImageEngine) {

--- a/index.mjs
+++ b/index.mjs
@@ -13,6 +13,7 @@ export const {
   supportedOutputFormats,
   version,
   getErrorCategory,
+  processBatchChunked,
   createStreamingPipeline,
   resolveEncodeProfile,
 } = mod;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -261,6 +261,26 @@ function createAbortError() {
   return error;
 }
 
+function isReadableInputFile(input) {
+  if (typeof input !== 'string') return false;
+  try {
+    fs.accessSync(input, fs.constants.R_OK);
+    return fs.statSync(input).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function createInputReadFailure(input) {
+  return {
+    source: input,
+    success: false,
+    error: `[E100] ${input}: failed to read input file`,
+    errorCode: 'E100',
+    errorCategory: 'UserError',
+  };
+}
+
 function createProcessBatchChunked(ImageEngine) {
   return function processBatchChunked(inputs, outputDir, options = {}) {
     if (!Array.isArray(inputs)) {
@@ -285,14 +305,34 @@ function createProcessBatchChunked(ImageEngine) {
       if (chunk.length === 0) {
         return Promise.resolve([]);
       }
-      const bootstrapInput = chunk.find((input) => typeof input === 'string' && fs.existsSync(input)) || chunk[0];
+      const bootstrapInput = chunk.find(isReadableInputFile);
+      if (!bootstrapInput) {
+        return Promise.resolve(chunk.map(createInputReadFailure));
+      }
       return ImageEngine.fromPath(bootstrapInput).processBatch(chunk, outputDir, batchOptions);
+    };
+
+    const reportProgress = (results, chunkResults, failed) => {
+      if (!onProgress) return;
+      try {
+        onProgress({
+          completed: results.length,
+          total: inputs.length,
+          lastChunk: chunkResults,
+          failed,
+        });
+      } catch (err) {
+        console.error('processBatchChunked onProgress callback threw:', err);
+      }
     };
 
     if (inputs.length <= chunkSize) {
       return (async () => {
         throwIfAborted();
-        return processChunk(inputs);
+        const chunkResults = await processChunk(inputs);
+        const failed = chunkResults.filter((result) => !result.success).length;
+        reportProgress(chunkResults, chunkResults, failed);
+        return chunkResults;
       })();
     }
 
@@ -305,19 +345,7 @@ function createProcessBatchChunked(ImageEngine) {
         const chunkResults = await processChunk(chunk);
         results.push(...chunkResults);
         failed += chunkResults.filter((result) => !result.success).length;
-
-        if (onProgress) {
-          try {
-            onProgress({
-              completed: results.length,
-              total: inputs.length,
-              lastChunk: chunkResults,
-              failed,
-            });
-          } catch (err) {
-            console.error('processBatchChunked onProgress callback threw:', err);
-          }
-        }
+        reportProgress(results, chunkResults, failed);
       }
       return results;
     })();

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const fs = require('node:fs');
+
 // ---------------------------------------------------------------------------
 // Helper functions extracted from the postbuild-appended JS block.
 // These are proper source files now instead of string-concatenated code.
@@ -247,6 +249,82 @@ function createGetErrorCategory(ErrorCategory, ErrorCode) {
 }
 
 // ---------------------------------------------------------------------------
+// processBatchChunked — chunk-level progress and abort around native batches.
+// ---------------------------------------------------------------------------
+
+function createAbortError() {
+  if (typeof DOMException === 'function') {
+    return new DOMException('processBatchChunked was aborted', 'AbortError');
+  }
+  const error = new Error('processBatchChunked was aborted');
+  error.name = 'AbortError';
+  return error;
+}
+
+function createProcessBatchChunked(ImageEngine) {
+  return function processBatchChunked(inputs, outputDir, options = {}) {
+    if (!Array.isArray(inputs)) {
+      throw new Error('inputs must be an array of file paths');
+    }
+    if (!ImageEngine || typeof ImageEngine.fromPath !== 'function') {
+      throw new Error('processBatchChunked requires ImageEngine.fromPath');
+    }
+
+    const { chunkSize = 16, onProgress, signal, ...batchOptions } = options;
+    if (!Number.isInteger(chunkSize) || chunkSize < 1) {
+      throw new Error('chunkSize must be a positive integer');
+    }
+
+    const throwIfAborted = () => {
+      if (signal?.aborted) {
+        throw createAbortError();
+      }
+    };
+
+    const processChunk = (chunk) => {
+      if (chunk.length === 0) {
+        return Promise.resolve([]);
+      }
+      const bootstrapInput = chunk.find((input) => typeof input === 'string' && fs.existsSync(input)) || chunk[0];
+      return ImageEngine.fromPath(bootstrapInput).processBatch(chunk, outputDir, batchOptions);
+    };
+
+    if (inputs.length <= chunkSize) {
+      return (async () => {
+        throwIfAborted();
+        return processChunk(inputs);
+      })();
+    }
+
+    return (async () => {
+      const results = [];
+      let failed = 0;
+      for (let i = 0; i < inputs.length; i += chunkSize) {
+        throwIfAborted();
+        const chunk = inputs.slice(i, i + chunkSize);
+        const chunkResults = await processChunk(chunk);
+        results.push(...chunkResults);
+        failed += chunkResults.filter((result) => !result.success).length;
+
+        if (onProgress) {
+          try {
+            onProgress({
+              completed: results.length,
+              total: inputs.length,
+              lastChunk: chunkResults,
+              failed,
+            });
+          } catch (err) {
+            console.error('processBatchChunked onProgress callback threw:', err);
+          }
+        }
+      }
+      return results;
+    })();
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Prototype method attachment — called with the ImageEngine class
 // ---------------------------------------------------------------------------
 
@@ -310,5 +388,6 @@ module.exports = {
   runTargetBytesSearch,
   resolveEncodeProfile,
   createGetErrorCategory,
+  createProcessBatchChunked,
   attachPrototypeMethods,
 };

--- a/scripts/postbuild-fixup.js
+++ b/scripts/postbuild-fixup.js
@@ -54,6 +54,32 @@ export interface EncodeOptionsInput {
 
 export declare function getErrorCategory(err: unknown): ErrorCategory | null
 
+export interface BatchProgressEvent {
+  /** Completed file count after the latest chunk finishes */
+  completed: number
+  /** Total input file count */
+  total: number
+  /** Results returned by the latest processBatch chunk */
+  lastChunk: BatchResult[]
+  /** Cumulative failed result count through the latest chunk */
+  failed: number
+}
+
+export interface ProcessBatchChunkedOptions extends BatchOptions {
+  /** Number of files per native processBatch call. Default: 16. */
+  chunkSize?: number
+  /** Called after each chunk. Throwing is logged and does not stop processing. */
+  onProgress?: (event: BatchProgressEvent) => void
+  /** Checked before each chunk starts. Aborted signals reject with AbortError. */
+  signal?: AbortSignal
+}
+
+export declare function processBatchChunked(
+  inputs: string[],
+  outputDir: string,
+  options: ProcessBatchChunkedOptions,
+): Promise<BatchResult[]>
+
 export declare function createStreamingPipeline(options: {
   format?: OutputFormat
   quality?: number
@@ -143,7 +169,9 @@ function patchIndexJs() {
 const { createStreamingPipeline } = require('./streaming/pipeline')
 const helpers = require('./lib/helpers')
 const _getErrorCategory = helpers.createGetErrorCategory(nativeBinding.ErrorCategory, nativeBinding.ErrorCode)
+const _processBatchChunked = helpers.createProcessBatchChunked(nativeBinding.ImageEngine)
 module.exports.getErrorCategory = _getErrorCategory
+module.exports.processBatchChunked = _processBatchChunked
 module.exports.createStreamingPipeline = createStreamingPipeline
 module.exports.resolveEncodeProfile = helpers.resolveEncodeProfile
 if (nativeBinding && nativeBinding.ImageEngine) {

--- a/test/integration/batch-chunked.test.js
+++ b/test/integration/batch-chunked.test.js
@@ -88,21 +88,25 @@ async function main() {
     assert.deepEqual(resultShape(chunked), resultShape(direct));
   });
 
-  await test('delegates single default-size chunk without progress callback overhead', async () => {
+  await test('reports progress for a single default-size chunk', async () => {
     const inputs = makeInputs('delegated', 3);
     const outputDir = resetDir(path.join(ROOT, 'delegated', 'out'));
-    let progressCalls = 0;
+    const progress = [];
 
     const results = await processBatchChunked(inputs, outputDir, {
       format: 'webp',
       quality: 80,
-      onProgress: () => {
-        progressCalls += 1;
+      onProgress: (event) => {
+        progress.push(event);
       },
     });
 
     assert.equal(results.length, 3);
-    assert.equal(progressCalls, 0);
+    assert.equal(progress.length, 1);
+    assert.equal(progress[0].completed, 3);
+    assert.equal(progress[0].total, 3);
+    assert.equal(progress[0].failed, 0);
+    assert.equal(progress[0].lastChunk.length, 3);
     assert(results.every((result) => result.success));
   });
 
@@ -187,6 +191,28 @@ async function main() {
     assert(failed, 'one result should fail');
     assert.equal(failed.source, missing);
     assert.equal(typeof failed.errorCode, 'string');
+  });
+
+  await test('returns failed results when a chunk has no readable bootstrap input', async () => {
+    const missingA = path.join(ROOT, 'all-missing', 'missing-a.jpg');
+    const missingB = path.join(ROOT, 'all-missing', 'missing-b.jpg');
+    const outputDir = resetDir(path.join(ROOT, 'all-missing', 'out'));
+    const progress = [];
+
+    const results = await processBatchChunked([missingA, missingB], outputDir, {
+      format: 'webp',
+      quality: 80,
+      chunkSize: 1,
+      onProgress: (event) => progress.push(event),
+    });
+
+    assert.equal(results.length, 2);
+    assert.deepEqual(results.map((result) => result.source), [missingA, missingB]);
+    assert(results.every((result) => result.success === false));
+    assert.deepEqual(results.map((result) => result.errorCode), ['E100', 'E100']);
+    assert.deepEqual(results.map((result) => result.errorCategory), ['UserError', 'UserError']);
+    assert.deepEqual(progress.map((event) => event.completed), [1, 2]);
+    assert.deepEqual(progress.map((event) => event.failed), [1, 2]);
   });
 
   await test('rejects invalid chunk sizes before returning a promise', async () => {

--- a/test/integration/batch-chunked.test.js
+++ b/test/integration/batch-chunked.test.js
@@ -1,0 +1,212 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { ImageEngine, processBatchChunked } = require('../..');
+const { resolveFixture, resolveTemp } = require('../helpers/paths');
+
+const SOURCE = resolveFixture('test_100KB_1057x1057.jpg');
+const ROOT = resolveTemp('batch-chunked');
+
+function resetDir(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function makeInputs(name, count) {
+  const dir = resetDir(path.join(ROOT, name, 'inputs'));
+  return Array.from({ length: count }, (_, index) => {
+    const target = path.join(dir, `input-${index}.jpg`);
+    fs.copyFileSync(SOURCE, target);
+    return target;
+  });
+}
+
+function resultShape(results) {
+  return results.map((result) => ({
+    source: result.source,
+    success: result.success,
+    outputFile: result.outputPath ? path.basename(result.outputPath) : undefined,
+    errorCode: result.errorCode,
+  }));
+}
+
+async function assertAbortError(promise) {
+  await assert.rejects(promise, (error) => {
+    assert.equal(error.name, 'AbortError');
+    return true;
+  });
+}
+
+async function test(name, fn) {
+  try {
+    await fn();
+    console.log(`✅ ${name}`);
+  } catch (error) {
+    console.log(`❌ ${name}`);
+    throw error;
+  }
+}
+
+async function main() {
+  assert.equal(typeof processBatchChunked, 'function');
+
+  await test('chunks inputs, preserves order, and reports progress', async () => {
+    const inputs = makeInputs('progress', 5);
+    const outputDir = resetDir(path.join(ROOT, 'progress', 'out'));
+    const progress = [];
+
+    const results = await processBatchChunked(inputs, outputDir, {
+      format: 'webp',
+      quality: 80,
+      chunkSize: 2,
+      onProgress: (event) => progress.push(event),
+    });
+
+    assert.equal(results.length, 5);
+    assert.deepEqual(results.map((result) => result.source), inputs);
+    assert.deepEqual(progress.map((event) => event.completed), [2, 4, 5]);
+    assert.deepEqual(progress.map((event) => event.total), [5, 5, 5]);
+    assert.deepEqual(progress.map((event) => event.failed), [0, 0, 0]);
+    assert.deepEqual(progress.map((event) => event.lastChunk.length), [2, 2, 1]);
+    assert(results.every((result) => result.success));
+    for (const result of results) {
+      assert(result.outputPath, 'successful result should expose outputPath');
+      assert(fs.existsSync(result.outputPath), `output should exist: ${result.outputPath}`);
+    }
+  });
+
+  await test('matches processBatch result order and output names', async () => {
+    const inputs = makeInputs('match-process-batch', 4);
+    const directOut = resetDir(path.join(ROOT, 'match-process-batch', 'direct'));
+    const chunkedOut = resetDir(path.join(ROOT, 'match-process-batch', 'chunked'));
+    const options = { format: 'jpeg', quality: 82, concurrency: 1 };
+
+    const direct = await ImageEngine.fromPath(inputs[0]).processBatch(inputs, directOut, options);
+    const chunked = await processBatchChunked(inputs, chunkedOut, { ...options, chunkSize: 2 });
+
+    assert.deepEqual(resultShape(chunked), resultShape(direct));
+  });
+
+  await test('delegates single default-size chunk without progress callback overhead', async () => {
+    const inputs = makeInputs('delegated', 3);
+    const outputDir = resetDir(path.join(ROOT, 'delegated', 'out'));
+    let progressCalls = 0;
+
+    const results = await processBatchChunked(inputs, outputDir, {
+      format: 'webp',
+      quality: 80,
+      onProgress: () => {
+        progressCalls += 1;
+      },
+    });
+
+    assert.equal(results.length, 3);
+    assert.equal(progressCalls, 0);
+    assert(results.every((result) => result.success));
+  });
+
+  await test('aborts at chunk boundaries and keeps completed chunk outputs', async () => {
+    const inputs = makeInputs('abort-after-first-chunk', 4);
+    const outputDir = resetDir(path.join(ROOT, 'abort-after-first-chunk', 'out'));
+    const controller = new AbortController();
+    let completedChunk = [];
+
+    await assertAbortError(processBatchChunked(inputs, outputDir, {
+      format: 'webp',
+      quality: 80,
+      chunkSize: 2,
+      onProgress: (event) => {
+        completedChunk = event.lastChunk;
+        controller.abort();
+      },
+      signal: controller.signal,
+    }));
+
+    assert.equal(completedChunk.length, 2);
+    for (const result of completedChunk) {
+      assert(result.success);
+      assert(result.outputPath);
+      assert(fs.existsSync(result.outputPath), `completed output should remain: ${result.outputPath}`);
+    }
+  });
+
+  await test('pre-aborted signal rejects before creating outputs', async () => {
+    const inputs = makeInputs('pre-aborted', 3);
+    const outputDir = resetDir(path.join(ROOT, 'pre-aborted', 'out'));
+    const controller = new AbortController();
+    controller.abort();
+
+    await assertAbortError(processBatchChunked(inputs, outputDir, {
+      format: 'webp',
+      quality: 80,
+      chunkSize: 2,
+      signal: controller.signal,
+    }));
+    assert.deepEqual(fs.readdirSync(outputDir), []);
+  });
+
+  await test('continues when progress callback throws', async () => {
+    const inputs = makeInputs('progress-throws', 4);
+    const outputDir = resetDir(path.join(ROOT, 'progress-throws', 'out'));
+    const originalError = console.error;
+    const errors = [];
+    console.error = (...args) => errors.push(args);
+    try {
+      const results = await processBatchChunked(inputs, outputDir, {
+        format: 'jpeg',
+        quality: 80,
+        chunkSize: 2,
+        onProgress: () => {
+          throw new Error('progress failed');
+        },
+      });
+
+      assert.equal(results.length, 4);
+      assert(results.every((result) => result.success));
+      assert.equal(errors.length, 2);
+    } finally {
+      console.error = originalError;
+    }
+  });
+
+  await test('preserves processBatch partial-failure semantics', async () => {
+    const inputs = makeInputs('partial-failure', 2);
+    const missing = path.join(ROOT, 'partial-failure', 'missing.jpg');
+    const outputDir = resetDir(path.join(ROOT, 'partial-failure', 'out'));
+
+    const results = await processBatchChunked([inputs[0], missing, inputs[1]], outputDir, {
+      format: 'webp',
+      quality: 80,
+      chunkSize: 2,
+    });
+
+    assert.equal(results.length, 3);
+    assert.deepEqual(results.map((result) => result.source), [inputs[0], missing, inputs[1]]);
+    const failed = results.find((result) => !result.success);
+    assert(failed, 'one result should fail');
+    assert.equal(failed.source, missing);
+    assert.equal(typeof failed.errorCode, 'string');
+  });
+
+  await test('rejects invalid chunk sizes before returning a promise', async () => {
+    const inputs = makeInputs('invalid-chunk-size', 1);
+    const outputDir = resetDir(path.join(ROOT, 'invalid-chunk-size', 'out'));
+
+    assert.throws(
+      () => processBatchChunked(inputs, outputDir, { format: 'webp', chunkSize: 0 }),
+      /chunkSize must be a positive integer/,
+    );
+    assert.throws(
+      () => processBatchChunked(inputs, outputDir, { format: 'webp', chunkSize: 1.5 }),
+      /chunkSize must be a positive integer/,
+    );
+  });
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/test/type-safety/typescript-typecheck.test.ts
+++ b/test/type-safety/typescript-typecheck.test.ts
@@ -4,12 +4,14 @@
  */
 import * as path from 'path';
 import {
+    BatchProgressEvent,
     ImageEngine,
     ImageMetadata,
     OutputFormat,
     PresetName,
     PresetResult,
     ResizeFit,
+    processBatchChunked,
 } from '../../index';
 import { createStreamingPipeline } from '../../streaming/pipeline';
 
@@ -79,6 +81,20 @@ async function testTypeSafety() {
     );
     
     console.log(`Batch processing: ${batchResults.length} results`);
+
+    const chunkedBatchResults = await processBatchChunked(
+        [imagePath],
+        path.resolve(__dirname, '../../.tmp/type-safety-batch-chunked'),
+        {
+            format: 'webp',
+            quality: 80,
+            chunkSize: 1,
+            onProgress: (event: BatchProgressEvent) => {
+                console.log(`Chunked progress: ${event.completed}/${event.total}`);
+            },
+        }
+    );
+    console.log(`Chunked batch processing: ${chunkedBatchResults.length} results`);
 
     const streamingPipeline = createStreamingPipeline({
         format: 'webp',


### PR DESCRIPTION
## Problem

Closes #702.

`processBatch()` is useful for build-time optimization, but large batches had no chunk-level progress signal and no safe stop point. That made long CI or static-site jobs look stalled until every file completed.

## Changes

- Added top-level `processBatchChunked(inputs, outputDir, options)` for chunked native `processBatch()` execution.
- Added `chunkSize`, `onProgress`, and `AbortSignal` support with chunk-boundary abort semantics.
- Exported the helper from CJS, ESM, and generated TypeScript declarations via `scripts/postbuild-fixup.js`.
- Added focused integration coverage for ordering, delegation, progress events, abort behavior, callback errors, partial failures, and invalid chunk sizes.
- Documented chunk-level progress/abort limitations in `docs/API.md` and added an example in `examples/batch-processing.mjs`.
- Added TypeScript typecheck coverage for the new API and progress event type.

## Behavior

`processBatchChunked()` returns a flat `BatchResult[]` in input order. For inputs larger than `chunkSize`, it calls `onProgress` after each completed chunk. `signal.aborted` is checked before a chunk starts; work already inside native `processBatch()` is not cancelled, and completed chunk outputs remain on disk. If `onProgress` throws, the error is logged and the batch continues.

## Verification

- `npm run build`
- `node test/integration/batch-chunked.test.js`
- `npm run test:types`
- `npm test` progressed through all JS gates, then stopped at Rust link due local disk exhaustion (`No space left on device`). After cleaning only generated Cargo build artifacts, the remaining gates passed individually:
  - `CARGO_INCREMENTAL=0 cargo test --no-default-features`
  - `npm run test:wasm:package`
- `npm pack --dry-run`
- `git diff --check`
- Smoke:
  ```bash
  node <<'NODE'
  const { processBatchChunked } = require('./index.js');
  const fs = require('fs'); const os = require('os'); const path = require('path');
  (async () => {
    const out = fs.mkdtempSync(path.join(os.tmpdir(), 'li-'));
    const src = 'test/fixtures/test_100KB_1057x1057.jpg';
    const inputs = Array.from({ length: 5 }, () => src);
    const results = await processBatchChunked(inputs, out, {
      format: 'webp', quality: 80, chunkSize: 2,
      onProgress: (e) => console.log(`progress ${e.completed}/${e.total}`),
    });
    console.log('done:', results.length);
  })();
  NODE
  ```
  Output included `progress 2/5`, `progress 4/5`, `progress 5/5`, and `done: 5`.

## Risks / follow-up

- Abort remains chunk-boundary only by design; native work already running in a chunk cannot be cancelled.
- The helper is a top-level batch convenience and does not carry a custom `ImageEngine` pipeline such as `.resize()`. Existing instance `processBatch()` remains the pipeline-aware API.
