### PR TITLE
refactor: centralize engine test fixtures for issue #685

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -47,6 +47,8 @@ mod pool;
 pub(crate) mod resize;
 mod stress;
 mod tasks;
+#[cfg(test)]
+pub(crate) mod test_support;
 pub(crate) mod validation;
 
 // -----------------------------------------------------------------------------
@@ -122,16 +124,11 @@ mod tests {
     use crate::engine::api::MetadataPolicy;
     use crate::engine::firewall::FirewallConfig;
     use crate::engine::tasks::{EncodeTask, TaskContext};
+    use crate::engine::test_support::create_test_image;
     use crate::error::LazyImageError;
     use crate::ops::OutputFormat;
-    use image::{DynamicImage, GenericImageView, RgbImage};
+    use image::GenericImageView;
     use std::sync::Arc;
-
-    fn create_test_image(width: u32, height: u32) -> DynamicImage {
-        DynamicImage::ImageRgb8(RgbImage::from_fn(width, height, |x, y| {
-            image::Rgb([(x % 256) as u8, (y % 256) as u8, 128])
-        }))
-    }
 
     fn create_png(width: u32, height: u32) -> Vec<u8> {
         let img = create_test_image(width, height);

--- a/src/engine/api/tests.rs
+++ b/src/engine/api/tests.rs
@@ -4,15 +4,9 @@
 // Kept as a sibling file so the production modules stay focused.
 
 use crate::engine::resize::fast_resize_owned;
+use crate::engine::test_support::create_test_image;
 #[allow(unused_imports)]
 use image::GenericImageView;
-use image::{DynamicImage, RgbImage};
-
-fn create_test_image(width: u32, height: u32) -> DynamicImage {
-    DynamicImage::ImageRgb8(RgbImage::from_fn(width, height, |x, y| {
-        image::Rgb([(x % 256) as u8, (y % 256) as u8, 128])
-    }))
-}
 
 #[test]
 fn fast_resize_owned_returns_error_instead_of_dummy_image() {

--- a/src/engine/encoder.rs
+++ b/src/engine/encoder.rs
@@ -493,20 +493,9 @@ pub fn encode_avif(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use image::{DynamicImage, RgbImage, RgbaImage};
-
-    // Helper function to create test images
-    fn create_test_image(width: u32, height: u32) -> DynamicImage {
-        DynamicImage::ImageRgb8(RgbImage::from_fn(width, height, |x, y| {
-            image::Rgb([(x % 256) as u8, (y % 256) as u8, 128])
-        }))
-    }
-
-    fn create_test_image_rgba(width: u32, height: u32) -> DynamicImage {
-        DynamicImage::ImageRgba8(RgbaImage::from_fn(width, height, |x, y| {
-            image::Rgba([(x % 256) as u8, (y % 256) as u8, 128, 255])
-        }))
-    }
+    use crate::engine::test_support::{
+        create_test_image, create_test_image_rgba, minimal_icc_profile,
+    };
 
     mod encode_tests {
         use super::*;
@@ -536,30 +525,7 @@ mod tests {
         #[test]
         fn test_encode_jpeg_with_icc() {
             let img = create_test_image(100, 100);
-            // Minimal valid ICC profile
-            let mut icc_data = vec![0u8; 128];
-            icc_data[0] = 0x00;
-            icc_data[1] = 0x00;
-            icc_data[2] = 0x00;
-            icc_data[3] = 0x80; // 128 bytes
-            icc_data[4] = b'A';
-            icc_data[5] = b'D';
-            icc_data[6] = b'B';
-            icc_data[7] = b'E';
-            icc_data[8] = 2;
-            icc_data[12] = b'm';
-            icc_data[13] = b'n';
-            icc_data[14] = b't';
-            icc_data[15] = b'r';
-            icc_data[16] = b'R';
-            icc_data[17] = b'G';
-            icc_data[18] = b'B';
-            icc_data[19] = b' ';
-            icc_data[20] = b'X';
-            icc_data[21] = b'Y';
-            icc_data[22] = b'Z';
-            icc_data[23] = b' ';
-
+            let icc_data = minimal_icc_profile();
             let result = encode_jpeg(&img, 80, Some(&icc_data)).unwrap();
             assert_eq!(&result[0..2], &[0xFF, 0xD8]);
         }
@@ -595,29 +561,7 @@ mod tests {
         #[test]
         fn test_encode_jpeg_fast_mode_with_icc() {
             let img = create_test_image(100, 100);
-            let mut icc_data = vec![0u8; 128];
-            icc_data[0] = 0x00;
-            icc_data[1] = 0x00;
-            icc_data[2] = 0x00;
-            icc_data[3] = 0x80;
-            icc_data[4] = b'A';
-            icc_data[5] = b'D';
-            icc_data[6] = b'B';
-            icc_data[7] = b'E';
-            icc_data[8] = 2;
-            icc_data[12] = b'm';
-            icc_data[13] = b'n';
-            icc_data[14] = b't';
-            icc_data[15] = b'r';
-            icc_data[16] = b'R';
-            icc_data[17] = b'G';
-            icc_data[18] = b'B';
-            icc_data[19] = b' ';
-            icc_data[20] = b'X';
-            icc_data[21] = b'Y';
-            icc_data[22] = b'Z';
-            icc_data[23] = b' ';
-
+            let icc_data = minimal_icc_profile();
             let result = encode_jpeg_with_settings(&img, 80, Some(&icc_data), true).unwrap();
             assert_eq!(&result[0..2], &[0xFF, 0xD8]);
         }
@@ -647,29 +591,7 @@ mod tests {
         #[test]
         fn test_encode_png_with_icc() {
             let img = create_test_image(100, 100);
-            let mut icc_data = vec![0u8; 128];
-            icc_data[0] = 0x00;
-            icc_data[1] = 0x00;
-            icc_data[2] = 0x00;
-            icc_data[3] = 0x80;
-            icc_data[4] = b'A';
-            icc_data[5] = b'D';
-            icc_data[6] = b'B';
-            icc_data[7] = b'E';
-            icc_data[8] = 2;
-            icc_data[12] = b'm';
-            icc_data[13] = b'n';
-            icc_data[14] = b't';
-            icc_data[15] = b'r';
-            icc_data[16] = b'R';
-            icc_data[17] = b'G';
-            icc_data[18] = b'B';
-            icc_data[19] = b' ';
-            icc_data[20] = b'X';
-            icc_data[21] = b'Y';
-            icc_data[22] = b'Z';
-            icc_data[23] = b' ';
-
+            let icc_data = minimal_icc_profile();
             let result = encode_png(&img, Some(&icc_data)).unwrap();
             assert_eq!(
                 &result[0..8],
@@ -689,29 +611,7 @@ mod tests {
         #[test]
         fn test_encode_webp_with_icc() {
             let img = create_test_image(100, 100);
-            let mut icc_data = vec![0u8; 128];
-            icc_data[0] = 0x00;
-            icc_data[1] = 0x00;
-            icc_data[2] = 0x00;
-            icc_data[3] = 0x80;
-            icc_data[4] = b'A';
-            icc_data[5] = b'D';
-            icc_data[6] = b'B';
-            icc_data[7] = b'E';
-            icc_data[8] = 2;
-            icc_data[12] = b'm';
-            icc_data[13] = b'n';
-            icc_data[14] = b't';
-            icc_data[15] = b'r';
-            icc_data[16] = b'R';
-            icc_data[17] = b'G';
-            icc_data[18] = b'B';
-            icc_data[19] = b' ';
-            icc_data[20] = b'X';
-            icc_data[21] = b'Y';
-            icc_data[22] = b'Z';
-            icc_data[23] = b' ';
-
+            let icc_data = minimal_icc_profile();
             let result = encode_webp(&img, 80, Some(&icc_data)).unwrap();
             assert_eq!(&result[0..4], b"RIFF");
             assert_eq!(&result[8..12], b"WEBP");

--- a/src/engine/io/test_helpers.rs
+++ b/src/engine/io/test_helpers.rs
@@ -6,14 +6,12 @@
 // the helpers via `super::super::test_helpers::*` without exposing them to
 // production builds.
 
-use image::{DynamicImage, RgbImage};
+use crate::engine::test_support;
+use image::DynamicImage;
 use std::io::Cursor;
 
-/// Build a deterministic RGB test image.
 pub(super) fn create_test_image(width: u32, height: u32) -> DynamicImage {
-    DynamicImage::ImageRgb8(RgbImage::from_fn(width, height, |x, y| {
-        image::Rgb([(x % 256) as u8, (y % 256) as u8, 128])
-    }))
+    test_support::create_test_image(width, height)
 }
 
 /// Produce a minimal valid JPEG via mozjpeg so format-aware parsers accept it.

--- a/src/engine/pipeline/tests.rs
+++ b/src/engine/pipeline/tests.rs
@@ -8,16 +8,10 @@
 
 use super::capabilities::{validate_operation_sequence_with_caps, OperationCapabilities};
 use super::*;
+use crate::engine::test_support::create_test_image;
 use crate::ops::{Operation, ResizeFit};
 use image::{DynamicImage, GenericImageView, RgbImage, RgbaImage};
 use std::borrow::Cow;
-
-// Helper function used by every submodule below.
-fn create_test_image(width: u32, height: u32) -> DynamicImage {
-    DynamicImage::ImageRgb8(RgbImage::from_fn(width, height, |x, y| {
-        image::Rgb([(x % 256) as u8, (y % 256) as u8, 128])
-    }))
-}
 
 #[path = "tests/apply_ops.rs"]
 mod apply_ops_tests;

--- a/src/engine/resize.rs
+++ b/src/engine/resize.rs
@@ -407,19 +407,8 @@ fn resize_with_source_image<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use image::{DynamicImage, GenericImageView, RgbImage, RgbaImage};
-
-    fn create_test_image(width: u32, height: u32) -> DynamicImage {
-        DynamicImage::ImageRgb8(RgbImage::from_fn(width, height, |x, y| {
-            image::Rgb([(x % 256) as u8, (y % 256) as u8, 128])
-        }))
-    }
-
-    fn create_test_image_rgba(width: u32, height: u32) -> DynamicImage {
-        DynamicImage::ImageRgba8(RgbaImage::from_fn(width, height, |x, y| {
-            image::Rgba([(x % 256) as u8, (y % 256) as u8, 128, 255])
-        }))
-    }
+    use crate::engine::test_support::{create_test_image, create_test_image_rgba};
+    use image::GenericImageView;
 
     mod resize_calc_tests {
         use super::*;

--- a/src/engine/test_support.rs
+++ b/src/engine/test_support.rs
@@ -1,0 +1,50 @@
+// Shared test fixtures for `engine` unit tests.
+//
+// This module is compiled only under `cfg(test)`. Shared fixtures here reduce
+// copy/paste drift across module-local test modules.
+
+use image::{DynamicImage, RgbImage, RgbaImage};
+
+/// Deterministic RGB test image (gradient pattern).
+pub(crate) fn create_test_image(width: u32, height: u32) -> DynamicImage {
+    DynamicImage::ImageRgb8(RgbImage::from_fn(width, height, |x, y| {
+        image::Rgb([(x % 256) as u8, (y % 256) as u8, 128])
+    }))
+}
+
+/// Deterministic RGBA test image (gradient pattern, fully opaque).
+pub(crate) fn create_test_image_rgba(width: u32, height: u32) -> DynamicImage {
+    DynamicImage::ImageRgba8(RgbaImage::from_fn(width, height, |x, y| {
+        image::Rgba([(x % 256) as u8, (y % 256) as u8, 128, 255])
+    }))
+}
+
+/// Minimal valid ICC profile used by several encoder tests.
+pub(crate) fn minimal_icc_profile() -> Vec<u8> {
+    let mut icc = vec![0u8; 128];
+    icc[0..4].copy_from_slice(&128u32.to_be_bytes());
+    icc[4..8].copy_from_slice(b"ADBE");
+    icc[8] = 2;
+    icc[12..16].copy_from_slice(b"mntr");
+    icc[16..20].copy_from_slice(b"RGB ");
+    icc[20..24].copy_from_slice(b"XYZ ");
+    icc
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn minimal_icc_profile_matches_encoder_fixture() {
+        let mut expected = vec![0u8; 128];
+        expected[0..4].copy_from_slice(&128u32.to_be_bytes()); // 128 bytes
+        expected[4..8].copy_from_slice(b"ADBE");
+        expected[8] = 2;
+        expected[12..16].copy_from_slice(b"mntr");
+        expected[16..20].copy_from_slice(b"RGB ");
+        expected[20..24].copy_from_slice(b"XYZ ");
+
+        assert_eq!(minimal_icc_profile(), expected);
+    }
+}


### PR DESCRIPTION
## 問題
- [Issue #685](https://github.com/albert-einshutoin/lazy-image/issues/685)
  - テスト内の重複フィクスチャ（最小 ICC プロファイル生成とテスト画像生成）が複数箇所にコピペされており、将来のドリフトが発生しやすい。

## 実装（コーディングは指定スキル担当）
- 実装は `opencode-rescue` (MiniMaxM3) と `gemini-rescue` (gemini-3.1-pro-preview) が担当。
- 修正内容
  - 新規: `src/engine/test_support.rs`
    - `create_test_image`
    - `create_test_image_rgba`
    - `minimal_icc_profile`
    - `minimal_icc_profile_matches_encoder_fixture` 自己検証テスト
  - 追加: `src/engine.rs` に `#[cfg(test)] pub(crate) mod test_support;`
  - 置換: `src/engine/encoder.rs`, `src/engine/resize.rs`, `src/engine/api/tests.rs`, `src/engine/pipeline/tests.rs`, `src/engine/io/test_helpers.rs` の重複ヘルパーを共通化。

## 変更の振る舞い
- 本番コードへの影響なし。
- テストユーティリティの重複排除により、ICC ヘルパーとテスト画像生成の一貫性を向上。

## 実施した検証
- `cargo fmt`
- `cargo clippy --no-default-features -- -D warnings`
- `cargo test --no-default-features`
- `npm pack --dry-run`
- `npm run build` は `napi` 未インストールで失敗
- `npm test` はネイティブバイナリ未インストール（`@alberteinshoin/lazy-image-darwin-*`, `sharp`）で失敗

## Codex 5.5 xhigh review
- Correctness: 既存テストを流用した同等性保証 + 新規自己検証で、ICC フィクスチャの内容一致を確認しつつ重複排除。
- Test adequacy: `cargo test --no-default-features` で `src` の既存テスト件数を維持し、回帰なし。
- Docs: 変更はテストユーティリティに限定されるため docs の追加/更新不要。
- Regressions/Security/API drift: 本体コード未変更で回帰・API ドリフトリスクは低い。
- OSS value: テスト保守性と重複解消の価値は高く、今後のテスト変更の一貫性を高める。

## 残タスク/フォローアップ
- `npm run build`, `npm test` はこの環境では前提ツール不足で未完。CI で再実行を推奨。

Fixes #685
