### PR TITLE
chore(deps): update libc to 0.2.186

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -912,9 +912,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libdeflate-sys"


### PR DESCRIPTION
## なぜ必要か

Issue #755 で、旧 `develop` 起点だった libc 更新 PR #579 を現在の GitHub Flow / `main` の依存グラフに対して再評価しました。旧PRは取り込まず、最新 `main` からlockfileを再生成しています。

libc 0.2.186 はRust 1.65以上を要求し、本プロジェクトのMSRV Rust 1.88を満たします。OS境界、mmap、メモリ計測、jemalloc周辺で利用される基盤crateのpatch更新を、意図しない依存更新なしで適用します。

## 変更内容

- `Cargo.lock` の libc を 0.2.183 から 0.2.186へ更新
- checksumをcrates.io公開値へ同期
- `Cargo.toml` の許容範囲 `libc = "0.2"` は変更なし

## Before / After

- Before: 旧develop由来PR #579は閉じられ、mainのlockfileは0.2.183のまま
- After: 最新mainからlibcだけを0.2.186へ更新し、他の依存と生成物は不変

## 品質・安全性

- MSRV: libc 1.65 <= lazy-image 1.88
- 差分: Cargo.lock 2行のみ
- 公開API変更なし
- advisoryの新規追加なし

## 検証

- `cargo fmt --check`
- `cargo clippy --all-features -- -D warnings`
- `cargo clippy --no-default-features -- -D warnings`
- `npm run build`
- `npm test`
- `cargo audit --deny unmaintained --deny unsound --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2026-0097 --ignore RUSTSEC-2026-0105`

Part of #755. Supersedes #579.
