### PR TITLE
chore(deps): update actions/github-script to v9

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -185,7 +185,7 @@ jobs:
 
       - name: Create issue on crash
         if: steps.check_crashes.outputs.has_crashes == 'true' && github.event_name != 'pull_request'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -43,7 +43,7 @@ jobs:
       
       - name: Create issue on failure
         if: failure() && github.event_name == 'schedule'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { upsertSecurityAuditIssue } = require(


### PR DESCRIPTION
## 背景

Issue #755 で、旧 develop 向けだった #569 を現在の main から再評価しました。actions/github-script v9 は Node.js 24 ランタイムへ更新されており、セキュリティ監査失敗・fuzz crash 通知を今後も保守可能な状態にするため採用します。

## 変更内容

- `.github/workflows/security.yml` の `actions/github-script` を v8 から v9.0.0 のimmutable SHAへ更新
- `.github/workflows/fuzz.yml` も同じimmutable SHAへ更新
- workflow権限・通知条件・issue本文生成ロジックは変更なし

## 変更前後

- 変更前: v8固定SHA
- 変更後: v9.0.0固定SHA `3a2844b7e9c422d3c10d287c895573f7108da1b3`

## 互換性判断

v9の破壊的変更を確認し、対象scriptには非互換となる `require(@actions/github)`、独自の `getOctokit` 再定義がないことを確認しました。既存のNode.js API利用とrepo内helper読込は継続できます。

## 検証

- `node test/unit/security-audit-notification.test.js`
- `npm run build`
- `npm test`
- `npm audit --audit-level=high`（0 vulnerabilities）
- `git diff --check`

Part of #755. Supersedes #569.