### PR TITLE
chore(deps): update proptest to 1.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1401,9 +1401,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ tikv-jemallocator = { version = "0.7", optional = true, features = ["disable_ini
 
 [dev-dependencies]
 criterion = "0.8"
-proptest = "1.10"
+proptest = "1.11"
 semver = "1"
 
 [[bench]]


### PR DESCRIPTION
## なぜ必要か

Issue #755で、旧 `develop` 起点のproptest更新PR #512を最新 `main` のproperty-based test suiteに対して再評価しました。proptestは本番バイナリではなく開発・検証時の入力生成と不変条件検査に使われますが、Rustエンジンの境界条件を守る重要な品質依存です。

proptest 1.11.0のMSRVはRust 1.85で、lazy-imageのMSRV Rust 1.88を満たします。

## 変更内容

- `Cargo.toml`: proptestの要求versionを1.10から1.11へ更新
- `Cargo.lock`: proptest 1.10.0から1.11.0へ更新
- 本番依存、公開API、生成物は変更なし

## Before / After

- Before: property-based testsはproptest 1.10系列を使用
- After: 1.11系列を明示し、全8 property testsを含むRust suiteで互換性を確認

## 品質・安全性

- MSRV: proptest 1.85 <= lazy-image 1.88
- 本番配布物への依存追加なし
- property-based tests 8件を含む全suite成功
- advisoryの新規追加なし

## 検証

- `cargo fmt --check`
- `cargo clippy --all-features -- -D warnings`
- `cargo clippy --no-default-features -- -D warnings`
- `npm run build`
- `npm test`
- `cargo audit --deny unmaintained --deny unsound --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2026-0097 --ignore RUSTSEC-2026-0105`

Part of #755. Supersedes #512.
