### PR TITLE
fix(security): remove vulnerable unused EXIF dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,21 +36,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloc-no-stdlib"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
-
-[[package]]
-name = "alloc-stdlib"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
-dependencies = [
- "alloc-no-stdlib",
-]
-
-[[package]]
 name = "alloca"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,9 +58,9 @@ checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"
@@ -210,27 +195,6 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
-]
-
-[[package]]
-name = "brotli"
-version = "8.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
 ]
 
 [[package]]
@@ -383,21 +347,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
-dependencies = [
- "crc-catalog",
-]
-
-[[package]]
-name = "crc-catalog"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
-
-[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,9 +411,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -926,7 +875,6 @@ dependencies = [
  "kamadak-exif",
  "libavif-sys",
  "libc",
- "little_exif",
  "memmap2",
  "mozjpeg",
  "napi",
@@ -1027,20 +975,6 @@ name = "litrs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
-
-[[package]]
-name = "little_exif"
-version = "0.6.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21eeb58b22d31be8dc5c625004fcd4b9b385cd3c05df575f523bcca382c51122"
-dependencies = [
- "brotli",
- "crc",
- "log",
- "miniz_oxide",
- "paste",
- "quick-xml",
-]
 
 [[package]]
 name = "lock_api"
@@ -1504,15 +1438,6 @@ name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
-
-[[package]]
-name = "quick-xml"
-version = "0.37.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "quote"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,6 @@ image = { version = "0.25", default-features = false, features = [
 ] }
 # EXIF parsing (Orientation tag extraction for auto-orient)
 exif = { package = "kamadak-exif", version = "0.6.1" }
-# EXIF read/write with tag-level access (MIT/Apache-2.0, pure Rust)
-# Used for Orientation reset and GPS stripping - exceeds Sharp's metadata handling
-little_exif = "0.6"
 # PNG optimization (disable default features to avoid clap/zopfli bloat)
 oxipng = { version = "10.1", default-features = false, features = ["parallel"] }
 
@@ -168,8 +165,6 @@ opt-level = "z"
 [profile.release.package.flate2]
 opt-level = "z"
 [profile.release.package.miniz_oxide]
-opt-level = "z"
-[profile.release.package.little_exif]
 opt-level = "z"
 [profile.release.package.kamadak-exif]
 opt-level = "z"

--- a/src/engine/api/engine.rs
+++ b/src/engine/api/engine.rs
@@ -66,7 +66,8 @@ pub struct ImageEngine {
     /// ICC color profile extracted from source image (lazy: extracted on first access)
     pub(crate) icc_profile: OnceLock<Option<Arc<Vec<u8>>>>,
     /// Raw EXIF data extracted from source image (lazy: extracted on first access)
-    /// Stored as raw bytes to avoid serialization issues with little_exif::Metadata
+    /// Stored as raw bytes so metadata can be sanitized and embedded without
+    /// retaining a parser-specific object graph between lazy output operations.
     pub(crate) exif_data: OnceLock<Option<Arc<Vec<u8>>>>,
     /// Whether to auto-apply EXIF Orientation (default: true)
     pub(crate) auto_orient: bool,


### PR DESCRIPTION
## なぜこの修正が必要か

Security Auditが RUSTSEC-2026-0194、RUSTSEC-2026-0195、RUSTSEC-2026-0204、RUSTSEC-2026-0190 を検出し、#749〜#754を含む全PRのCargo Auditをブロックしています。画像やEXIFは外部入力になり得るため、監査ignoreの追加ではなくshipping dependency treeから原因を解消します。

Closes #741

## 調査結果と意思決定

- quick-xml 0.37.5はlittle_exif 0.6.23経由でした
- リポジトリ全体を照合するとlittle_exifはCargo.tomlに残っているだけで、Rust実装から参照されていません
- 現在のEXIF処理はkamadak-exif、img-parts、独自TIFF sanitizer/embed処理で完結しています
- 未mergeのforkや新しいaudit ignoreへ依存せず、未使用依存を削除する方が供給網・保守性・binary sizeの面で安全です

## 変更内容

- 未使用のlittle_exif直接依存とrelease profile設定を削除
- lockfileからlittle_exif、quick-xml、brotli、crc等の不要なtransitive依存を除去
- crossbeam-epochを0.9.20へ更新
- anyhowを1.0.103へ更新
- little_exifを前提にしていた古いコメントを現在のraw EXIF設計へ修正

## Before / After

Before:
- quick-xml 0.37.5が2件のHIGH DoS advisory対象
- crossbeam-epoch 0.9.18がinvalid pointer dereference advisory対象
- anyhow 1.0.100がunsound advisory対象
- Cargo Audit失敗

After:
- little_exifとquick-xmlはdependency treeから完全に除去
- crossbeam-epoch 0.9.20、anyhow 1.0.103
- 4件のadvisoryを新規ignoreなしで解消
- EXIF保持、GPS除去、JPEG/WebP/PNG roundtrip、AVIF出力契約は維持

## 検証

- cargo audit --deny unmaintained --deny unsound --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2026-0097 --ignore RUSTSEC-2026-0105
- cargo tree -i quick-xml: package not found
- cargo tree -i little_exif: package not found
- cargo tree -i crossbeam-epoch: 0.9.20
- cargo tree -i anyhow: 1.0.103
- cargo fmt --check
- cargo clippy --all-features -- -D warnings
- cargo clippy --no-default-features -- -D warnings
- cargo test --no-default-features
- npm run build
- npm test
- npm audit --audit-level=high

すべて成功しています。Cargo Auditに残るcore2 yanked warningは、既存の根拠付きRUSTSEC-2026-0105管理対象で非fatalです。