### PR TITLE
test(lazy-image): add target-bytes native contract tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "test": "npm run test:js && npm run test:rust && npm run test:wasm:package",
     "test:js": "npm run test:js:specs && npm run test:js:type-safety && npm run test:pack-contract && npm run test:pack-metadata && npm run test:release-policy && npm run test:types && npm run test:examples",
     "test:js:specs": "node test/integration/run.js",
-    "test:js:type-safety": "node test/type-safety/runtime-type-safety-exit.test.js && node test/type-safety/runtime-type-safety.test.js",
+    "test:js:type-safety": "node test/type-safety/runtime-type-safety-exit.test.js && node test/type-safety/runtime-type-safety.test.js && node test/unit/target-bytes-search.test.js",
     "test:pack-contract": "node scripts/verify-pack.js",
     "test:pack-metadata": "node test/integration/package-metadata.test.js",
     "test:release-policy": "node test/unit/release-policy.test.js",

--- a/test/unit/target-bytes-search.test.js
+++ b/test/unit/target-bytes-search.test.js
@@ -1,0 +1,95 @@
+const assert = require('node:assert/strict');
+
+const { runTargetBytesSearch } = require('../../lib/helpers');
+
+function test(name, fn) {
+  fn()
+    .then(() => console.log(`ok - ${name}`))
+    .catch((error) => {
+      console.error(`not ok - ${name}`);
+      throw error;
+    });
+}
+
+test('runTargetBytesSearch uses toBufferTargetBytesNative and returns normalized fields', async () => {
+  let calledArgs;
+  const expected = {
+    data: Buffer.from('ok'),
+    quality: 72,
+    bytesOut: 120,
+    targetBytes: 2000,
+    budgetMet: true,
+    metrics: { totalMs: 1.5 },
+  };
+
+  const engine = {
+    toBufferTargetBytesNative: async (format, targetBytes, minQuality, maxQuality, fastMode, strict) => {
+      calledArgs = { format, targetBytes, minQuality, maxQuality, fastMode, strict };
+      return expected;
+    },
+  };
+
+  const result = await runTargetBytesSearch(engine, 'jPeG', {
+    targetBytes: 2000,
+    minQuality: 40,
+    maxQuality: 90,
+    fastMode: true,
+    qualityFloorPolicy: 'strict',
+  });
+
+  assert.deepStrictEqual(result, expected);
+  assert.deepStrictEqual(calledArgs, {
+    format: 'jpeg',
+    targetBytes: 2000,
+    minQuality: 40,
+    maxQuality: 90,
+    fastMode: true,
+    strict: true,
+  });
+});
+
+test('runTargetBytesSearch accepts jpg and defaults strict policy to false', async () => {
+  let calledArgs;
+  const expected = {
+    data: Buffer.from('ok'),
+    quality: 70,
+    bytesOut: 110,
+    budgetMet: false,
+    targetBytes: 1500,
+    metrics: null,
+  };
+
+  const engine = {
+    toBufferTargetBytesNative: async (format, targetBytes, minQuality, maxQuality, fastMode, strict) => {
+      calledArgs = { format, targetBytes, minQuality, maxQuality, fastMode, strict };
+      return expected;
+    },
+  };
+
+  const result = await runTargetBytesSearch(engine, 'jpg', {
+    targetBytes: 1500,
+    minQuality: 30,
+    maxQuality: 95,
+  });
+
+  assert.deepStrictEqual(result, expected);
+  assert.deepStrictEqual(calledArgs, {
+    format: 'jpeg',
+    targetBytes: 1500,
+    minQuality: 30,
+    maxQuality: 95,
+    fastMode: false,
+    strict: false,
+  });
+});
+
+test('runTargetBytesSearch throws explicit guidance when native target-bytes method is missing', async () => {
+  await assert.rejects(
+    runTargetBytesSearch({}, 'jpeg', {
+      targetBytes: 2000,
+      minQuality: 40,
+      maxQuality: 90,
+    }),
+    /Reinstall @alberteinshutoin\/lazy-image/, 'should instruct reinstall when native method is absent',
+  );
+});


### PR DESCRIPTION
- Issue: https://github.com/albert-einshutoin/lazy-image/issues/693

## 何の問題を解決したか
Issue #693では、`runTargetBytesSearch` の JS 側フォールバック仕様について、「ネイティブ側未提供時のみ走る経路」の実体確認と、JS 実装維持の妥当性検証を要求していました。現状コードでは既にネイティブ必須化が行われていたため、実装ロジック自体を削減せず、代わりに契約を固定する回帰テストを追加して到達性とエラーメッセージ仕様を保証します。

## 実装担当
- 実装スキル: 本作業環境では `opencode-rescue` / `gemini-rescue` の実行検知ができなかったため、Codex 側で直接実装（TDD/最小差分）しました。

## 変更内容
### 変更したコード
- `package.json`
  - `test:js:type-safety` に `test/unit/target-bytes-search.test.js` を追加
- `test/unit/target-bytes-search.test.js`（新規）
  - `runTargetBytesSearch` が `toBufferTargetBytesNative` を呼ぶ引数の正規化（`jpg`/`jPeG` → `jpeg`）を検証
  - `qualityFloorPolicy` の既定値（`strict`）時の挙動を検証
  - `toBufferTargetBytesNative` 非存在時に再インストールを促す明示エラーを検証

## 振る舞いの変化
- 実行時機能の追加/変更はありません。
- `runTargetBytesSearch` がネイティブバインディング前提である契約をテストレベルで固定し、将来のリグレッション（フォールバック経路の誤再導入）を防ぎます。

## 検証コマンド
- `node test/unit/release-policy.test.js && node test/unit/target-bytes-search.test.js`
  - pass
- `npm run test:rust`
  - pass
- `npm run test:pack-contract`
  - pass
- `npm run test:js:specs`
  - fail（ローカル環境で optional な Rust バイナリ依存で `Cannot find native binding` が再現）
- `npm run test:js:type-safety`
  - fail（既存テスト `runtime-type-safety.test.js` が環境要件でネイティブバインディング欠如により失敗）
- `npm run test:types`
  - fail（`Cannot find type definition file for 'node'`）

## Codex 5.5 xhigh レビュー結果
- 正しさ: 高（既存実装の不変性を保ちつつ、重要コア契約を直接検証）
- テスト十分性: 中〜高（新規に3ケースを追加。型安全パイプライン依存失敗を除けば、ターゲット機能の主要経路を網羅）
- Docs: コード変更中心のため docs 更新は不要
- 回帰リスク: 低（挙動そのものを変更しない）
- セキュリティ: 影響なし
- API/契約ドリフト: 低（`runTargetBytesSearch` の引数・戻り値形式とエラー文言を固定）
- 保守性: 高（将来のデッドコード再導入を検出しやすくなる）
- OSS価値: 中〜高（契約テスト追加で実装意図の明文化に寄与）

## 残リスク / 追加フォロー
- `npm run test:js:type-safety` が常時実行されるCIでは、ネイティブバインディングを含む環境での再実行が必要
- 開発環境依存で発生した失敗は、今後の実行結果比較を前提に運用ドキュメントに追記検討
