### PR TITLE
refactor: centralize signed percent validation

### DIFF
--- a/src/engine/api/pipeline_ops.rs
+++ b/src/engine/api/pipeline_ops.rs
@@ -306,18 +306,7 @@ impl ImageEngine {
         this: Reference<ImageEngine>,
         value: f64,
     ) -> Result<Reference<ImageEngine>> {
-        let value = validation::ensure_finite_integer("brightness", value)
-            .and_then(|int| {
-                if !(-100..=100).contains(&int) {
-                    Err(LazyImageError::invalid_argument(
-                        "brightness",
-                        int.to_string(),
-                        "expected value between -100 and 100",
-                    ))
-                } else {
-                    Ok(int as i32)
-                }
-            })
+        let value = validation::sanitize_signed_percent("brightness", value)
             .map_err(|e| napi_err(&env, e))?;
 
         self.ops.push(Operation::Brightness { value });
@@ -332,18 +321,7 @@ impl ImageEngine {
         this: Reference<ImageEngine>,
         value: f64,
     ) -> Result<Reference<ImageEngine>> {
-        let value = validation::ensure_finite_integer("contrast", value)
-            .and_then(|int| {
-                if !(-100..=100).contains(&int) {
-                    Err(LazyImageError::invalid_argument(
-                        "contrast",
-                        int.to_string(),
-                        "expected value between -100 and 100",
-                    ))
-                } else {
-                    Ok(int as i32)
-                }
-            })
+        let value = validation::sanitize_signed_percent("contrast", value)
             .map_err(|e| napi_err(&env, e))?;
 
         self.ops.push(Operation::Contrast { value });

--- a/src/engine/io/icc.rs
+++ b/src/engine/io/icc.rs
@@ -170,6 +170,12 @@ where
 
 /// Validate ICC profile header
 /// ICC profiles must start with a 128-byte header containing specific fields
+fn is_printable_ascii_field(bytes: &[u8]) -> bool {
+    bytes
+        .iter()
+        .all(|&byte| (32..=126).contains(&byte) || byte == 0)
+}
+
 pub(crate) fn validate_icc_profile(icc_data: &[u8]) -> bool {
     // Minimum ICC profile size is 128 bytes (header)
     if icc_data.len() < 128 {
@@ -185,13 +191,17 @@ pub(crate) fn validate_icc_profile(icc_data: &[u8]) -> bool {
         return false;
     }
 
-    // Check preferred CMM type (bytes 4-7) - should be ASCII
-    // Common values: "ADBE", "appl", "lcms", etc.
-    // We just check that it's printable ASCII
-    for &byte in &icc_data[4..8] {
-        if !(32..=126).contains(&byte) && byte != 0 {
-            return false;
-        }
+    // Check printable ASCII tag fields:
+    // - preferred CMM type (bytes 4-7), common values: "ADBE", "appl", "lcms"
+    // - profile class signature (bytes 12-15), common values: "mntr", "prtr", "scnr", "spac"
+    // - data color space (bytes 16-19)
+    // - PCS (Profile Connection Space) signature (bytes 20-23)
+    if !is_printable_ascii_field(&icc_data[4..8])
+        || !is_printable_ascii_field(&icc_data[12..16])
+        || !is_printable_ascii_field(&icc_data[16..20])
+        || !is_printable_ascii_field(&icc_data[20..24])
+    {
+        return false;
     }
 
     // Check profile version (bytes 8-11)
@@ -199,29 +209,6 @@ pub(crate) fn validate_icc_profile(icc_data: &[u8]) -> bool {
     let major_version = icc_data[8];
     if major_version > 10 {
         return false;
-    }
-
-    // Check profile class signature (bytes 12-15)
-    // Common: "mntr" (monitor), "prtr" (printer), "scnr" (scanner), "spac" (color space)
-    // We just check that it's ASCII
-    for &byte in &icc_data[12..16] {
-        if !(32..=126).contains(&byte) && byte != 0 {
-            return false;
-        }
-    }
-
-    // Check data color space (bytes 16-19) - should be ASCII
-    for &byte in &icc_data[16..20] {
-        if !(32..=126).contains(&byte) && byte != 0 {
-            return false;
-        }
-    }
-
-    // Check PCS (Profile Connection Space) signature (bytes 20-23) - should be ASCII
-    for &byte in &icc_data[20..24] {
-        if !(32..=126).contains(&byte) && byte != 0 {
-            return false;
-        }
     }
 
     // Basic validation passed

--- a/src/engine/validation.rs
+++ b/src/engine/validation.rs
@@ -171,6 +171,22 @@ pub fn sanitize_quality(quality: Option<f64>) -> std::result::Result<Option<u8>,
 }
 
 #[cfg(feature = "napi")]
+pub(crate) fn sanitize_signed_percent(
+    name: &'static str,
+    value: f64,
+) -> std::result::Result<i32, LazyImageError> {
+    let int = ensure_finite_integer(name, value)?;
+    if !(-100..=100).contains(&int) {
+        return Err(LazyImageError::invalid_argument(
+            name,
+            int.to_string(),
+            "expected value between -100 and 100",
+        ));
+    }
+    Ok(int as i32)
+}
+
+#[cfg(feature = "napi")]
 pub fn sanitize_concurrency(concurrency: Option<f64>) -> std::result::Result<u32, LazyImageError> {
     match concurrency {
         None => Ok(0),
@@ -259,4 +275,55 @@ pub fn validate_output_path(path: &str) -> std::result::Result<(), LazyImageErro
     }
 
     Ok(())
+}
+
+#[cfg(all(test, feature = "napi"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_signed_percent_accepts_boundaries() {
+        assert_eq!(sanitize_signed_percent("brightness", -100.0).unwrap(), -100);
+        assert_eq!(sanitize_signed_percent("brightness", 0.0).unwrap(), 0);
+        assert_eq!(sanitize_signed_percent("brightness", 100.0).unwrap(), 100);
+    }
+
+    #[test]
+    fn sanitize_signed_percent_rejects_out_of_range_values() {
+        let below = sanitize_signed_percent("brightness", -101.0).unwrap_err();
+        assert_eq!(
+            below.to_string(),
+            "Invalid value for brightness: -101. expected value between -100 and 100"
+        );
+
+        let above = sanitize_signed_percent("contrast", 101.0).unwrap_err();
+        assert_eq!(
+            above.to_string(),
+            "Invalid value for contrast: 101. expected value between -100 and 100"
+        );
+    }
+
+    #[test]
+    fn sanitize_signed_percent_rejects_non_finite_values() {
+        let nan = sanitize_signed_percent("brightness", f64::NAN).unwrap_err();
+        assert_eq!(
+            nan.to_string(),
+            "Invalid value for brightness: NaN. must be a finite number"
+        );
+
+        let infinity = sanitize_signed_percent("contrast", f64::INFINITY).unwrap_err();
+        assert_eq!(
+            infinity.to_string(),
+            "Invalid value for contrast: Infinity. must be a finite number"
+        );
+    }
+
+    #[test]
+    fn sanitize_signed_percent_rejects_fractional_values() {
+        let err = sanitize_signed_percent("brightness", 50.5).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Invalid value for brightness: 50.5. must be an integer"
+        );
+    }
 }


### PR DESCRIPTION
## Problem

Closes #690.

Issue #690 reported two small validation duplications:

- `brightness()` and `contrast()` each carried the same finite/integer/-100..=100 validation block.
- `validate_icc_profile()` repeated the same printable-ASCII ICC header field loop four times.

## Implementation

Implementation skill status:

- `gemini-rescue` with `gemini-3.1-pro-preview` was invoked. The first run failed on Gemini trusted-directory configuration; the trusted retry stalled on an unavailable `run_shell_command` tool and was cancelled with no file changes.
- `opencode-rescue` with `MiniMaxM3` was invoked for a read-only implementation review, but OpenCode failed with `Model not found: MiniMaxM3/` and produced no code changes.
- Codex completed the scoped implementation and performed the final manager/reviewer pass because the requested implementation runtimes did not complete safely.

Changes:

- Added `validation::sanitize_signed_percent()` as the single source for signed percent validation.
- Replaced `brightness()` and `contrast()` duplicate validation with the shared helper while preserving existing error text and E400 behavior.
- Added focused Rust unit coverage for `-101`, `-100`, `0`, `100`, `101`, `NaN`, `Infinity`, and `50.5`.
- Added `is_printable_ascii_field()` and routed all four ICC header ASCII field checks through it without changing accepted/rejected data.

## Behavior

No public API change is intended. Brightness and contrast still accept only finite integer values in `-100..=100`, reject invalid values with the same `Invalid value for ... expected value between -100 and 100` wording, and keep the same lazy-image user error category/code. ICC profile validation keeps the same printable ASCII or NUL-padding rule for CMM type, profile class, color space, and PCS fields.

## Verification

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo clippy --no-default-features -- -D warnings`
- `cargo test sanitize_signed_percent`
- `cargo test validate_icc_profile`
- `cargo test --no-default-features`
- `npm ci`
- `npm run build`
- `npm test`
- `node -e "const { ImageEngine } = require('./index.js'); const fs = require('fs'); const files = fs.readdirSync('test/fixtures'); const fixture = files.find(f => /\\.(jpe?g|png)$/i.test(f)); const buf = fs.readFileSync('test/fixtures/' + fixture); ImageEngine.from(buf).brightness(101);" 2>&1 | grep "expected value between -100 and 100"`
- `git diff --check`
- `git diff -- index.js index.d.ts` (empty after dropping unrelated postbuild-generated `index.js` drift)

## Codex Review Result

Reviewed the full diff for correctness, test adequacy, docs impact, regressions, security issues, API/contract drift, maintainability, and OSS value. The change is intentionally narrow, reduces duplicate validation logic, keeps JS-visible behavior stable, and adds targeted regression coverage. Remaining risk is low; no docs update is needed because the documented public range and behavior are unchanged.
