### PR TITLE
chore: switch workflow to GitHub Flow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ version: 2
 updates:
   - package-ecosystem: "cargo"
     directory: "/"
-    target-branch: "develop"
+    target-branch: "main"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -19,7 +19,7 @@ updates:
 
   - package-ecosystem: "npm"
     directory: "/"
-    target-branch: "develop"
+    target-branch: "main"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -35,7 +35,7 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "develop"
+    target-branch: "main"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,17 +73,17 @@ npm run test:stress:napi
 
 ### Branch Strategy (GitHub Flow)
 
-1. **develop branch**: Base branch for development
-2. **feature/\*** branches: For new feature development
-3. **fix/\*** branches: For bug fixes
-4. **main branch**: For releases (do not push directly)
+1. **main branch**: Protected default branch and release source (do not push directly)
+2. **feature/\*** branches: Short-lived branches for new feature work
+3. **fix/\*** branches: Short-lived branches for bug fixes
+4. **docs/\*** and **chore/\*** branches: Short-lived branches for documentation and maintenance
 
 ### PR Creation Workflow
 
 ```bash
-# 1. Get the latest from develop branch
-git checkout develop
-git pull origin develop
+# 1. Get the latest from main
+git checkout main
+git pull --ff-only origin main
 
 # 2. Create a working branch (include issue number)
 git checkout -b feature/123-add-new-feature
@@ -98,7 +98,7 @@ git commit -m "feat: add new feature (#123)"
 
 # 6. Push and create PR
 git push origin feature/123-add-new-feature
-gh pr create --base develop --title "feat: add new feature" --body "Closes #123"
+gh pr create --base main --title "feat: add new feature" --body "Closes #123"
 ```
 
 ### PR Checklist
@@ -315,17 +315,17 @@ npm run test:types
 
 ### ブランチ戦略（GitHub Flow）
 
-1. **develop ブランチ**: 開発用のベースブランチ
-2. **feature/\*** ブランチ: 新機能開発用
-3. **fix/\*** ブランチ: バグ修正用
-4. **main ブランチ**: リリース用（直接pushしない）
+1. **main ブランチ**: 保護されたデフォルトブランチ兼リリース元（直接pushしない）
+2. **feature/\*** ブランチ: 新機能用の短命ブランチ
+3. **fix/\*** ブランチ: バグ修正用の短命ブランチ
+4. **docs/\*** / **chore/\*** ブランチ: ドキュメント・保守用の短命ブランチ
 
 ### PR作成の流れ
 
 ```bash
-# 1. developブランチから最新を取得
-git checkout develop
-git pull origin develop
+# 1. mainブランチから最新を取得
+git checkout main
+git pull --ff-only origin main
 
 # 2. 作業ブランチを作成（Issue番号を含める）
 git checkout -b feature/123-add-new-feature
@@ -340,7 +340,7 @@ git commit -m "feat: add new feature (#123)"
 
 # 6. プッシュしてPRを作成
 git push origin feature/123-add-new-feature
-gh pr create --base develop --title "feat: add new feature" --body "Closes #123"
+gh pr create --base main --title "feat: add new feature" --body "Closes #123"
 ```
 
 ### PRのチェックリスト

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,6 +1,6 @@
 # Release Guide
 
-This document describes how to cut a release of `@alberteinshutoin/lazy-image` following git flow.
+This document describes how to cut a release of `@alberteinshutoin/lazy-image` with GitHub Flow.
 
 Related docs:
 - [SEMVER_POLICY.md](SEMVER_POLICY.md) — versioning rules and breaking change criteria
@@ -11,24 +11,22 @@ Related docs:
 
 ## Overview
 
-lazy-image follows the **git flow** branching model:
+lazy-image uses **GitHub Flow**:
 
-```
-main         ──●─────────────────●──────────  (production, tagged releases)
-                ╲               ╱
-release/x.y.z   ●─●───────────●──            (release prep)
-                ╲             ╲
-develop      ────●─●─●─●─●─●─●──●──────────  (integration)
-                  ╲ ╲ ╲ ╲ ╲ ╲
-feature/...      ●─●─●─●─●─●                  (feature work)
+```text
+main            ──●──────●──────●──────●──────  (protected default branch, tagged releases)
+                    ╲      ╲      ╲
+feature/fix/...      ●──●   ●──●   ●──●          (short-lived PR branches)
+release/x.y.z                ●──●                (short-lived release prep branch)
 ```
 
-Key rules (from [CLAUDE.md](../CLAUDE.md)):
-- Feature branches are cut from `develop`
-- Release branches are cut from `develop`
-- **PRs only** — never merge directly via CLI `git merge` into `main`/`develop`
-- Use GitHub UI or `gh pr merge` after review
-- All CI checks must pass before merge
+Key rules:
+- `main` is the only long-lived branch.
+- Feature, fix, docs, chore, hotfix, and release-prep branches are cut from latest `main`.
+- All changes land through PRs back to `main`.
+- Do not merge directly from a local CLI into `main`; use GitHub UI or `gh pr merge` after review.
+- All required CI checks must pass before merge.
+- Release tags are created from the merged `main` commit.
 
 ---
 
@@ -36,17 +34,17 @@ Key rules (from [CLAUDE.md](../CLAUDE.md)):
 
 Before starting a release:
 
-1. **`develop` is green**: all CI workflows pass on the latest commit
-2. **No open release branch**: only one release in flight at a time
-3. **`NPM_TOKEN` secret is valid**: check expiry in GitHub repo settings (Settings → Secrets and variables → Actions)
-4. **Local tooling**: `gh`, `cargo`, `npm`, `git` installed and authenticated
-5. **Decide the next version**: follow [SEMVER_POLICY.md](SEMVER_POLICY.md)
+1. **`main` is green**: all required CI workflows pass on the latest commit.
+2. **No open release PR**: only one release in flight at a time.
+3. **`NPM_TOKEN` secret is valid**: check expiry in GitHub repo settings (Settings -> Secrets and variables -> Actions).
+4. **Local tooling**: `gh`, `cargo`, `npm`, `git` installed and authenticated.
+5. **Decide the next version**: follow [SEMVER_POLICY.md](SEMVER_POLICY.md).
    - MAJOR (`x.0.0`): breaking changes
    - MINOR (`0.x.0`): backward-compatible additions
    - PATCH (`0.0.x`): bug fixes only
 6. **Check breaking-change markers**: if the target changelog section contains
    `BREAKING` or `Removed`, the release version must be a major boundary
-   (`x.0.0`). For current 0.x development, that means `1.0.0`.
+   (`x.0.0`). For current 0.x work, that means `1.0.0`.
 
 ---
 
@@ -55,11 +53,11 @@ Before starting a release:
 ### Phase 1 — Prepare the release branch
 
 ```bash
-# 1. Start from latest develop
-git checkout develop
-git pull origin develop
+# 1. Start from latest main
+git checkout main
+git pull --ff-only origin main
 
-# 2. Create release branch (replace X.Y.Z with the target version)
+# 2. Create a short-lived release branch
 git checkout -b release/X.Y.Z
 ```
 
@@ -79,31 +77,32 @@ The files below need to move from the current version to the new one. Skipping a
 | `index.js` | Generated native loader version checks | `npm run build` |
 | `CHANGELOG.md` | Add new `[X.Y.Z]` section under `[Unreleased]` | Manual edit |
 
-> ⚠️ **`Cargo.lock` is required.** The Supply Chain CI job runs `cargo metadata --locked` and will fail if `Cargo.lock` does not match `Cargo.toml`. This is the most common release-time failure.
+> **`Cargo.lock` is required.** The Supply Chain CI job runs `cargo metadata --locked` and will fail if `Cargo.lock` does not match `Cargo.toml`.
 >
-> ⚠️ **`package-lock.json` is required, even though it may pass CI on the release PR itself.** The release PR can pass `npm ci` even with an out-of-sync lock file because the new platform packages don't exist on npm yet — npm silently skips the optional-deps check. Once the publish job runs on the `vX.Y.Z` tag, every subsequent PR's `npm ci` will fail with `Invalid: lock file's @alberteinshutoin/lazy-image-*@<prev> does not satisfy @alberteinshutoin/lazy-image-*@<new>`. See [Pitfall 6](#6-package-lockjson-not-bumped--every-post-release-pr-breaks) below.
+> **`package-lock.json` is required.** The release PR can pass before the new platform packages exist on npm, but later `npm ci` runs will fail once those packages are published if the lock file still points at the previous version.
 
 Optional helper:
+
 ```bash
-npm run version   # verifies package.json ↔ Cargo.toml are in sync (does NOT bump)
-npm run release:check   # rejects non-major releases that contain BREAKING/Removed entries
+npm run version
+npm run release:check
 ```
 
 #### CHANGELOG entry
 
 Follow [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Section order:
-`### Added` → `### Changed` → `### Deprecated` → `### Removed` → `### Fixed` → `### Security`
+`### Added` -> `### Changed` -> `### Deprecated` -> `### Removed` -> `### Fixed` -> `### Security`
 
 Use `git log <prev-tag>..HEAD --oneline` to enumerate merged PRs.
 
 If a release section contains `### Changed (BREAKING)`, `BREAKING` bullets, or
 `### Removed`, run `npm run release:check` before committing the release branch.
 The command uses the version in `package.json` by default; it also accepts an
-explicit version for planning checks, for example:
+explicit version for planning checks:
 
 ```bash
 node scripts/check-release-policy.js 1.0.0
-node scripts/check-release-policy.js 0.16.0  # expected to fail if breaking entries remain
+node scripts/check-release-policy.js 0.16.0
 ```
 
 #### Commit and push
@@ -116,9 +115,7 @@ git push -u origin release/X.Y.Z
 
 ---
 
-### Phase 2 — Merge to `main` and tag
-
-#### Open the PR
+### Phase 2 — Open the PR to `main`
 
 ```bash
 gh pr create \
@@ -138,14 +135,13 @@ gh pr create \
 - [ ] All CI jobs green
 - [ ] Quality gate passes
 - [ ] Perf-safety gate passes
+- [ ] `npm run release:check` passes
 EOF
 )"
 ```
 
-#### Wait for CI
-
-The following workflows must all succeed before merging:
-- `CI` (build × 6 platforms, tests × 3 Node versions, quality, perf-safety, supply-chain, coverage, leak-detection)
+Required checks before merging:
+- `CI` (multi-platform build, tests, quality, perf-safety, supply-chain, coverage, leak detection)
 - `Fuzz`
 - `Security Audit`
 
@@ -153,56 +149,35 @@ The following workflows must all succeed before merging:
 gh pr checks <PR_NUMBER> --watch
 ```
 
-#### Merge and tag
+---
+
+### Phase 3 — Merge, tag, and publish
 
 After CI is green and review is approved:
 
 ```bash
-# Merge (preserves merge commit — required for git flow history)
+# Merge through GitHub so branch protection and review history are preserved.
 gh pr merge <PR_NUMBER> --merge --subject "chore(release): X.Y.Z (#<PR_NUMBER>)"
 
-# Tag the merge commit on main
+# Tag the merged main commit.
 git checkout main
-git pull origin main
+git pull --ff-only origin main
 git tag -a vX.Y.Z -m "Release vX.Y.Z"
 git push origin vX.Y.Z
 ```
 
-> ⚠️ **Do not use `git merge` directly on `main` from your local CLI.** This bypasses required PR checks and review history.
-
-Pushing the `vX.Y.Z` tag triggers the `Publish to npm` job in [CI.yml](../.github/workflows/CI.yml). The job:
-1. Downloads the prebuilt `.node` artifacts for all 6 platforms
-2. Publishes each platform package (`@alberteinshutoin/lazy-image-{platform}`)
-3. Publishes the Wasm workspace package (`@alberteinshutoin/lazy-image-wasm`)
-4. Publishes the main package
-5. Creates a GitHub Release with auto-generated notes
-
----
-
-### Phase 3 — Sync back to `develop`
-
-The release branch contains version bumps and CHANGELOG entries that must flow back to `develop`. Skipping this leaves `develop` perpetually behind.
-
-```bash
-gh pr create \
-  --base develop \
-  --head release/X.Y.Z \
-  --title "chore(develop): sync X.Y.Z from release" \
-  --body "Sync version bump and CHANGELOG from release/X.Y.Z back to develop."
-```
-
-After CI passes:
-```bash
-gh pr merge <SYNC_PR_NUMBER> --merge --subject "chore(develop): sync X.Y.Z from release (#<SYNC_PR_NUMBER>)"
-```
+Pushing the `vX.Y.Z` tag triggers the publish job in [CI.yml](../.github/workflows/CI.yml). The job:
+1. Downloads the prebuilt `.node` artifacts for all supported platforms.
+2. Publishes each platform package (`@alberteinshutoin/lazy-image-{platform}`).
+3. Publishes the Wasm workspace package (`@alberteinshutoin/lazy-image-wasm`).
+4. Publishes the main package.
+5. Creates a GitHub Release with generated notes.
 
 ---
 
 ### Phase 4 — Cleanup
 
 ```bash
-git checkout develop
-git pull origin develop
 git branch -d release/X.Y.Z
 git push origin --delete release/X.Y.Z
 ```
@@ -216,22 +191,21 @@ Confirm the release landed everywhere:
 ```bash
 # 1. npm main package
 npm view @alberteinshutoin/lazy-image version
-# → should print X.Y.Z
 
-# 2. All platform packages (must match main version)
+# 2. All platform packages must match the main version
 for pkg in darwin-arm64 darwin-x64 linux-x64-gnu linux-x64-musl linux-arm64-gnu win32-x64-msvc; do
   echo "$pkg: $(npm view @alberteinshutoin/lazy-image-$pkg version)"
 done
 
 # 3. Wasm package
 npm view @alberteinshutoin/lazy-image-wasm version
-# → should print X.Y.Z
 
 # 4. GitHub Release exists
 gh release view vX.Y.Z --json name,tagName,isDraft,isPrerelease,url
 ```
 
 Smoke test the published packages:
+
 ```bash
 mkdir /tmp/lazy-image-smoke && cd /tmp/lazy-image-smoke
 npm init -y
@@ -246,12 +220,11 @@ node --input-type=module -e "import { VERSION } from '@alberteinshutoin/lazy-ima
 
 ## Common Pitfalls
 
-Issues observed in past releases. Check these first when something breaks.
-
-### 1. `Cargo.lock` not updated → Supply Chain fails
+### 1. `Cargo.lock` not updated -> Supply Chain fails
 
 **Symptom:** `Supply Chain` job fails with:
-```
+
+```text
 error: the lock file /home/runner/.../Cargo.lock needs to be updated but --locked was passed
 ```
 
@@ -259,75 +232,63 @@ error: the lock file /home/runner/.../Cargo.lock needs to be updated but --locke
 
 **Prevention:** Always stage `Cargo.lock` together with `Cargo.toml` in the release prep commit.
 
-### 2. `NPM_TOKEN` expired → publish job fails with 404
+### 2. `NPM_TOKEN` expired -> publish job fails with 404
 
 **Symptom:** `Publish to npm` job fails with:
-```
+
+```text
 npm error 404 Not Found - PUT https://registry.npmjs.org/@alberteinshutoin%2flazy-image-...
 ```
 
-The 404 is misleading — it's actually an authentication failure for existing packages.
+The 404 is misleading; it is usually an authentication failure for existing packages.
 
 **Fix:**
-1. Generate a new automation token at [npmjs.com/settings/.../tokens](https://www.npmjs.com/settings/~/tokens)
-2. Update the `NPM_TOKEN` secret in GitHub (Settings → Secrets and variables → Actions)
-3. Re-run the failed `Publish to npm` job: `gh run rerun <RUN_ID> --failed`
+1. Generate a new automation token at [npmjs.com/settings/.../tokens](https://www.npmjs.com/settings/~/tokens).
+2. Update the `NPM_TOKEN` secret in GitHub (Settings -> Secrets and variables -> Actions).
+3. Re-run the failed publish job: `gh run rerun <RUN_ID> --failed`.
 
 **Prevention:** Set a calendar reminder before token expiry.
 
-### 3. `optionalDependencies` versions not bumped → main package install fails
+### 3. `optionalDependencies` versions not bumped -> install fails
 
 **Symptom:** Users installing the new version see missing optional dependency warnings or runtime errors loading the native binding.
 
 **Fix:** Update all 6 entries under `optionalDependencies` in `package.json` to match the new version.
 
 **Prevention:** Search for the old version string before committing:
-```bash
-grep -n "0\.X\.Y" package.json
-```
-
-### 4. Direct CLI merge into `main` → bypasses CI requirements
-
-**Symptom:** A `git merge` into `main` from a local checkout pushes without going through PR review.
-
-**Fix:** Revert with a PR, then re-do via `gh pr merge`.
-
-**Prevention:** Enable branch protection on `main` requiring PR review and status checks. Never run `git push origin main` after a local merge.
-
-### 5. Skipping the sync-back PR → `develop` drifts from `main`
-
-**Symptom:** Subsequent releases re-introduce the previous version because `develop` was never updated.
-
-**Fix:** Always complete Phase 3 (sync back PR) immediately after Phase 2.
-
-**Prevention:** Treat the release as incomplete until Phase 4 cleanup has run.
-
-### 6. `package-lock.json` not bumped → every post-release PR breaks
-
-**Symptom:** The release PR and sync-back PR both pass CI, but every PR opened after the publish job runs starts failing in the Build / Test / Coverage / Package Contract / ASan jobs with:
-
-```
-npm error code EUSAGE
-npm error `npm ci` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync.
-npm error Invalid: lock file's @alberteinshutoin/lazy-image-darwin-arm64@<old> does not satisfy @alberteinshutoin/lazy-image-darwin-arm64@<new>
-```
-
-**Why the release PR doesn't catch it:** at the time the release PR runs, `@alberteinshutoin/lazy-image-*@<new>` does not exist on npm yet. npm treats the missing optional dependency as "skip silently" instead of "lock file out of sync", so `npm ci` succeeds. After the `vX.Y.Z` tag triggers the publish job, npm can see the new platform packages exist — and every subsequent `npm ci` enforces the lock file strictly.
-
-**Fix:** Open a follow-up `chore: sync package-lock.json to X.Y.Z` PR with:
 
 ```bash
-git checkout develop
-git pull origin develop
+grep -n "0\\.X\\.Y" package.json
+```
+
+### 4. Direct CLI merge into `main` -> bypasses CI requirements
+
+**Symptom:** A local merge is pushed to `main` without PR review and required status checks.
+
+**Fix:** Revert with a PR, then re-do the change via PR.
+
+**Prevention:** Keep branch protection enabled on `main`. Never run `git push origin main` after a local merge.
+
+### 5. `package-lock.json` not bumped -> post-release PRs break
+
+**Symptom:** PRs opened after publish start failing in `npm ci` with lock-file mismatch errors for `@alberteinshutoin/lazy-image-*`.
+
+**Why the release PR may miss it:** before the tag publishes the new platform packages, npm can treat missing optional dependencies as skipped. After publish, npm sees the new package versions and enforces the lock file strictly.
+
+**Fix:** Open a follow-up PR to `main`:
+
+```bash
+git checkout main
+git pull --ff-only origin main
 git checkout -b chore/sync-package-lock-X.Y.Z
 npm install --package-lock-only --ignore-scripts
 git add package-lock.json
 git commit -m "chore: sync package-lock.json to X.Y.Z"
 git push -u origin chore/sync-package-lock-X.Y.Z
-gh pr create --base develop --title "chore: sync package-lock.json to X.Y.Z"
+gh pr create --base main --title "chore: sync package-lock.json to X.Y.Z"
 ```
 
-**Prevention:** Update `package-lock.json` in Phase 1, alongside `package.json` / `packages/lazy-image-wasm/package.json` / `packages/lazy-image-wasm/shared.js` / `Cargo.toml` / `Cargo.lock` / `index.js` / `CHANGELOG.md`. Run `npm install --package-lock-only --ignore-scripts` after bumping `package.json`'s `optionalDependencies`.
+**Prevention:** Update `package-lock.json` in Phase 1 with the rest of the version bump files.
 
 ---
 
@@ -336,18 +297,15 @@ gh pr create --base develop --title "chore: sync package-lock.json to X.Y.Z"
 For urgent fixes that cannot wait for the next regular release:
 
 ```bash
-# Cut hotfix from main (not develop)
 git checkout main
-git pull origin main
+git pull --ff-only origin main
 git checkout -b hotfix/X.Y.(Z+1)
 
-# Fix, test, bump PATCH version (apply Phase 1 file changes)
-# Open PRs to BOTH main and develop
+# Fix, test, bump PATCH version if needed, then open a PR to main.
 gh pr create --base main --head hotfix/X.Y.Z+1 --title "fix: <issue>"
-gh pr create --base develop --head hotfix/X.Y.Z+1 --title "fix: <issue> (sync)"
 ```
 
-After both PRs merge, tag and push as in Phase 2. Delete the hotfix branch.
+After the PR merges, tag and push as in Phase 3. Delete the hotfix branch.
 
 ---
 
@@ -355,14 +313,14 @@ After both PRs merge, tag and push as in Phase 2. Delete the hotfix branch.
 
 For quick reference, the canonical set of files updated for a routine version bump:
 
-```
-package.json        # version + optionalDependencies (×6)
+```text
+package.json        # version + optionalDependencies (x6)
 packages/lazy-image-wasm/package.json  # workspace package version
 packages/lazy-image-wasm/shared.js     # exported VERSION constant
-package-lock.json   # root version + workspace + 6 lazy-image-* optional entries (via `npm install --package-lock-only --ignore-scripts`)
+package-lock.json   # root version + workspace + 6 lazy-image-* optional entries
 Cargo.toml          # [package].version
-Cargo.lock          # lazy-image entry (via `cargo update -p lazy-image`)
-index.js            # generated native loader version checks (via `npm run build`)
+Cargo.lock          # lazy-image entry
+index.js            # generated native loader version checks
 CHANGELOG.md        # new [X.Y.Z] section
 ```
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,11 +2,11 @@
 
 > **Vision:** To be the most efficient, secure, and portable web image optimization engine for the cloud age.
 
-This document reflects the current state of `develop` and focuses on the work that still meaningfully remains.
+This document reflects the current state of `main` and focuses on the work that still meaningfully remains.
 
 ## Current State
 
-The following foundations are already in place on `develop`:
+The following foundations are already in place on `main`:
 
 - **Lazy, non-destructive pipeline**: deferred decode, `clone()`, file-based happy path
 - **V8-heap bypass for file inputs**: `fromPath()` and `processBatch()` keep source bytes out of the Node.js heap (read-into-memory ≤ 256 MB, mmap with advisory locks > 256 MB)
@@ -76,11 +76,11 @@ To maintain focus and stability, the following features are explicitly **out of 
 
 > **ビジョン:** クラウド時代における、最も効率的で、安全で、ポータブルなWeb画像最適化エンジンとなること。
 
-このドキュメントは `develop` の現状を反映し、今後本当に残っている課題に絞って整理したものです。
+このドキュメントは `main` の現状を反映し、今後本当に残っている課題に絞って整理したものです。
 
 ## 現在の状態
 
-`develop` にはすでに以下の基盤があります。
+`main` にはすでに以下の基盤があります。
 
 - **lazy / 非破壊パイプライン**: deferred decode、`clone()`、file-to-file の主導線
 - **V8 ヒープを経由しないファイル入力**: `fromPath()` と `processBatch()` は入力バイトを Node.js ヒープに載せない（256 MB 以下は Rust 所有バッファに読み込み、256 MB 超は advisory lock 付き mmap）

--- a/docs/SHARP_PERF_INVESTIGATION_2026-02-17.md
+++ b/docs/SHARP_PERF_INVESTIGATION_2026-02-17.md
@@ -1,7 +1,7 @@
 # sharp 比較パフォーマンス徹底調査 (2026-02-17)
 
-## 1. 実施体制 (gitflow + worktree)
-- Base: `develop`
+## 1. 実施体制 (GitHub Flow + worktree)
+- Base: `main`
 - Investigation branch: `codex/feature-sharp-perf-investigation`
 - Worktree: `/Users/shutoide/Developer/perf-sharp-investigate`
 

--- a/docs/VERSIONING_PLAN.md
+++ b/docs/VERSIONING_PLAN.md
@@ -1,9 +1,9 @@
 # 📋 Versioning Plan & Priorities
 
-> **Current package version**: v0.15.x
-> **Working baseline**: `develop`
+> **Current package version**: v0.16.x
+> **Working baseline**: `main`
 
-このドキュメントは、古い issue 番号ベースの固定計画ではなく、`develop` の現状に合った優先順位を簡潔に示します。
+このドキュメントは、古い issue 番号ベースの固定計画ではなく、`main` の現状に合った優先順位を簡潔に示します。
 
 ## 現在の優先順位
 


### PR DESCRIPTION
## Summary
- point contributor and release docs at GitHub Flow with main as the only long-lived branch
- remove release sync-back guidance and main/develop PR instructions
- target Dependabot updates at main

## Verification
- npm run build
- npm test
- npm audit --audit-level=high
- rg --hidden --glob '!.git' --glob '!.claude' --glob '!target' --glob '!node_modules' -n '\bdevelop\b|gitflow|git flow|Git flow|git-flow' .

## Follow-up
Remote develop is not deleted in this PR because origin/develop still has commits not present on origin/main and open Dependabot PRs still target it.