### PR TITLE
security(deps): enforce expiring Cargo audit exceptions

### DIFF
--- a/.github/security/cargo-audit-exceptions.json
+++ b/.github/security/cargo-audit-exceptions.json
@@ -1,0 +1,15 @@
+{
+  "exceptions": [
+    {
+      "advisory": "RUSTSEC-2024-0436",
+      "package": "paste",
+      "reason": "libavif-sys 0.17.0 constrains the production AVIF backend to rav1e 0.7.x, while paste was removed only from the newer rav1e line.",
+      "impact": "This is an unmaintained proc-macro warning, not a known runtime vulnerability. The root graph compiles it through the pinned AVIF backend; the fuzz lock also resolves it through image/exr metadata even though those optional runtime features are disabled. It is not exposed to image input at runtime.",
+      "remediation": "Re-evaluate libavif-sys or a compatible AVIF backend update, then remove this exception once rav1e 0.7.x leaves the production dependency graph.",
+      "owner": "lazy-image maintainers",
+      "upstream": "https://github.com/xiph/rav1e/issues/3418",
+      "reviewBy": "2026-10-19",
+      "lockfiles": ["Cargo.lock", "fuzz/Cargo.lock"]
+    }
+  ]
+}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -31,15 +31,7 @@ jobs:
         run: cargo install cargo-audit --locked
       
       - name: Run security audit
-        run: >
-          cargo audit --deny unmaintained --deny unsound
-          --ignore RUSTSEC-2024-0436
-          --ignore RUSTSEC-2026-0097
-          --ignore RUSTSEC-2026-0105
-        # Ignore RUSTSEC-2024-0436 (paste unmaintained) - indirect dependency via rav1e, not a security risk
-        # Ignore RUSTSEC-2026-0097 (rand unsound custom logger path) - indirect via rav1e/proptest; lazy-image does not use rand::rng() logging hooks
-        # Ignore RUSTSEC-2026-0105 (core2 unmaintained) - indirect via image -> ravif -> rav1e; no patched upstream path is available yet
-        # cargo-audit cannot ignore yanked crates by advisory ID, so yanked warnings remain non-fatal until core2 leaves the upstream tree
+        run: node scripts/cargo-audit-policy.js
       
       - name: Create issue on failure
         if: failure() && github.event_name == 'schedule'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,11 +178,11 @@ checksum = "6099cdc01846bc367c4e7dd630dc5966dccf36b652fae7a74e17b640411a91b2"
 
 [[package]]
 name = "bitstream-io"
-version = "4.9.0"
+version = "4.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60d4bd9d1db2c6bdf285e223a7fa369d5ce98ec767dec949c6ca62863ce61757"
+checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
 dependencies = [
- "core2",
+ "no_std_io2",
 ]
 
 [[package]]
@@ -335,15 +335,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
-]
-
-[[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -1151,6 +1142,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "no_std_io2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1399,7 +1399,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -1452,9 +1452,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -1463,9 +1463,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -1546,7 +1546,7 @@ dependencies = [
  "once_cell",
  "paste",
  "profiling",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "scan_fmt",
  "simd_helpers",
@@ -1567,7 +1567,7 @@ dependencies = [
  "arrayvec",
  "av-scenechange",
  "av1-grain",
- "bitstream-io 4.9.0",
+ "bitstream-io 4.10.0",
  "built 0.8.0",
  "cfg-if",
  "interpolate_name",
@@ -1582,7 +1582,7 @@ dependencies = [
  "num-traits",
  "paste",
  "profiling",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "simd_helpers",
  "thiserror 2.0.18",

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -68,6 +68,17 @@ lazy-image implements several security measures to protect against common vulner
 
 Key upstreams: mozjpeg, libwebp, libavif-sys/rav1e, image crate.
 
+### Cargo audit exceptions
+
+CI audits both `Cargo.lock` and the independent `fuzz/Cargo.lock` through
+`scripts/cargo-audit-policy.js`. Temporary advisory exceptions live in
+`.github/security/cargo-audit-exceptions.json` and must include the affected
+lockfile, impact assessment, upstream tracking URL, remediation plan, owner,
+and a `reviewBy` date. The policy test fails once that date expires, so an
+exception cannot silently become permanent. Scope an exception only to the
+lockfile whose dependency path was reviewed; a new occurrence in the other
+dependency graph must fail the audit.
+
 - We monitor upstream security advisories (CVE feeds, GitHub Security Advisories, distro trackers).
 - **Critical/High upstream CVEs**: update dependency and release a patched version within 14 days.
 - **Medium upstream CVEs**: update in the next regular release (target ≤ 30 days).

--- a/examples/stress_test.rs
+++ b/examples/stress_test.rs
@@ -36,6 +36,6 @@ fn main() {
 
 fn run_or_fail(label: &str, iteration: usize, data: &[u8]) {
     if let Err(err) = run_stress_iteration(data) {
-        panic!("{} stress iteration {} failed: {}", label, iteration, err);
+        panic!("{label} stress iteration {iteration} failed: {err}");
     }
 }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
@@ -49,14 +49,14 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "as-slice"
@@ -69,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "av-scenechange"
@@ -109,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "avif-serialize"
-version = "0.8.6"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c8fbc0f831f4519fe8b810b6a7a91410ec83031b8233f730a0480029f6a23f"
+checksum = "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38"
 dependencies = [
  "arrayvec",
 ]
@@ -130,18 +130,18 @@ checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bitstream-io"
-version = "4.9.0"
+version = "4.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60d4bd9d1db2c6bdf285e223a7fa369d5ce98ec767dec949c6ca62863ce61757"
+checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
 dependencies = [
- "core2",
+ "no_std_io2",
 ]
 
 [[package]]
 name = "bitvec"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
 dependencies = [
  "funty",
  "radium",
@@ -151,21 +151,21 @@ dependencies = [
 
 [[package]]
 name = "built"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
+checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
-version = "1.24.0"
+version = "1.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
 
 [[package]]
 name = "byteorder-lite"
@@ -175,15 +175,15 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.2.51"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0aeaff4ff1a90589618835a598e545176939b97874f7abc7851caa0618f203"
+checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -198,15 +198,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -236,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -248,13 +239,13 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "derive_arbitrary"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -274,9 +265,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "equator"
@@ -295,7 +286,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -316,14 +307,16 @@ dependencies = [
 
 [[package]]
 name = "exr"
-version = "1.74.0"
+version = "1.74.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
+checksum = "711fe42c9964295e01ee3fba3f9fe0e1d24b98886950d68efe81b1c76e21adf3"
 dependencies = [
  "bit_field",
  "half",
  "lebe",
  "miniz_oxide",
+ "num-complex",
+ "pulp",
  "rayon-core",
  "smallvec",
  "zune-inflate",
@@ -346,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fdeflate"
@@ -361,15 +354,15 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645cbb3a84e60b7531617d5ae4e57f7e27308f6445f5abf653209ea76dec8dff"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
-version = "1.1.5"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -389,8 +382,19 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -418,9 +422,9 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "image"
-version = "0.25.9"
+version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
@@ -458,9 +462,9 @@ dependencies = [
 
 [[package]]
 name = "imgref"
-version = "1.12.0"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
+checksum = "89194689a993ab15268672e99e7b0e19da2da3268ac682e8f02d29d4d1434cd7"
 
 [[package]]
 name = "indexmap"
@@ -481,7 +485,7 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -495,11 +499,11 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom",
+ "getrandom 0.4.3",
  "libc",
 ]
 
@@ -577,13 +581,19 @@ dependencies = [
 
 [[package]]
 name = "libfuzzer-sys"
-version = "0.4.10"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5037190e1f70cbeef565bd267599242926f724d3b8a9f510fd7e0b540cfa4404"
+checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
 dependencies = [
  "arbitrary",
  "cc",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libwebp-sys"
@@ -618,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "loop9"
@@ -643,15 +653,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmap2"
-version = "0.9.9"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -668,9 +678,9 @@ dependencies = [
 
 [[package]]
 name = "moxcms"
-version = "0.7.10"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80986bbbcf925ebd3be54c26613d861255284584501595cf418320c078945608"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
@@ -709,9 +719,9 @@ checksum = "13d2233c9842d08cfe13f9eac96e207ca6a2ea10b80259ebe8ad0268be27d2af"
 
 [[package]]
 name = "nasm-rs"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34f676553b60ccbb76f41f9ae8f2428dac3f259ff8f1c2468a174778d06a1af9"
+checksum = "706bf8a5e8c8ddb99128c3291d31bd21f4bcde17f0f4c20ec678d85c74faa149"
 dependencies = [
  "jobserver",
  "log",
@@ -722,6 +732,15 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "nom"
@@ -740,11 +759,21 @@ checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "bytemuck",
  "num-traits",
 ]
 
@@ -756,7 +785,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -790,9 +819,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oxipng"
@@ -846,9 +875,9 @@ checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "png"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
  "bitflags",
  "crc32fast",
@@ -868,40 +897,60 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.104"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9695f8df41bb4f3d222c95a67532365f569318332d03d5f3f67f37b20e6ebdf0"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "profiling"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
 dependencies = [
  "profiling-procmacros",
 ]
 
 [[package]]
 name = "profiling-procmacros"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
+checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
-name = "pxfm"
-version = "0.1.27"
+name = "pulp"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
+checksum = "046aa45b989642ec2e4717c8e72d677b13edd831a4d3b6cf37d9a3e54912496a"
 dependencies = [
- "num-traits",
+ "bytemuck",
+ "cfg-if",
+ "libm",
+ "num-complex",
+ "paste",
+ "pulp-wasm-simd-flag",
+ "raw-cpuid",
+ "reborrow",
+ "version_check",
 ]
+
+[[package]]
+name = "pulp-wasm-simd-flag"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d8f70e07b9c3962945a74e59ca1c511bba65b6419468acc217c457d93f3c740"
+
+[[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
 name = "quick-error"
@@ -911,9 +960,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -925,6 +974,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,9 +987,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -956,7 +1011,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -996,9 +1051,9 @@ dependencies = [
 
 [[package]]
 name = "ravif"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef69c1990ceef18a116855938e74793a5f7496ee907562bd0857b6ac734ab285"
+checksum = "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45"
 dependencies = [
  "avif-serialize",
  "imgref",
@@ -1007,6 +1062,15 @@ dependencies = [
  "rav1e",
  "rayon",
  "rgb",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -1028,6 +1092,12 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "reborrow"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
 name = "redox_syscall"
@@ -1068,9 +1138,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "scopeguard"
@@ -1080,15 +1150,15 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd_helpers"
@@ -1101,9 +1171,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1113,9 +1183,20 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "syn"
-version = "2.0.112"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21f182278bf2d2bcb3c88b1b08a37df029d71ce3d3ae26168e3c653b213b99d4"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fac314a64dc9a36e61a9eb4261a5e9bbfbc922b27e518af97bc32b926cf967"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1135,7 +1216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -1143,29 +1224,29 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.0",
 ]
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "v_frame"
@@ -1179,19 +1260,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+name = "version_check"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.106"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1202,9 +1289,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.106"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1212,22 +1299,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.106"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.106"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
@@ -1259,9 +1346,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wyz"
@@ -1280,22 +1367,22 @@ checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.31"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.31"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1315,18 +1402,18 @@ dependencies = [
 
 [[package]]
 name = "zune-jpeg"
-version = "0.5.6"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f520eebad972262a1dde0ec455bce4f8b298b1e5154513de58c114c4c54303e8"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
 ]
 
 [[package]]
 name = "zune-png"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af6dc406edc296451b9597ee98643df8606396066d8f0864682c266eda16f310"
+checksum = "5a321146329f7617ba0a5b26982cba45b7ce78163135aba78be25850aefcea80"
 dependencies = [
  "zune-core",
  "zune-inflate",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "scripts": {
     "build": "node scripts/postbuild-fixup.js --prepare && napi build --platform --release && node scripts/postbuild-fixup.js",
     "test": "npm run test:js && npm run test:rust && npm run test:wasm:package",
-    "test:js": "npm run test:js:specs && npm run test:js:type-safety && npm run test:pack-contract && npm run test:pack-metadata && npm run test:release-policy && npm run test:generated-artifact-policy && npm run test:security-audit-notification && npm run test:benchmark-quality-gate && npm run test:types && npm run test:examples",
+    "test:js": "npm run test:js:specs && npm run test:js:type-safety && npm run test:pack-contract && npm run test:pack-metadata && npm run test:release-policy && npm run test:generated-artifact-policy && npm run test:security-audit-notification && npm run test:cargo-audit-policy && npm run test:benchmark-quality-gate && npm run test:types && npm run test:examples",
     "test:js:specs": "node test/integration/run.js",
     "test:js:type-safety": "node test/type-safety/runtime-type-safety-exit.test.js && node test/type-safety/runtime-type-safety.test.js && node test/unit/target-bytes-search.test.js",
     "test:pack-contract": "node scripts/verify-pack.js",
@@ -57,6 +57,7 @@
     "test:benchmark-quality-gate": "node test/unit/benchmark-quality-gate.test.js",
     "test:generated-artifact-policy": "node test/unit/generated-artifact-policy.test.js",
     "test:security-audit-notification": "node test/unit/security-audit-notification.test.js",
+    "test:cargo-audit-policy": "node test/unit/cargo-audit-policy.test.js",
     "test:types": "tsc --noEmit",
     "test:examples": "node examples/run-all.mjs",
     "test:bench": "npm run test:bench:compare && npm run test:bench:verify && npm run test:bench:smoke",

--- a/scripts/cargo-audit-policy.js
+++ b/scripts/cargo-audit-policy.js
@@ -1,0 +1,131 @@
+'use strict'
+
+const fs = require('node:fs')
+const path = require('node:path')
+const { spawnSync } = require('node:child_process')
+
+const POLICY_PATH = '.github/security/cargo-audit-exceptions.json'
+const ADVISORY_PATTERN = /^RUSTSEC-\d{4}-\d{4}$/
+const REVIEW_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+const AUDITED_LOCKFILES = ['Cargo.lock', 'fuzz/Cargo.lock']
+
+function isValidReviewDate(reviewBy) {
+  if (!REVIEW_DATE_PATTERN.test(reviewBy || '')) return false
+
+  // Round-trip through UTC so JavaScript's permissive date normalization cannot
+  // turn an invalid policy deadline such as 2026-13-40 into a different date.
+  const parsed = new Date(`${reviewBy}T00:00:00Z`)
+  return !Number.isNaN(parsed.valueOf()) && parsed.toISOString().slice(0, 10) === reviewBy
+}
+
+function validateAuditPolicy(policy, now = new Date()) {
+  if (!policy || !Array.isArray(policy.exceptions)) {
+    throw new Error('Cargo audit policy must contain an exceptions array')
+  }
+
+  const today = now.toISOString().slice(0, 10)
+  const advisoryIds = new Set()
+
+  for (const exception of policy.exceptions) {
+    if (!ADVISORY_PATTERN.test(exception.advisory || '')) {
+      throw new Error(`Invalid advisory ID: ${exception.advisory || '<missing>'}`)
+    }
+    if (advisoryIds.has(exception.advisory)) {
+      throw new Error(`Duplicate advisory exception: ${exception.advisory}`)
+    }
+    advisoryIds.add(exception.advisory)
+
+    for (const field of ['package', 'reason', 'impact', 'remediation', 'owner']) {
+      if (typeof exception[field] !== 'string' || exception[field].trim() === '') {
+        throw new Error(`${exception.advisory} must define ${field}`)
+      }
+    }
+
+    if (
+      !Array.isArray(exception.lockfiles) ||
+      exception.lockfiles.length === 0 ||
+      exception.lockfiles.some((lockfile) => !AUDITED_LOCKFILES.includes(lockfile)) ||
+      new Set(exception.lockfiles).size !== exception.lockfiles.length
+    ) {
+      throw new Error(
+        `${exception.advisory} must define unique lockfiles from: ${AUDITED_LOCKFILES.join(', ')}`,
+      )
+    }
+
+    try {
+      const upstream = new URL(exception.upstream)
+      if (upstream.protocol !== 'https:') throw new Error('HTTPS required')
+    } catch {
+      throw new Error(`${exception.advisory} must define a valid HTTPS upstream URL`)
+    }
+
+    if (!isValidReviewDate(exception.reviewBy)) {
+      throw new Error(`${exception.advisory} must define reviewBy as a valid YYYY-MM-DD date`)
+    }
+    if (exception.reviewBy < today) {
+      throw new Error(
+        `${exception.advisory} exception expired on ${exception.reviewBy}; review or remove it`,
+      )
+    }
+  }
+
+  return policy
+}
+
+function loadAuditPolicy(repositoryRoot = path.join(__dirname, '..'), now = new Date()) {
+  const policyPath = path.join(repositoryRoot, POLICY_PATH)
+  const policy = JSON.parse(fs.readFileSync(policyPath, 'utf8'))
+  return validateAuditPolicy(policy, now)
+}
+
+function buildAuditCommands(policy, now = new Date()) {
+  const validatedPolicy = validateAuditPolicy(policy, now)
+  const denyArgs = ['--deny', 'unmaintained', '--deny', 'unsound']
+
+  // Audit both lockfiles explicitly because the fuzz crate has an independent
+  // dependency graph and stale pins there must not be hidden by a clean root audit.
+  return AUDITED_LOCKFILES.map((lockfile) => {
+    // Scope exceptions to the lockfile whose dependency path was reviewed. A
+    // new occurrence in the other graph must fail CI and receive its own assessment.
+    const ignoreArgs = validatedPolicy.exceptions
+      .filter((exception) => exception.lockfiles.includes(lockfile))
+      .flatMap(({ advisory }) => ['--ignore', advisory])
+    const fileArgs = lockfile === 'Cargo.lock' ? [] : ['--file', lockfile]
+    return {
+      label: lockfile,
+      args: ['audit', ...fileArgs, ...denyArgs, ...ignoreArgs],
+    }
+  })
+}
+
+function runAuditPolicy(repositoryRoot = path.join(__dirname, '..')) {
+  const policy = loadAuditPolicy(repositoryRoot)
+
+  for (const command of buildAuditCommands(policy)) {
+    console.log(`Auditing ${command.label}`)
+    const result = spawnSync('cargo', command.args, {
+      cwd: repositoryRoot,
+      stdio: 'inherit',
+    })
+    if (result.error) throw result.error
+    if (result.status !== 0) {
+      throw new Error(`cargo audit failed for ${command.label} with status ${result.status}`)
+    }
+  }
+}
+
+if (require.main === module) {
+  try {
+    runAuditPolicy()
+  } catch (error) {
+    console.error(error.message)
+    process.exitCode = 1
+  }
+}
+
+module.exports = {
+  buildAuditCommands,
+  loadAuditPolicy,
+  runAuditPolicy,
+  validateAuditPolicy,
+}

--- a/src/codecs/avif_safe.rs
+++ b/src/codecs/avif_safe.rs
@@ -650,7 +650,7 @@ mod tests {
             .expect("dimensions beyond limit should fail");
         assert!(err
             .to_string()
-            .contains(&format!("exceed MAX_DIMENSION {}", MAX_DIMENSION)));
+            .contains(&format!("exceed MAX_DIMENSION {MAX_DIMENSION}")));
     }
 
     #[test]

--- a/src/engine/encoder.rs
+++ b/src/engine/encoder.rs
@@ -636,8 +636,8 @@ mod tests {
             let high_quality = encode_avif(&img, 80, None).unwrap();
             let low_quality = encode_avif(&img, 40, None).unwrap();
             // Both outputs should be valid AVIF
-            assert!(high_quality.len() > 0);
-            assert!(low_quality.len() > 0);
+            assert!(!high_quality.is_empty());
+            assert!(!low_quality.is_empty());
         }
 
         #[test]

--- a/src/engine/firewall.rs
+++ b/src/engine/firewall.rs
@@ -568,8 +568,7 @@ mod tests {
         let err_msg = result.unwrap_err().to_string();
         assert!(
             err_msg.contains("EXIF metadata") && err_msg.contains("exceeds limit"),
-            "Expected EXIF size limit message, got: {}",
-            err_msg
+            "Expected EXIF size limit message, got: {err_msg}"
         );
     }
 

--- a/src/engine/memory/estimate.rs
+++ b/src/engine/memory/estimate.rs
@@ -557,9 +557,7 @@ mod tests {
         let cache_len = get_estimate_cache().lock().len();
         assert!(
             cache_len <= ESTIMATE_CACHE_MAX_ENTRIES,
-            "cache size {} should be <= {}",
-            cache_len,
-            ESTIMATE_CACHE_MAX_ENTRIES
+            "cache size {cache_len} should be <= {ESTIMATE_CACHE_MAX_ENTRIES}"
         );
 
         get_estimate_cache().lock().clear();

--- a/src/engine/pool.rs
+++ b/src/engine/pool.rs
@@ -53,12 +53,13 @@ pub(crate) static GLOBAL_THREAD_POOL: OnceLock<std::result::Result<Arc<ThreadPoo
     OnceLock::new();
 
 #[cfg(all(test, feature = "napi"))]
-pub(crate) static GLOBAL_THREAD_POOL: OnceLock<
-    RwLock<Option<std::result::Result<Arc<ThreadPool>, String>>>,
-> = OnceLock::new();
+type TestThreadPoolState = RwLock<Option<std::result::Result<Arc<ThreadPool>, String>>>;
 
 #[cfg(all(test, feature = "napi"))]
-fn pool_cell() -> &'static RwLock<Option<std::result::Result<Arc<ThreadPool>, String>>> {
+pub(crate) static GLOBAL_THREAD_POOL: OnceLock<TestThreadPoolState> = OnceLock::new();
+
+#[cfg(all(test, feature = "napi"))]
+fn pool_cell() -> &'static TestThreadPoolState {
     GLOBAL_THREAD_POOL.get_or_init(|| RwLock::new(None))
 }
 

--- a/src/engine/tasks/encode.rs
+++ b/src/engine/tasks/encode.rs
@@ -44,6 +44,7 @@ define_encode_task! {
 #[cfg(test)]
 impl EncodeTask {
     /// Delegate to TaskContext for backward compatibility with test callers.
+    #[cfg(not(feature = "napi"))]
     pub(crate) fn process_and_encode(
         &self,
         metrics: Option<&mut crate::ProcessingMetrics>,

--- a/test/unit/cargo-audit-policy.test.js
+++ b/test/unit/cargo-audit-policy.test.js
@@ -1,0 +1,97 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+
+const {
+  buildAuditCommands,
+  loadAuditPolicy,
+  validateAuditPolicy,
+} = require('../../scripts/cargo-audit-policy')
+
+const repositoryRoot = path.join(__dirname, '../..')
+
+function test(name, fn) {
+  try {
+    fn()
+    console.log(`ok - ${name}`)
+  } catch (error) {
+    console.error(`not ok - ${name}`)
+    console.error(error)
+    process.exitCode = 1
+  }
+}
+
+test('audits root and fuzz lockfiles with lockfile-scoped exceptions', () => {
+  const policy = loadAuditPolicy(repositoryRoot)
+  const commands = buildAuditCommands(policy, new Date('2026-07-19T00:00:00Z'))
+
+  assert.equal(commands.length, 2)
+  assert.deepEqual(
+    commands.map(({ args }) => args.slice(0, 4)),
+    [
+      ['audit', '--deny', 'unmaintained', '--deny'],
+      ['audit', '--file', 'fuzz/Cargo.lock', '--deny'],
+    ],
+  )
+
+  assert.ok(commands.every(({ args }) => args.includes('unsound')))
+  assert.deepEqual(
+    commands[0].args.filter((argument) => argument.startsWith('RUSTSEC-')),
+    ['RUSTSEC-2024-0436'],
+  )
+  assert.deepEqual(
+    commands[1].args.filter((argument) => argument.startsWith('RUSTSEC-')),
+    ['RUSTSEC-2024-0436'],
+  )
+})
+
+test('rejects expired and malformed audit exceptions', () => {
+  const validException = {
+    advisory: 'RUSTSEC-2024-0436',
+    package: 'paste',
+    reason: 'Blocked by the production AVIF dependency path.',
+    impact: 'Compile-time proc macro only.',
+    remediation: 'Upgrade the AVIF dependency path.',
+    owner: 'lazy-image maintainers',
+    upstream: 'https://github.com/xiph/rav1e/issues/3418',
+    reviewBy: '2026-10-31',
+    lockfiles: ['Cargo.lock'],
+  }
+
+  assert.throws(
+    () =>
+      validateAuditPolicy(
+        { exceptions: [{ ...validException, reviewBy: '2026-07-18' }] },
+        new Date('2026-07-19T00:00:00Z'),
+      ),
+    /expired/,
+  )
+  assert.throws(
+    () =>
+      validateAuditPolicy(
+        { exceptions: [{ ...validException, upstream: 'not-a-url' }] },
+        new Date('2026-07-19T00:00:00Z'),
+      ),
+    /upstream/,
+  )
+  assert.throws(
+    () =>
+      validateAuditPolicy(
+        { exceptions: [{ ...validException, reviewBy: '2026-13-40' }] },
+        new Date('2026-07-19T00:00:00Z'),
+      ),
+    /reviewBy/,
+  )
+})
+
+test('security workflow delegates Cargo auditing to the tested policy runner', () => {
+  const workflow = fs.readFileSync(
+    path.join(repositoryRoot, '.github/workflows/security.yml'),
+    'utf8',
+  )
+
+  assert.match(workflow, /node scripts\/cargo-audit-policy\.js/)
+  assert.doesNotMatch(workflow, /--ignore RUSTSEC-/)
+})

--- a/tests/edge_cases.rs
+++ b/tests/edge_cases.rs
@@ -210,8 +210,7 @@ mod corrupted_image_tests {
         let err = result.unwrap_err().to_string();
         assert!(
             err.contains("EOI"),
-            "expected EOI error for truncated JPEG, got: {}",
-            err
+            "expected EOI error for truncated JPEG, got: {err}"
         );
     }
 

--- a/tests/error_tests.rs
+++ b/tests/error_tests.rs
@@ -664,8 +664,7 @@ fn test_error_code_as_str_exhaustive() {
         assert_eq!(
             code.as_str(),
             *expected,
-            "ErrorCode::{:?} should map to {expected}",
-            code
+            "ErrorCode::{code:?} should map to {expected}"
         );
     }
 }
@@ -703,9 +702,7 @@ fn test_error_code_category_exhaustive() {
         assert_eq!(
             code.category(),
             *expected_cat,
-            "ErrorCode::{:?} should have category {:?}",
-            code,
-            expected_cat
+            "ErrorCode::{code:?} should have category {expected_cat:?}"
         );
     }
 }
@@ -743,15 +740,13 @@ fn test_error_code_is_recoverable_exhaustive() {
     for code in &recoverable_codes {
         assert!(
             code.is_recoverable(),
-            "ErrorCode::{:?} should be recoverable",
-            code
+            "ErrorCode::{code:?} should be recoverable"
         );
     }
     for code in &non_recoverable_codes {
         assert!(
             !code.is_recoverable(),
-            "ErrorCode::{:?} should NOT be recoverable",
-            code
+            "ErrorCode::{code:?} should NOT be recoverable"
         );
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -31,7 +31,7 @@ mod tests {
     // pointer for success-path tests. This keeps coverage on the `dimensions` API
     // without requiring a real Node.js runtime in cargo test.
     fn dummy_env() -> Env {
-        unsafe { Env::from_raw(std::ptr::null_mut()) }
+        Env::from_raw(std::ptr::null_mut())
     }
 
     #[test]


### PR DESCRIPTION
## なぜこの修正が必要か

Issue #764 の再監査で、ルートと fuzz の Rust 依存グラフに、修正版がある `rand` / `memmap2` / `anyhow`、除去可能な `core2`、上流制約で直ちに除去できない `paste` の advisory が残っていました。

従来の Security workflow はルート `Cargo.lock` だけを監査し、3件の advisory を期限・担当・依存グラフの区別なくインラインで無期限 ignore していました。そのため、fuzz 側の古い lockfile と、新規 warning の混入を継続的に検知できませんでした。

## 変更内容

### 1. 解消可能な advisory を依存更新で除去

- `rand 0.8.5 -> 0.8.6`、`rand 0.9.2 -> 0.9.4`
- fuzz の `memmap2 0.9.9 -> 0.9.11`、`anyhow 1.0.100 -> 1.0.104`
- `bitstream-io 4.9.0 -> 4.10.0` により、保守停止・yanked の `core2` を root/fuzz の両グラフから除去
- 独立した `fuzz/Cargo.lock` を再生成し、MSRV 1.88 で全target checkを実施

### 2. 残る例外を期限付き・lockfile単位で管理

- `.github/security/cargo-audit-exceptions.json` を唯一の例外台帳として追加
- 残る `RUSTSEC-2024-0436` (`paste`) に、理由、影響評価、修正方針、担当、上流URL、対象lockfile、再評価期限 `2026-10-19` を記録
- `scripts/cargo-audit-policy.js` が root/fuzz をそれぞれ `--deny unmaintained --deny unsound` で監査
- 期限切れ、不正日付、重複advisory、不正URL、不正lockfile、必須メタデータ欠落をCIで拒否
- 例外をlockfile単位に適用し、別グラフへの新規混入を既存ignoreで隠さない

### 3. CIとドキュメントを同期

- Security workflow のインラインignoreを、テスト済みポリシーrunnerへ置換
- `npm test` に監査ポリシーのunit testを追加
- `SECURITY.md` に例外登録・期限・scopeの運用を明文化
- Issueのstrict Clippy完了条件で顕在化した既存警告を、挙動を変えない最小変更で解消

## 変更前と変更後

| 観点 | 変更前 | 変更後 |
| --- | --- | --- |
| 監査対象 | rootのみ | root + fuzz |
| 修正版のあるwarning | ignoreに混在 | 修正版へ更新 |
| 残存例外 | workflow内の無期限コメント | 機械検証される期限付き台帳 |
| 例外scope | 全監査で暗黙共有 | lockfileごとに明示 |
| 期限検証 | なし | 実在日付を検証し、期限切れで失敗 |

## TDD・検証

日付検証を含むポリシー要件は、失敗テストを確認してから実装しました。

- `cargo +1.88.0 fmt --all --check`
- `cargo +1.88.0 clippy --all-targets --all-features -- -D warnings`
- `cargo +1.88.0 clippy --all-targets --no-default-features -- -D warnings`
- `cargo +1.88.0 check --manifest-path fuzz/Cargo.toml --all-targets`
- `node scripts/cargo-audit-policy.js`
- `npm run build`
- `npm test`
- `npm audit --audit-level=high`
- `npm run test:bench`
- `git diff --check`

すべて成功しています。canonical benchmark のJPEG出力は 4.5MB PNGケースで sharp 比 -20.0%、100KB JPEGケースで -18.0% を維持しました。

Closes #764
