### PR TITLE
fix(api): isolate self-contained preset outputs

### DIFF
--- a/src/engine/api/output_ops.rs
+++ b/src/engine/api/output_ops.rs
@@ -43,10 +43,17 @@ impl ImageEngine {
     ///
     /// `last_error` is always initialised to `None`; task implementations set
     /// it in their `compute` / `reject` path.
-    fn build_task_context(&mut self, format: OutputFormat) -> TaskContext {
+    fn build_task_context(&self, format: OutputFormat) -> TaskContext {
+        self.build_task_context_with_ops(format, self.ops.clone())
+    }
+
+    fn build_task_context_with_ops(
+        &self,
+        format: OutputFormat,
+        ops: Vec<Operation>,
+    ) -> TaskContext {
         let source = self.source.clone();
         let decoded = self.decoded.clone();
-        let ops = self.ops.clone();
         let mut policy = self.metadata_policy;
         policy.apply_firewall(self.firewall.reject_metadata);
         let auto_orient = self.auto_orient;
@@ -76,6 +83,25 @@ impl ImageEngine {
             #[cfg(feature = "napi")]
             last_error: None,
         }
+    }
+
+    fn resolve_preset(env: &Env, preset_name: &str) -> Result<PresetConfig> {
+        PresetConfig::get(preset_name)
+            .ok_or_else(|| napi_err(env, LazyImageError::invalid_preset(preset_name.to_string())))
+    }
+
+    /// Build output-only preset state without mutating the reusable engine.
+    ///
+    /// The resize belongs to this task snapshot, not `self.ops`: retaining it
+    /// on the engine would make later outputs depend on call order.
+    fn build_preset_task_context(&self, preset: &PresetConfig) -> TaskContext {
+        let mut ops = self.ops.clone();
+        ops.push(Operation::Resize {
+            width: preset.width,
+            height: preset.height,
+            fit: ResizeFit::Inside,
+        });
+        self.build_task_context_with_ops(preset.format.clone(), ops)
     }
 }
 
@@ -115,46 +141,17 @@ impl ImageEngine {
         }))
     }
 
-    /// Convenience: encode using the last applied preset by name.
-    /// Equivalent to calling `preset(name)` then `toBuffer(preset.format, preset.quality)`.
+    /// Encode with a named preset without changing the engine's queued operations.
     #[napi(js_name = "toBufferWithPreset", ts_return_type = "Promise<Buffer>")]
     pub fn to_buffer_with_preset(
         &mut self,
         env: Env,
         preset_name: String,
     ) -> Result<AsyncTask<EncodeTask>> {
-        let preset = match PresetConfig::get(&preset_name) {
-            Some(config) => config,
-            None => {
-                let lazy_err = LazyImageError::invalid_preset(preset_name.clone());
-                return Err(crate::error::napi_error_with_code(&env, lazy_err)?);
-            }
-        };
-
-        // Apply resize ops in-place, mirroring preset()
-        self.ops.push(Operation::Resize {
-            width: preset.width,
-            height: preset.height,
-            fit: ResizeFit::Inside,
-        });
-
-        self.last_preset = Some(preset.clone());
-
-        let (format_str, quality, fast_mode) = match &preset.format {
-            OutputFormat::Jpeg { quality, fast_mode } => {
-                ("jpeg", Some(quality.get()), Some(*fast_mode))
-            }
-            OutputFormat::Png => ("png", None, None),
-            OutputFormat::WebP { quality } => ("webp", Some(quality.get()), None),
-            OutputFormat::Avif { quality } => ("avif", Some(quality.get()), None),
-        };
-
-        self.to_buffer(
-            env,
-            format_str.to_string(),
-            quality.map(|q| q as f64),
-            fast_mode,
-        )
+        let preset = Self::resolve_preset(&env, &preset_name)?;
+        Ok(AsyncTask::new(EncodeTask {
+            ctx: self.build_preset_task_context(&preset),
+        }))
     }
 
     /// Encode to buffer asynchronously with performance metrics.
@@ -184,8 +181,7 @@ impl ImageEngine {
         }))
     }
 
-    /// Convenience: encode with metrics using a preset name.
-    /// Equivalent to `preset(name)` then `toBufferWithMetrics(preset.format, preset.quality)`.
+    /// Encode with metrics using a named preset without changing the engine's queued operations.
     #[napi(
         js_name = "toBufferWithMetricsPreset",
         ts_return_type = "Promise<OutputWithMetrics>"
@@ -195,37 +191,10 @@ impl ImageEngine {
         env: Env,
         preset_name: String,
     ) -> Result<AsyncTask<EncodeWithMetricsTask>> {
-        let preset = match PresetConfig::get(&preset_name) {
-            Some(config) => config,
-            None => {
-                let lazy_err = LazyImageError::invalid_preset(preset_name.clone());
-                return Err(crate::error::napi_error_with_code(&env, lazy_err)?);
-            }
-        };
-
-        self.ops.push(Operation::Resize {
-            width: preset.width,
-            height: preset.height,
-            fit: ResizeFit::Inside,
-        });
-
-        self.last_preset = Some(preset.clone());
-
-        let (format_str, quality, fast_mode) = match &preset.format {
-            OutputFormat::Jpeg { quality, fast_mode } => {
-                ("jpeg", Some(quality.get()), Some(*fast_mode))
-            }
-            OutputFormat::Png => ("png", None, None),
-            OutputFormat::WebP { quality } => ("webp", Some(quality.get()), None),
-            OutputFormat::Avif { quality } => ("avif", Some(quality.get()), None),
-        };
-
-        self.to_buffer_with_metrics(
-            env,
-            format_str.to_string(),
-            quality.map(|q| q as f64),
-            fast_mode,
-        )
+        let preset = Self::resolve_preset(&env, &preset_name)?;
+        Ok(AsyncTask::new(EncodeWithMetricsTask {
+            ctx: self.build_preset_task_context(&preset),
+        }))
     }
 
     /// Encode to buffer with a byte-budget constraint.
@@ -403,50 +372,24 @@ impl ImageEngine {
     ) -> Result<AsyncTask<crate::engine::tasks::UnifiedEncodeTask>> {
         let want_metrics = options.metrics.unwrap_or(false);
 
-        // Resolve format/quality/fastMode — preset wins when supplied.
-        let (format_str, quality_f64, fast_mode) = if let Some(ref preset_name) = options.preset {
-            let preset = match PresetConfig::get(preset_name) {
-                Some(c) => c,
-                None => {
-                    let lazy_err = LazyImageError::invalid_preset(preset_name.clone());
-                    return Err(crate::error::napi_error_with_code(&env, lazy_err)?);
-                }
-            };
-
-            // Apply the preset's resize ops.
-            self.ops.push(Operation::Resize {
-                width: preset.width,
-                height: preset.height,
-                fit: ResizeFit::Inside,
-            });
-            self.last_preset = Some(preset.clone());
-
-            let (f, q, fm) = match &preset.format {
-                OutputFormat::Jpeg { quality, fast_mode } => (
-                    "jpeg".to_string(),
-                    Some(quality.get() as f64),
-                    Some(*fast_mode),
-                ),
-                OutputFormat::Png => ("png".to_string(), None, None),
-                OutputFormat::WebP { quality } => {
-                    ("webp".to_string(), Some(quality.get() as f64), None)
-                }
-                OutputFormat::Avif { quality } => {
-                    ("avif".to_string(), Some(quality.get() as f64), None)
-                }
-            };
-            (f, q, fm.unwrap_or(false))
+        let ctx = if let Some(ref preset_name) = options.preset {
+            let preset = Self::resolve_preset(&env, preset_name)?;
+            self.build_preset_task_context(&preset)
         } else {
-            let fmt = options.format.unwrap_or_else(|| "jpeg".to_string());
-            (fmt, options.quality, options.fast_mode.unwrap_or(false))
+            let format = options.format.unwrap_or_else(|| "jpeg".to_string());
+            let quality =
+                validation::sanitize_quality(options.quality).map_err(|e| napi_err(&env, e))?;
+            let output_format = OutputFormat::from_str_with_options(
+                &format,
+                quality,
+                options.fast_mode.unwrap_or(false),
+            )
+            .map_err(|e| napi_err(&env, e))?;
+            self.build_task_context(output_format)
         };
 
-        let quality = validation::sanitize_quality(quality_f64).map_err(|e| napi_err(&env, e))?;
-        let output_format = OutputFormat::from_str_with_options(&format_str, quality, fast_mode)
-            .map_err(|e| napi_err(&env, e))?;
-
         Ok(AsyncTask::new(crate::engine::tasks::UnifiedEncodeTask {
-            ctx: self.build_task_context(output_format),
+            ctx,
             want_metrics,
         }))
     }
@@ -465,56 +408,32 @@ impl ImageEngine {
         validation::validate_output_path(&path).map_err(|e| napi_err(&env, e))?;
         let want_metrics = options.metrics.unwrap_or(false);
 
-        let (format_str, quality_f64, fast_mode) = if let Some(ref preset_name) = options.preset {
-            let preset = match PresetConfig::get(preset_name) {
-                Some(c) => c,
-                None => {
-                    let lazy_err = LazyImageError::invalid_preset(preset_name.clone());
-                    return Err(crate::error::napi_error_with_code(&env, lazy_err)?);
-                }
-            };
-
-            self.ops.push(Operation::Resize {
-                width: preset.width,
-                height: preset.height,
-                fit: ResizeFit::Inside,
-            });
-            self.last_preset = Some(preset.clone());
-
-            let (f, q, fm) = match &preset.format {
-                OutputFormat::Jpeg { quality, fast_mode } => (
-                    "jpeg".to_string(),
-                    Some(quality.get() as f64),
-                    Some(*fast_mode),
-                ),
-                OutputFormat::Png => ("png".to_string(), None, None),
-                OutputFormat::WebP { quality } => {
-                    ("webp".to_string(), Some(quality.get() as f64), None)
-                }
-                OutputFormat::Avif { quality } => {
-                    ("avif".to_string(), Some(quality.get() as f64), None)
-                }
-            };
-            (f, q, fm.unwrap_or(false))
+        let ctx = if let Some(ref preset_name) = options.preset {
+            let preset = Self::resolve_preset(&env, preset_name)?;
+            self.build_preset_task_context(&preset)
         } else {
-            let fmt = options.format.unwrap_or_else(|| "jpeg".to_string());
-            (fmt, options.quality, options.fast_mode.unwrap_or(false))
-        };
-
-        let quality = validation::sanitize_quality(quality_f64).map_err(|e| napi_err(&env, e))?;
-        let output_format = OutputFormat::from_str_with_options(&format_str, quality, fast_mode)
+            let format = options.format.unwrap_or_else(|| "jpeg".to_string());
+            let quality =
+                validation::sanitize_quality(options.quality).map_err(|e| napi_err(&env, e))?;
+            let output_format = OutputFormat::from_str_with_options(
+                &format,
+                quality,
+                options.fast_mode.unwrap_or(false),
+            )
             .map_err(|e| napi_err(&env, e))?;
+            self.build_task_context(output_format)
+        };
 
         Ok(AsyncTask::new(
             crate::engine::tasks::UnifiedEncodeToFileTask {
-                ctx: self.build_task_context(output_format),
+                ctx,
                 want_metrics,
                 output_path: path,
             },
         ))
     }
 
-    /// Convenience: encode to file using the preset's recommended format/quality.
+    /// Encode to file with a named preset without changing the engine's queued operations.
     #[napi(js_name = "toFileWithPreset", ts_return_type = "Promise<number>")]
     pub fn to_file_with_preset(
         &mut self,
@@ -522,37 +441,11 @@ impl ImageEngine {
         path: String,
         preset_name: String,
     ) -> Result<AsyncTask<WriteFileTask>> {
-        let preset = match PresetConfig::get(&preset_name) {
-            Some(config) => config,
-            None => {
-                let lazy_err = LazyImageError::invalid_preset(preset_name.clone());
-                return Err(crate::error::napi_error_with_code(&env, lazy_err)?);
-            }
-        };
-
-        self.ops.push(Operation::Resize {
-            width: preset.width,
-            height: preset.height,
-            fit: ResizeFit::Inside,
-        });
-
-        self.last_preset = Some(preset.clone());
-
-        let (format_str, quality, fast_mode) = match &preset.format {
-            OutputFormat::Jpeg { quality, fast_mode } => {
-                ("jpeg", Some(quality.get()), Some(*fast_mode))
-            }
-            OutputFormat::Png => ("png", None, None),
-            OutputFormat::WebP { quality } => ("webp", Some(quality.get()), None),
-            OutputFormat::Avif { quality } => ("avif", Some(quality.get()), None),
-        };
-
-        self.to_file(
-            env,
-            path,
-            format_str.to_string(),
-            quality.map(|q| q as f64),
-            fast_mode,
-        )
+        let preset = Self::resolve_preset(&env, &preset_name)?;
+        validation::validate_output_path(&path).map_err(|e| napi_err(&env, e))?;
+        Ok(AsyncTask::new(WriteFileTask {
+            ctx: self.build_preset_task_context(&preset),
+            output_path: path,
+        }))
     }
 }

--- a/test/integration/preset-output-isolation.test.js
+++ b/test/integration/preset-output-isolation.test.js
@@ -1,0 +1,139 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const {
+  resolveFixture,
+  resolveRoot,
+  resolveTemp,
+} = require('../helpers/paths')
+const { ImageEngine, inspect, inspectFile } = require(resolveRoot('index'))
+
+const INPUT = resolveFixture('test_100KB_1057x1057.jpg')
+const ORIGINAL_SIZE = { width: 1057, height: 1057 }
+
+async function plainDimensions(engine) {
+  return inspect(await engine.toBuffer('jpeg', 85))
+}
+
+function assertDimensions(actual, expected, message) {
+  assert.deepEqual(
+    { width: actual.width, height: actual.height },
+    expected,
+    message,
+  )
+}
+
+async function run() {
+  {
+    const engine = ImageEngine.fromPath(INPUT)
+    const preset = await engine.encode({ preset: 'thumbnail' })
+    assertDimensions(inspect(preset.data), { width: 150, height: 150 })
+    assertDimensions(
+      await plainDimensions(engine),
+      ORIGINAL_SIZE,
+      'encode({ preset }) must not change later encode operations',
+    )
+  }
+
+  {
+    const engine = ImageEngine.fromPath(INPUT)
+    const preset = await engine.encode({ preset: 'avatar', metrics: true })
+    assertDimensions(inspect(preset.data), { width: 200, height: 200 })
+    assert(preset.metrics, 'metrics should still be returned for preset output')
+    assertDimensions(
+      await plainDimensions(engine),
+      ORIGINAL_SIZE,
+      'metrics must not change preset isolation',
+    )
+  }
+
+  {
+    const engine = ImageEngine.fromPath(INPUT)
+    const preset = await engine.toBufferWithPreset('thumbnail')
+    assertDimensions(inspect(preset), { width: 150, height: 150 })
+    assertDimensions(
+      await plainDimensions(engine),
+      ORIGINAL_SIZE,
+      'toBufferWithPreset must not mutate queued operations',
+    )
+  }
+
+  {
+    const engine = ImageEngine.fromPath(INPUT)
+    const preset = await engine.toBufferWithMetricsPreset('avatar')
+    assertDimensions(inspect(preset.data), { width: 200, height: 200 })
+    assertDimensions(
+      await plainDimensions(engine),
+      ORIGINAL_SIZE,
+      'toBufferWithMetricsPreset must not mutate queued operations',
+    )
+  }
+
+  {
+    const engine = ImageEngine.fromPath(INPUT)
+    const thumbnail = await engine.toBufferWithPreset('thumbnail')
+    const avatar = await engine.toBufferWithPreset('avatar')
+    assertDimensions(inspect(thumbnail), { width: 150, height: 150 })
+    assertDimensions(
+      inspect(avatar),
+      { width: 200, height: 200 },
+      'each preset must start from the caller pipeline, not a prior preset output',
+    )
+  }
+
+  {
+    const presetPath = resolveTemp('preset-isolation.webp')
+    const plainPath = resolveTemp('preset-isolation-plain.jpg')
+    const engine = ImageEngine.fromPath(INPUT)
+    try {
+      await engine.toFileWithPreset(presetPath, 'thumbnail')
+      await engine.toFile(plainPath, 'jpeg', 85)
+      assertDimensions(inspectFile(presetPath), { width: 150, height: 150 })
+      assertDimensions(
+        inspectFile(plainPath),
+        ORIGINAL_SIZE,
+        'toFileWithPreset must not mutate queued operations',
+      )
+    } finally {
+      fs.rmSync(presetPath, { force: true })
+      fs.rmSync(plainPath, { force: true })
+    }
+  }
+
+  {
+    const presetPath = resolveTemp('encode-preset-isolation.webp')
+    const plainPath = resolveTemp('encode-preset-isolation-plain.jpg')
+    const engine = ImageEngine.fromPath(INPUT)
+    try {
+      await engine.encodeToFile(presetPath, { preset: 'avatar', metrics: true })
+      await engine.toFile(plainPath, 'jpeg', 85)
+      assertDimensions(inspectFile(presetPath), { width: 200, height: 200 })
+      assertDimensions(
+        inspectFile(plainPath),
+        ORIGINAL_SIZE,
+        'encodeToFile({ preset }) must not mutate queued operations',
+      )
+    } finally {
+      fs.rmSync(presetPath, { force: true })
+      fs.rmSync(plainPath, { force: true })
+    }
+  }
+
+  {
+    const engine = ImageEngine.fromPath(INPUT)
+    engine.preset('thumbnail')
+    assertDimensions(
+      await plainDimensions(engine),
+      { width: 150, height: 150 },
+      'deprecated preset() remains an explicitly mutating pipeline API',
+    )
+  }
+
+  console.log('preset output isolation tests passed')
+}
+
+run().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})


### PR DESCRIPTION
## なぜこの修正が必要か

self-contained として公開している Preset 出力 API が、出力時の Resize を `self.ops` に追加していました。そのため同じ `ImageEngine` を再利用すると、後続の通常出力や次の Preset 出力が過去の呼び出し順に依存していました。

Closes #740

## 変更内容

- Preset 用 Resize を engine 本体ではなく TaskContext の一時 operations に追加
- `self.ops` / `self.last_preset` を self-contained API から変更しない
- Preset の `OutputFormat` を文字列化・再parseせず、そのまま TaskContext に渡す共通 helper を追加
- 以下の全経路を同じ helper に統一
  - `encode({ preset })`
  - `encodeToFile({ preset })`
  - `toBufferWithPreset()`
  - `toBufferWithMetricsPreset()`
  - `toFileWithPreset()`
- deprecated `.preset()` は後方互換のため明示的な mutating API のまま維持

## Before / After

Before: `thumbnail` 出力後の通常出力も 150x150 になり、続けて `avatar` を呼んでも先行 Resize の影響を受けました。

After: 各 self-contained Preset 出力は呼び出し時点の元パイプラインだけを snapshot として使い、後続出力を変更しません。

## 回帰テスト

同一インスタンスで以下を検証しています。

- `encode` の metrics 有無
- buffer / file の Preset 出力後に通常出力が元寸法を維持
- `encodeToFile`
- 異なる Preset の連続呼び出し
- deprecated `.preset()` が従来どおりパイプラインを変更

## 検証

- `npm run build`
- `npm test`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `git diff --check`

補足: `cargo clippy --all-targets --features napi -- -D warnings` では本変更外の既存 lint（tests の unused unsafe、dead code、len_zero、type_complexity）が残っています。Issue 受け入れ条件の標準 `cargo clippy -- -D warnings` は成功しています。
