### PR TITLE
feat(api): add event-loop-safe fromPathAsync

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -27,6 +27,7 @@ console.log(`Wrote ${bytesWritten} bytes`);
 
 - JPEG サイズは「canonical な PNG→JPEG の単純ケース」で 17-20% の改善が成立
 - 256MB を超える大きな入力は Rust 側バッファへ全量読み込まず、メモリ安全な mmap 経路で処理します。`fromPath()` を使う際は、同時に対象ファイルの変更・切り詰め・削除を避け、破損や `SIGBUS` / `SIGSEGV` を防いでください。
+- `fromPath()` は256MB以下のsourceを呼び出しthreadで同期readします。HTTP/serverless経路では `await ImageEngine.fromPathAsync(path)` を使い、source setupをNode.js event loop外へ移してください。
 - メタデータは既定で安全寄り（GPS は既定で除去、`keepMetadata()` で制御）
 - API は drop-in 置換ではない（互換が必要なら sharp）
 
@@ -40,8 +41,8 @@ console.log(`Wrote ${bytesWritten} bytes`);
 
 ## Recommended Paths
 
-- 画像配信最適化: `fromPath() -> resize()/crop() -> toFile()`
-- アップロード検証: `fromPath() -> sanitize({ policy: 'strict' }) -> toFile()/toBuffer()`
+- 画像配信最適化: `await fromPathAsync() -> resize()/crop() -> toFile()`
+- アップロード検証: `await fromPathAsync() -> sanitize({ policy: 'strict' }) -> toFile()/toBuffer()`
 - 静的サイト生成バッチ: `processBatch()` / `clone()`
 - 編集後の最終最適化: sharp/ImageMagick の後段に lazy-image を通す
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ In current canonical benchmarks, lazy-image produces **17-20% smaller JPEG outpu
   disabled. File-path inputs (`fromPath()`/`processBatch()` → `toFile()`) bypass
   the V8 heap. Small/medium files (≤ 256 MB) are read into Rust-owned memory
   for SIGBUS safety, and files larger than 256 MB use mmap with advisory locks.
+  `fromPath()` performs that setup synchronously; use
+  `await ImageEngine.fromPathAsync(path)` in request-serving code to move it
+  off the Node.js event loop.
   For mmap paths, avoid modifying, truncating, or deleting source files during
   processing; use a copy or `from(Buffer)` for mutable inputs.
   See [docs/ZERO_COPY.md](./docs/ZERO_COPY.md).
@@ -69,8 +72,8 @@ Benchmarks and details: [docs/PERFORMANCE.md](./docs/PERFORMANCE.md). Full compa
 
 Start with one of these workflows:
 
-- **Web delivery optimization**: `fromPath() -> resize()/crop() -> toFile()` for the lowest heap usage and the clearest operational path
-- **Upload sanitization**: `fromPath() -> sanitize({ policy: 'strict' }) -> toFile()/toBuffer()` for untrusted user uploads
+- **Web delivery optimization**: `await fromPathAsync() -> resize()/crop() -> toFile()` for event-loop-safe source loading and low V8 heap use
+- **Upload sanitization**: `await fromPathAsync() -> sanitize({ policy: 'strict' }) -> toFile()/toBuffer()` for untrusted user uploads
 - **Build-time / batch generation**: `processBatch()` or `clone()` for static sites, media pipelines, and multi-output generation
 - **Final optimization after editing**: use sharp/ImageMagick for compositing, filters, or animation, then pass the result through lazy-image for final JPEG/WebP/AVIF optimization
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -10,10 +10,16 @@ API is intentionally narrower and is documented separately in
 
 | Method | Description |
 |--------|-------------|
-| `ImageEngine.from(buffer)` | Create engine from a Buffer (loads into V8 heap). Full pixel decode is deferred, but constructor-time metadata extraction still runs. |
-| `ImageEngine.fromPath(path)` | **Recommended**: Create engine from file path (bypasses V8 heap). Full pixel decode is deferred, but constructor-time file setup and metadata extraction still run. Size-tiered: files ≤ 256 MB are read once into a Rust-owned buffer; files > 256 MB are accessed via `mmap` with an advisory lock and a retained fd. **Note**: On Windows, memory-mapped files (the > 256 MB tier) cannot be deleted while mapped. See [TROUBLESHOOTING.md](./TROUBLESHOOTING.md#windows-file-locking) and [ZERO_COPY.md](./ZERO_COPY.md). |
+| `ImageEngine.from(buffer)` | Create engine from a Buffer. The bytes cross the V8 boundary and are copied into Rust-owned memory; metadata extraction and full pixel decode are deferred. |
+| `await ImageEngine.fromPathAsync(path)` | **Recommended for servers**: performs file open/read/mmap setup on an N-API worker so a ≤256 MB source read does not block the Node.js event loop. It uses the same SIGBUS-safe source policy and error codes as `fromPath()`. |
+| `ImageEngine.fromPath(path)` | Synchronous compatibility API (bypasses V8 heap but not the event loop). Files ≤ 256 MB are synchronously read into Rust-owned memory on the calling thread; files > 256 MB use `mmap` with an advisory lock and retained fd. **Note**: On Windows, mapped files cannot be deleted while open. See [TROUBLESHOOTING.md](./TROUBLESHOOTING.md#windows-file-locking) and [ZERO_COPY.md](./ZERO_COPY.md). |
 
 See [LAZY_SEMANTICS.md](./LAZY_SEMANTICS.md) for the exact deferred vs eager contract.
+
+```javascript
+const engine = await ImageEngine.fromPathAsync('input.jpg');
+const bytes = await engine.resize(800).toFile('output.jpg', 'jpeg', 80);
+```
 
 ## Pipeline Operations (chainable)
 

--- a/docs/LAZY_SEMANTICS.md
+++ b/docs/LAZY_SEMANTICS.md
@@ -5,17 +5,19 @@ In `lazy-image`, "lazy" does not mean "constructors do nothing."
 ## What is eager
 
 - `ImageEngine.from(buffer)` copies the input buffer into Rust-owned memory.
-- `ImageEngine.from(buffer)` and `ImageEngine.fromPath(path)` extract lightweight metadata needed for later decisions, including ICC and EXIF payloads when present.
-- `ImageEngine.fromPath(path)` validates the path and opens the source using the safe file-loading path (in-memory read for smaller files, mmap for large files).
+- `ImageEngine.fromPath(path)` synchronously validates and opens the source. Files at or below 256 MB are fully read into Rust-owned memory on the calling thread; larger files use mmap setup with an advisory lock and retained file descriptor.
 
 ## What is deferred
 
 - Full pixel decode.
 - Auto-orientation and all queued image operations.
 - Output encoding (`toBuffer`, `toFile`, metrics variants, preset variants).
+- `ImageEngine.fromPathAsync(path)` source setup runs on an N-API worker; after its Promise resolves, decode and pipeline execution remain deferred like the synchronous API.
+- ICC and EXIF extraction is lazy and cached on first use.
 
 ## Contract
 
 - `lazy-image` is a **lazy decode / lazy execution** pipeline, not a zero-work constructor API.
-- Constructor work is intentionally limited to cheap source setup and metadata extraction.
+- `fromPath()` is synchronous compatibility behavior and can block the event loop while reading up to 256 MB. Prefer `await fromPathAsync()` in request-serving code.
+- Both path APIs preserve the same SIGBUS policy: in-memory reads through 256 MB, then mmap with advisory lock/fd retention (or a memory fallback when the lock cannot be acquired).
 - If you need metadata only, use `inspect()` / `inspectFile()` instead of building a pipeline.

--- a/index.d.ts
+++ b/index.d.ts
@@ -61,6 +61,11 @@ export declare class ImageEngine {
    * This is the recommended way for server-side processing of large images.
    */
   static fromPath(path: string): ImageEngine
+  /**
+   * Create an engine from a file path without reading the source on Node's
+   * main thread. File open/read/mmap setup runs on an N-API worker.
+   */
+  static fromPathAsync(path: string): Promise<ImageEngine>
   /** Create a clone of this engine (for multi-output scenarios) */
   clone(): ImageEngine
   /**

--- a/src/engine/api/engine.rs
+++ b/src/engine/api/engine.rs
@@ -21,6 +21,38 @@ use std::sync::OnceLock;
 #[cfg(feature = "napi")]
 use napi::bindgen_prelude::*;
 
+#[cfg(feature = "napi")]
+pub struct LoadFileTask {
+    path: std::path::PathBuf,
+    last_error: Option<LazyImageError>,
+}
+
+#[cfg(feature = "napi")]
+#[napi]
+impl Task for LoadFileTask {
+    type Output = Source;
+    type JsValue = ImageEngine;
+
+    fn compute(&mut self) -> Result<Self::Output> {
+        load_file_safe(&self.path).map_err(|error| {
+            self.last_error = Some(error.clone());
+            napi::Error::from(error)
+        })
+    }
+
+    fn resolve(&mut self, _env: Env, source: Self::Output) -> Result<Self::JsValue> {
+        Ok(ImageEngine::with_source(source))
+    }
+
+    fn reject(&mut self, env: Env, error: napi::Error) -> Result<Self::JsValue> {
+        let lazy_error = self
+            .last_error
+            .take()
+            .unwrap_or_else(|| LazyImageError::generic(error.to_string()));
+        Err(crate::error::napi_error_with_code(&env, lazy_error)?)
+    }
+}
+
 // MetadataPolicy lives in the sibling `metadata` module (src/engine/metadata.rs).
 // Re-export so downstream code (tasks.rs, engine.rs tests) can still reach it
 // via `super::api::MetadataPolicy` or `crate::engine::api::MetadataPolicy`.
@@ -115,6 +147,23 @@ impl ImageEngine {
         };
 
         Ok(Self::with_source(source))
+    }
+
+    /// Create an engine from a file path without reading the source on Node's
+    /// main thread. File open/read/mmap setup runs on an N-API worker.
+    #[napi(js_name = "fromPathAsync", ts_return_type = "Promise<ImageEngine>")]
+    pub fn from_path_async(env: Env, path: String) -> Result<AsyncTask<LoadFileTask>> {
+        if path.trim().is_empty() {
+            return Err(napi_err(
+                &env,
+                LazyImageError::invalid_argument("path", "<empty>", "path must not be empty"),
+            ));
+        }
+
+        Ok(AsyncTask::new(LoadFileTask {
+            path: std::path::PathBuf::from(path),
+            last_error: None,
+        }))
     }
 
     /// Create a clone of this engine (for multi-output scenarios)

--- a/src/engine/api/engine.rs
+++ b/src/engine/api/engine.rs
@@ -160,8 +160,15 @@ impl ImageEngine {
             ));
         }
 
+        // Resolve relative paths before enqueueing. The worker may run after a
+        // caller changes process.cwd(), but the selected source must retain the
+        // same call-time semantics as synchronous fromPath().
+        let path = std::path::absolute(&path).map_err(|error| {
+            napi_err(&env, LazyImageError::file_read_failed(path.clone(), error))
+        })?;
+
         Ok(AsyncTask::new(LoadFileTask {
-            path: std::path::PathBuf::from(path),
+            path,
             last_error: None,
         }))
     }

--- a/test/integration/from-path-async.test.js
+++ b/test/integration/from-path-async.test.js
@@ -2,6 +2,7 @@
 
 const assert = require('node:assert/strict')
 const fs = require('node:fs')
+const path = require('node:path')
 const { resolveFixture, resolveRoot, resolveTemp } = require('../helpers/paths')
 const { ImageEngine, inspect } = require(resolveRoot('index'))
 
@@ -29,6 +30,25 @@ async function main() {
   assert(asyncError, 'async path should reject a missing file')
   assert.equal(asyncError.code, syncError.code)
   assert.equal(asyncError.category, syncError.category)
+
+  const originalCwd = process.cwd()
+  const relativeRoot = fs.mkdtempSync(resolveTemp('from-path-relative-'))
+  const sourceCwd = path.join(relativeRoot, 'source')
+  const otherCwd = path.join(relativeRoot, 'other')
+  fs.mkdirSync(sourceCwd)
+  fs.mkdirSync(otherCwd)
+  fs.copyFileSync(INPUT, path.join(sourceCwd, 'input.jpg'))
+  try {
+    process.chdir(sourceCwd)
+    const relativeLoad = ImageEngine.fromPathAsync('input.jpg')
+    process.chdir(otherCwd)
+    const relativeEngine = await relativeLoad
+    const relativeOutput = await relativeEngine.resize(64).toBuffer('jpeg', 80)
+    assert.equal(inspect(relativeOutput).width, 64)
+  } finally {
+    process.chdir(originalCwd)
+    fs.rmSync(relativeRoot, { recursive: true, force: true })
+  }
 
   const largePath = resolveTemp('from-path-async-128mb.bin')
   const fd = fs.openSync(largePath, 'w')

--- a/test/integration/from-path-async.test.js
+++ b/test/integration/from-path-async.test.js
@@ -1,0 +1,65 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const { resolveFixture, resolveRoot, resolveTemp } = require('../helpers/paths')
+const { ImageEngine, inspect } = require(resolveRoot('index'))
+
+const INPUT = resolveFixture('test_100KB_1057x1057.jpg')
+
+async function main() {
+  const engine = await ImageEngine.fromPathAsync(INPUT)
+  const output = await engine.resize(120).toBuffer('jpeg', 80)
+  assert.equal(inspect(output).width, 120)
+
+  const missing = resolveTemp('from-path-async-missing.jpg')
+  let syncError
+  let asyncError
+  try {
+    ImageEngine.fromPath(missing)
+  } catch (error) {
+    syncError = error
+  }
+  try {
+    await ImageEngine.fromPathAsync(missing)
+  } catch (error) {
+    asyncError = error
+  }
+  assert(syncError, 'sync path should reject a missing file')
+  assert(asyncError, 'async path should reject a missing file')
+  assert.equal(asyncError.code, syncError.code)
+  assert.equal(asyncError.category, syncError.category)
+
+  const largePath = resolveTemp('from-path-async-128mb.bin')
+  const fd = fs.openSync(largePath, 'w')
+  fs.ftruncateSync(fd, 128 * 1024 * 1024)
+  fs.closeSync(fd)
+  try {
+    let loadFinished = false
+    const load = ImageEngine.fromPathAsync(largePath).then((loaded) => {
+      loadFinished = true
+      return loaded
+    })
+    let timerObservedInFlightRead = false
+    await new Promise((resolve) =>
+      setTimeout(() => {
+        timerObservedInFlightRead = !loadFinished
+        resolve()
+      }, 0),
+    )
+    await load
+    assert(
+      timerObservedInFlightRead,
+      'timer should run while the Rust worker is still reading the file source',
+    )
+  } finally {
+    fs.rmSync(largePath, { force: true })
+  }
+
+  console.log('fromPathAsync tests passed')
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/test/type-safety/typescript-typecheck.test.ts
+++ b/test/type-safety/typescript-typecheck.test.ts
@@ -27,7 +27,9 @@ async function testTypeSafety() {
         console.log(`Testing format: ${format}`);
         
         // These are type-safe and do not cause compile errors
-        const engine = ImageEngine.fromPath(imagePath);
+    const engine = ImageEngine.fromPath(imagePath);
+    const asyncEngine: ImageEngine = await ImageEngine.fromPathAsync(imagePath);
+    await asyncEngine.toBuffer('jpeg', 80);
         const fitMode = fitModes[index % fitModes.length];
         const result = await engine.resize(400, 300, fitMode).toBuffer(format, 80);
         console.log(`✅ ${format}: ${result.length} bytes`);


### PR DESCRIPTION
## なぜこの修正が必要か

`ImageEngine.fromPath()` はV8 heapを避ける一方、256MB以下のsourceを呼び出しthreadで同期readしていました。HTTP/serverlessではconstructor呼び出しがNode.js event loopを止める可能性があります。

Closes #745

## 変更内容

- `await ImageEngine.fromPathAsync(path)` を公開
- file open / ≤256MB read / >256MB mmap setup を N-API AsyncTask workerへ移動
- 既存 `load_file_safe()` を同期・非同期で共有
  - SIGBUS対策
  - advisory shared lock
  - mapped file descriptor lifetime
  - memory semaphore予約
  - error taxonomy
  を分岐させず維持
- `fromPath()` は後方互換の同期APIとして維持
- TypeScript declaration / typecheckを追加

## エラー契約

missing fileについて同期・非同期経路の `code` と `category` が一致することを回帰テストで確認しています。空pathも同じE400 validationを使用します。

## Event-loop回帰テスト

128MB sparse sourceをasync loadし、Promise解決より前に0ms timerが実行されることを検証します。これによりsource readがJSメインthreadに戻る回帰を検出します。fixtureは `.tmp` に一時作成し、テスト後に削除します。

## ドキュメント

README / API / LAZY_SEMANTICSに以下を明記しました。

- `fromPath()` は≤256MBを同期read
- server request経路では `fromPathAsync()` を推奨
- 両経路のin-memory/mmap閾値とlock/fd policyは同一

## 検証

- `npm run build`
- `npm test`
- `node test/integration/from-path-async.test.js`
- `npm run test:types`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `npm audit --audit-level=high`（0 vulnerabilities）
- `git diff --check`
