### PR TITLE
fix(wasm): nativeとWasmのエラー契約を統一する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **BREAKING (Wasm error contract)**: aligned
+  `@alberteinshutoin/lazy-image-wasm` with the native error taxonomy. Categories
+  are now `UserError`, `CodecError`, `ResourceLimit`, and `InternalBug`.
+  Remapped codes: `E101→E400`, `E102→E131`, `E103→E111`, `E104→E123`,
+  `E105→E122`, fit-related `E202→E203/E204`, `E201→E502`, abort
+  `E204→E500`, timeout `E205→E123`, `E301/E302→E400`, encode
+  `E303→E300`, unavailable Blob `E303→E501`, and validation `E402→E400`.
+
 ---
 
 ## [0.16.0] - 2026-06-06

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -13,6 +13,10 @@ lazy-image uses a 4-tier error taxonomy to enable proper error handling in JavaS
 | **ResourceLimit** | Memory/time/dimension limits | Sometimes | Dimension exceeds limit, file I/O errors (disk full, memory pressure) |
 | **InternalBug** | Library bugs (should not happen) | No | Internal panic, unexpected state |
 
+Native codes use `E1xx` through `E4xx` and `E9xx`. `E5xx` is reserved for
+Wasm-only runtime boundary failures. When native and Wasm expose the same
+code, the meaning and category must be identical.
+
 ## Panic Policy
 
 All codec entry points (decode/encode/ICC embedding) execute inside a unified

--- a/docs/WASM_PACKAGE_API.md
+++ b/docs/WASM_PACKAGE_API.md
@@ -193,16 +193,30 @@ result, unless the runtime can report them cheaply and accurately.
 
 ## Errors
 
-The Wasm package should keep the same broad error taxonomy as the native
-package:
+The Wasm package uses the native package as the source of truth for error
+codes and categories. A shared code always has the same meaning in both
+packages. The `E5xx` range is reserved for failures that exist only at a Wasm
+runtime boundary.
 
-| Range | Category | Wasm examples |
-|---|---|---|
-| `E1xx` | Input | unsupported input type, corrupt image, unsupported input format |
-| `E2xx` | Processing | invalid resize, byte-budget search failure in strict mode |
-| `E3xx` | Output | unsupported output format, encode failure |
-| `E4xx` | Config | invalid profile, invalid policy, invalid limits |
-| `E9xx` | Internal | Wasm initialization failure, unexpected codec panic boundary |
+| Code | Meaning | Category | Previous Wasm code |
+|---|---|---|---|
+| `E111` | Unsupported input image format | `CodecError` | `E103` |
+| `E122` | Input exceeds the pixel limit | `ResourceLimit` | `E105` |
+| `E123` | Input-byte or timeout policy violation | `ResourceLimit` | `E104` / `E205` |
+| `E131` | Codec failed to decode the input | `CodecError` | `E102` |
+| `E203` | Cover resize is missing a required dimension | `UserError` | `E202` |
+| `E204` | Unsupported resize fit | `UserError` | `E202` |
+| `E300` | Codec failed to encode the output | `CodecError` | `E303` |
+| `E400` | Invalid input type, option, output format, or output kind | `UserError` | `E101` / `E301` / `E302` / `E402` |
+| `E401` | Invalid Wasm profile | `UserError` | `E401` |
+| `E500` | Operation aborted through `AbortSignal` | `UserError` | `E204` |
+| `E501` | Requested output kind is unavailable in the runtime | `ResourceLimit` | `E303` |
+| `E502` | Strict target-byte budget cannot be met above the quality floor | `ResourceLimit` | `E201` |
+| `E901` | Codec returned an invalid buffer type | `InternalBug` | `E901` |
+
+`UserError` and `ResourceLimit` are recoverable by default. `CodecError` and
+`InternalBug` are not. Callers should branch on both `code` and `category`
+instead of deriving a category from the numeric range.
 
 Native filesystem errors such as file-not-found, mmap failure, and file-write
 failure must not appear in the browser/Edge API.
@@ -210,7 +224,7 @@ failure must not appear in the browser/Edge API.
 ```typescript
 interface LazyImageWasmError extends Error {
   code: string;
-  category: 'Input' | 'Processing' | 'Output' | 'Config' | 'Internal';
+  category: 'UserError' | 'CodecError' | 'ResourceLimit' | 'InternalBug';
   recoverable: boolean;
   recoveryHint?: string;
 }

--- a/packages/lazy-image-wasm/README.md
+++ b/packages/lazy-image-wasm/README.md
@@ -41,7 +41,11 @@ const result = await optimizer.optimizeUpload(new Uint8Array(await request.array
 
 `examples/edge.mjs` (shipped in this package) is a small runtime-safe pattern:
 it caches one optimizer per isolate, reads `@jsquash` Wasm bindings from
-`env.JSQUASH_*` keys, and maps `LazyImageWasmError` input errors to HTTP 400.
+`env.JSQUASH_*` keys, and maps caller-correctable `LazyImageWasmError` values
+to HTTP 400. Wasm errors use the native package categories
+(`UserError`, `CodecError`, `ResourceLimit`, `InternalBug`); see
+[`docs/WASM_PACKAGE_API.md`](https://github.com/albert-einshutoin/lazy-image/blob/main/docs/WASM_PACKAGE_API.md#errors) for the
+cross-package code table.
 
 Copy the file into your Worker project and change its relative imports to the
 package specifiers (`@alberteinshutoin/lazy-image-wasm/edge` and

--- a/packages/lazy-image-wasm/browser.js
+++ b/packages/lazy-image-wasm/browser.js
@@ -167,11 +167,11 @@ async function decodeImage(bytes, inputFormat) {
     if (inputFormat === 'webp') return await webpDecode(buffer);
   } catch (error) {
     if (error instanceof LazyImageWasmError) throw error;
-    throwWasmError('E102', `Failed to decode ${inputFormat} input: ${error.message}`, {
+    throwWasmError('E131', `Failed to decode ${inputFormat} input: ${error.message}`, {
       recoveryHint: 'Check that the input image is not corrupt.',
     });
   }
-  throwWasmError('E103', `Unsupported input format: ${inputFormat}`);
+  throwWasmError('E111', `Unsupported input format: ${inputFormat}`);
 }
 
 async function encodeWithPolicy(imageData, options, now, totalStart) {
@@ -226,7 +226,7 @@ async function encodeWithPolicy(imageData, options, now, totalStart) {
   const selected = bestUnderBudget ?? smallest;
   const budgetMet = selected.bytesOut <= options.targetBytes;
   if (!budgetMet && options.qualityFloorPolicy === 'strict') {
-    throwWasmError('E201', `Unable to meet targetBytes=${options.targetBytes} within quality floor.`, {
+    throwWasmError('E502', `Unable to meet targetBytes=${options.targetBytes} within quality floor.`, {
       recoveryHint: 'Increase targetBytes, reduce max dimensions, or use qualityFloorPolicy: "best-effort".',
     });
   }
@@ -257,7 +257,7 @@ async function encodeAtQuality(imageData, format, quality) {
     }
   } catch (error) {
     if (error instanceof LazyImageWasmError) throw error;
-    throwWasmError('E303', `Failed to encode ${format} output: ${error.message}`);
+    throwWasmError('E300', `Failed to encode ${format} output: ${error.message}`);
   }
-  throwWasmError('E301', `Unsupported output format: ${format}`);
+  throwWasmError('E400', `Unsupported output format: ${format}`);
 }

--- a/packages/lazy-image-wasm/examples/edge.mjs
+++ b/packages/lazy-image-wasm/examples/edge.mjs
@@ -68,7 +68,11 @@ export async function handleOptimizeRequest(request, env = {}) {
     });
   } catch (error) {
     if (error instanceof LazyImageWasmError) {
-      const isCallerError = error.category === 'UserError' || error.code === 'E111';
+      // E111/E131 are CodecError in the shared native taxonomy, but at this
+      // HTTP boundary they still describe caller-supplied input. Keep encoder
+      // CodecErrors such as E300 as server failures.
+      const isCallerError =
+        error.category === 'UserError' || error.code === 'E111' || error.code === 'E131';
       return new Response(`[${error.code}] ${error.message}`, {
         status: isCallerError ? 400 : 500,
       });

--- a/packages/lazy-image-wasm/examples/edge.mjs
+++ b/packages/lazy-image-wasm/examples/edge.mjs
@@ -68,7 +68,7 @@ export async function handleOptimizeRequest(request, env = {}) {
     });
   } catch (error) {
     if (error instanceof LazyImageWasmError) {
-      const isCallerError = error.category === 'Input' || error.category === 'Config';
+      const isCallerError = error.category === 'UserError' || error.code === 'E111';
       return new Response(`[${error.code}] ${error.message}`, {
         status: isCallerError ? 400 : 500,
       });

--- a/packages/lazy-image-wasm/shared.d.ts
+++ b/packages/lazy-image-wasm/shared.d.ts
@@ -5,6 +5,11 @@ export type WasmResizeFit = 'inside' | 'cover' | 'fill';
 export type WasmQualityFloorPolicy = 'best-effort' | 'strict';
 export type WasmProfile = 'upload-safe' | 'avatar' | 'attachment' | 'balanced';
 export type WasmRuntime = 'browser' | 'browser-worker' | 'edge-isolate';
+export type WasmErrorCategory =
+  | 'UserError'
+  | 'CodecError'
+  | 'ResourceLimit'
+  | 'InternalBug';
 
 export interface CreateUploadOptimizerOptions {
   wasmModules?: {
@@ -82,9 +87,18 @@ export interface WasmProcessingMetrics {
 
 export declare class LazyImageWasmError extends Error {
   code: string;
-  category: 'Input' | 'Processing' | 'Output' | 'Config' | 'Internal';
+  category: WasmErrorCategory;
   recoverable: boolean;
   recoveryHint?: string;
 }
+
+export declare const ERROR_CATEGORIES: Readonly<{
+  UserError: 'UserError';
+  CodecError: 'CodecError';
+  ResourceLimit: 'ResourceLimit';
+  InternalBug: 'InternalBug';
+}>;
+
+export declare function categoryForCode(code: string): WasmErrorCategory;
 
 export declare const VERSION: string;

--- a/packages/lazy-image-wasm/shared.js
+++ b/packages/lazy-image-wasm/shared.js
@@ -1,12 +1,31 @@
 export const VERSION = '0.16.0';
 
-export const ERROR_CATEGORIES = {
-  Input: 'Input',
-  Processing: 'Processing',
-  Output: 'Output',
-  Config: 'Config',
-  Internal: 'Internal',
-};
+export const ERROR_CATEGORIES = Object.freeze({
+  UserError: 'UserError',
+  CodecError: 'CodecError',
+  ResourceLimit: 'ResourceLimit',
+  InternalBug: 'InternalBug',
+});
+
+// Keep this table explicit instead of deriving categories from number ranges.
+// Native codes within the same range intentionally have different recovery
+// semantics, and upload preflight must make the same decision as server-side
+// processing when callers branch on `code` and `category`.
+const ERROR_CODE_CATEGORIES = Object.freeze({
+  E111: ERROR_CATEGORIES.CodecError,
+  E122: ERROR_CATEGORIES.ResourceLimit,
+  E123: ERROR_CATEGORIES.ResourceLimit,
+  E131: ERROR_CATEGORIES.CodecError,
+  E203: ERROR_CATEGORIES.UserError,
+  E204: ERROR_CATEGORIES.UserError,
+  E300: ERROR_CATEGORIES.CodecError,
+  E400: ERROR_CATEGORIES.UserError,
+  E401: ERROR_CATEGORIES.UserError,
+  E500: ERROR_CATEGORIES.UserError,
+  E501: ERROR_CATEGORIES.ResourceLimit,
+  E502: ERROR_CATEGORIES.ResourceLimit,
+  E901: ERROR_CATEGORIES.InternalBug,
+});
 
 const FORMATS = new Set(['jpeg', 'webp']);
 const OUTPUT_KINDS = new Set(['blob', 'arrayBuffer', 'uint8Array']);
@@ -41,7 +60,10 @@ export class LazyImageWasmError extends Error {
     this.name = 'LazyImageWasmError';
     this.code = code;
     this.category = options.category ?? categoryForCode(code);
-    this.recoverable = options.recoverable ?? this.category !== ERROR_CATEGORIES.Internal;
+    this.recoverable =
+      options.recoverable ??
+      (this.category === ERROR_CATEGORIES.UserError ||
+        this.category === ERROR_CATEGORIES.ResourceLimit);
     if (options.recoveryHint) {
       this.recoveryHint = options.recoveryHint;
     }
@@ -49,11 +71,7 @@ export class LazyImageWasmError extends Error {
 }
 
 export function categoryForCode(code) {
-  if (/^E1\d\d$/.test(code)) return ERROR_CATEGORIES.Input;
-  if (/^E2\d\d$/.test(code)) return ERROR_CATEGORIES.Processing;
-  if (/^E3\d\d$/.test(code)) return ERROR_CATEGORIES.Output;
-  if (/^E4\d\d$/.test(code)) return ERROR_CATEGORIES.Config;
-  return ERROR_CATEGORIES.Internal;
+  return ERROR_CODE_CATEGORIES[code] ?? ERROR_CATEGORIES.InternalBug;
 }
 
 export function throwWasmError(code, message, options) {
@@ -71,7 +89,7 @@ export async function inputToBytes(input) {
     const buffer = await input.arrayBuffer();
     return new Uint8Array(buffer);
   }
-  throwWasmError('E101', 'Unsupported input type for Wasm upload optimization.', {
+  throwWasmError('E400', 'Unsupported input type for Wasm upload optimization.', {
     recoveryHint: 'Pass a File, Blob, ArrayBuffer, or Uint8Array.',
   });
 }
@@ -106,7 +124,7 @@ export function detectInputFormat(bytes) {
   ) {
     return 'webp';
   }
-  throwWasmError('E103', 'Unsupported input image format for the Wasm MVP.', {
+  throwWasmError('E111', 'Unsupported input image format for the Wasm MVP.', {
     recoveryHint: 'Use JPEG, PNG, or WebP input for the first upload-preflight slice.',
   });
 }
@@ -129,24 +147,24 @@ export function normalizeOptions(options = {}, runtimeDefaults = {}) {
   };
 
   if (!FORMATS.has(normalized.format)) {
-    throwWasmError('E301', `Unsupported Wasm output format: ${normalized.format}`, {
+    throwWasmError('E400', `Unsupported Wasm output format: ${normalized.format}`, {
       recoveryHint: 'Use "jpeg" or "webp". AVIF is deferred for the MVP.',
     });
   }
   if (!OUTPUT_KINDS.has(normalized.output)) {
-    throwWasmError('E302', `Unsupported Wasm output kind: ${normalized.output}`);
+    throwWasmError('E400', `Unsupported Wasm output kind: ${normalized.output}`);
   }
   if (!FITS.has(normalized.fit)) {
-    throwWasmError('E202', `Unsupported resize fit: ${normalized.fit}`);
+    throwWasmError('E204', `Unsupported resize fit: ${normalized.fit}`);
   }
   if (!FLOOR_POLICIES.has(normalized.qualityFloorPolicy)) {
-    throwWasmError('E402', `Unsupported qualityFloorPolicy: ${normalized.qualityFloorPolicy}`);
+    throwWasmError('E400', `Unsupported qualityFloorPolicy: ${normalized.qualityFloorPolicy}`);
   }
 
   normalized.minQuality = normalizeQuality(normalized.minQuality, 'minQuality');
   normalized.maxQuality = normalizeQuality(normalized.maxQuality, 'maxQuality');
   if (normalized.minQuality > normalized.maxQuality) {
-    throwWasmError('E402', 'minQuality must be less than or equal to maxQuality.');
+    throwWasmError('E400', 'minQuality must be less than or equal to maxQuality.');
   }
 
   for (const key of ['maxWidth', 'maxHeight', 'targetBytes']) {
@@ -168,14 +186,14 @@ export function normalizeOptions(options = {}, runtimeDefaults = {}) {
 
 export function validateInputLimits(bytes, options) {
   if (options.limits.maxBytes !== undefined && bytes.byteLength > options.limits.maxBytes) {
-    throwWasmError('E104', `Input exceeds limits.maxBytes (${options.limits.maxBytes}).`);
+    throwWasmError('E123', `Input exceeds limits.maxBytes (${options.limits.maxBytes}).`);
   }
 }
 
 export function validatePixelLimits(width, height, options) {
   const pixels = width * height;
   if (options.limits.maxPixels !== undefined && pixels > options.limits.maxPixels) {
-    throwWasmError('E105', `Input exceeds limits.maxPixels (${options.limits.maxPixels}).`);
+    throwWasmError('E122', `Input exceeds limits.maxPixels (${options.limits.maxPixels}).`);
   }
 }
 
@@ -188,7 +206,7 @@ export function resolveTargetDimensions(width, height, options) {
 
   if (options.fit === 'cover') {
     if (!maxWidth || !maxHeight) {
-      throwWasmError('E202', 'cover fit requires both maxWidth and maxHeight.');
+      throwWasmError('E203', 'cover fit requires both maxWidth and maxHeight.');
     }
     return {
       width: maxWidth,
@@ -214,7 +232,7 @@ export function resolveTargetDimensions(width, height, options) {
 
 export function checkAbort(signal) {
   if (signal?.aborted) {
-    throwWasmError('E204', 'Wasm upload optimization was aborted.', {
+    throwWasmError('E500', 'Wasm upload optimization was aborted.', {
       recoverable: true,
     });
   }
@@ -228,7 +246,7 @@ export function checkTimeout(startMs, stage, options, now) {
 
   const elapsedMs = nowMs(now) - startMs;
   if (elapsedMs > timeoutMs) {
-    throwWasmError('E205', `Wasm upload optimization exceeded limits.timeoutMs (${timeoutMs}) at ${stage}.`, {
+    throwWasmError('E123', `Wasm upload optimization exceeded limits.timeoutMs (${timeoutMs}) at ${stage}.`, {
       recoveryHint:
         'Increase limits.timeoutMs, reduce max dimensions, or use AbortController for external cancellation.',
     });
@@ -256,7 +274,7 @@ export function makeResultData(arrayBuffer, output, format) {
     return new Uint8Array(exact);
   }
   if (typeof Blob !== 'function') {
-    throwWasmError('E303', 'Blob output is not available in this runtime.', {
+    throwWasmError('E501', 'Blob output is not available in this runtime.', {
       recoveryHint: 'Use output: "arrayBuffer" or output: "uint8Array".',
     });
   }
@@ -270,7 +288,7 @@ export function nowMs(now) {
 function normalizeQuality(value, key) {
   const quality = value === undefined ? undefined : Number(value);
   if (!Number.isInteger(quality) || quality < 1 || quality > 100) {
-    throwWasmError('E402', `${key} must be an integer from 1 to 100.`);
+    throwWasmError('E400', `${key} must be an integer from 1 to 100.`);
   }
   return quality;
 }
@@ -278,7 +296,7 @@ function normalizeQuality(value, key) {
 function normalizePositiveInteger(value, key) {
   const normalized = Number(value);
   if (!Number.isInteger(normalized) || normalized <= 0) {
-    throwWasmError('E402', `${key} must be a positive integer.`);
+    throwWasmError('E400', `${key} must be a positive integer.`);
   }
   return normalized;
 }

--- a/packages/lazy-image-wasm/test/run.mjs
+++ b/packages/lazy-image-wasm/test/run.mjs
@@ -343,4 +343,15 @@ await test('edge example handler guards method and maps input errors to HTTP sta
   );
   assert.equal(badResponse.status, 400);
   assert.match(await badResponse.text(), /^\[E111\]/);
+
+  const corruptJpegResponse = await edgeExampleHandler.fetch(
+    new Request('http://localhost/', {
+      method: 'POST',
+      body: new Uint8Array([0xff, 0xd8, 0xff, 0x00, 0x00, 0x00]),
+      duplex: 'half',
+    }),
+    env
+  );
+  assert.equal(corruptJpegResponse.status, 400);
+  assert.match(await corruptJpegResponse.text(), /^\[E131\]/);
 });

--- a/packages/lazy-image-wasm/test/run.mjs
+++ b/packages/lazy-image-wasm/test/run.mjs
@@ -7,7 +7,12 @@ import { fileURLToPath } from 'node:url';
 import { createUploadOptimizer } from '../browser.js';
 import { createUploadOptimizer as createEdgeUploadOptimizer } from '../edge.js';
 import edgeExampleHandler from '../examples/edge.mjs';
-import { LazyImageWasmError, VERSION } from '../shared.js';
+import {
+  categoryForCode,
+  ERROR_CATEGORIES,
+  LazyImageWasmError,
+  VERSION,
+} from '../shared.js';
 
 if (typeof globalThis.ImageData !== 'function') {
   globalThis.ImageData = class ImageData {
@@ -66,6 +71,63 @@ const optimizer = await createUploadOptimizer({
 
 await test('exports the workspace package version', async () => {
   assert.equal(VERSION, packageJson.version);
+});
+
+await test('uses the native error category vocabulary and code semantics', async () => {
+  assert.deepEqual(ERROR_CATEGORIES, {
+    UserError: 'UserError',
+    CodecError: 'CodecError',
+    ResourceLimit: 'ResourceLimit',
+    InternalBug: 'InternalBug',
+  });
+
+  const expectedSemantics = {
+    E111: ['CodecError', false],
+    E122: ['ResourceLimit', true],
+    E123: ['ResourceLimit', true],
+    E131: ['CodecError', false],
+    E203: ['UserError', true],
+    E204: ['UserError', true],
+    E300: ['CodecError', false],
+    E400: ['UserError', true],
+    E401: ['UserError', true],
+    E500: ['UserError', true],
+    E501: ['ResourceLimit', true],
+    E502: ['ResourceLimit', true],
+    E901: ['InternalBug', false],
+  };
+
+  for (const [code, [category, recoverable]] of Object.entries(expectedSemantics)) {
+    assert.equal(categoryForCode(code), category, `${code} must use native category semantics`);
+    assert.equal(
+      new LazyImageWasmError(code, 'test').recoverable,
+      recoverable,
+      `${code} must use native recoverability semantics`
+    );
+  }
+});
+
+await test('keeps every non-E5xx Wasm throw code in the native code registry', async () => {
+  const [nativeErrorSource, sharedSource, browserSource] = await Promise.all([
+    fs.readFile(path.join(repoRoot, 'src', 'error.rs'), 'utf8'),
+    fs.readFile(path.join(packageRoot, 'shared.js'), 'utf8'),
+    fs.readFile(path.join(packageRoot, 'browser.js'), 'utf8'),
+  ]);
+  const nativeCodes = new Set(
+    [...nativeErrorSource.matchAll(/=>\s*"(E\d{3})"/g)].map((match) => match[1])
+  );
+  const wasmCodes = new Set(
+    [...`${sharedSource}\n${browserSource}`.matchAll(/throwWasmError\('(E\d{3})'/g)].map(
+      (match) => match[1]
+    )
+  );
+
+  for (const code of wasmCodes) {
+    assert(
+      nativeCodes.has(code) || /^E5\d{2}$/.test(code),
+      `${code} must match a native code or use the Wasm-reserved E5xx range`
+    );
+  }
 });
 
 await test('optimizes JPEG input to JPEG with a target byte budget', async () => {
@@ -135,7 +197,7 @@ await test('cover fit produces exact target dimensions', async () => {
   assert.equal(result.metrics.heightOut, 180);
 });
 
-await test('strict target byte policy fails with structured processing error', async () => {
+await test('strict target byte policy fails with a Wasm resource-limit error', async () => {
   const input = await fixture('test_38kb_input.jpg');
   await assert.rejects(
     () =>
@@ -147,11 +209,14 @@ await test('strict target byte policy fails with structured processing error', a
         qualityFloorPolicy: 'strict',
         output: 'arrayBuffer',
       }),
-    (error) => error instanceof LazyImageWasmError && error.code === 'E201' && error.category === 'Processing'
+    (error) =>
+      error instanceof LazyImageWasmError &&
+      error.code === 'E502' &&
+      error.category === 'ResourceLimit'
   );
 });
 
-await test('limits.timeoutMs fails with structured processing error', async () => {
+await test('limits.timeoutMs uses the native firewall violation contract', async () => {
   let fakeNow = 0;
   const timeoutOptimizer = await createUploadOptimizer({
     wasmModules,
@@ -172,18 +237,25 @@ await test('limits.timeoutMs fails with structured processing error', async () =
           timeoutMs: 1,
         },
       }),
-    (error) => error instanceof LazyImageWasmError && error.code === 'E205' && error.category === 'Processing'
+    (error) =>
+      error instanceof LazyImageWasmError &&
+      error.code === 'E123' &&
+      error.category === 'ResourceLimit'
   );
 });
 
-await test('unsupported input format fails with E103', async () => {
+await test('unsupported input format fails with native E111 semantics', async () => {
   await assert.rejects(
     () =>
       optimizer.optimizeUpload(new Uint8Array([1, 2, 3, 4]), {
         format: 'jpeg',
         output: 'arrayBuffer',
       }),
-    (error) => error instanceof LazyImageWasmError && error.code === 'E103' && error.category === 'Input'
+    (error) =>
+      error instanceof LazyImageWasmError &&
+      error.code === 'E111' &&
+      error.category === 'CodecError' &&
+      error.recoverable === false
   );
 });
 
@@ -270,5 +342,5 @@ await test('edge example handler guards method and maps input errors to HTTP sta
     env
   );
   assert.equal(badResponse.status, 400);
-  assert.match(await badResponse.text(), /^\[E103\]/);
+  assert.match(await badResponse.text(), /^\[E111\]/);
 });


### PR DESCRIPTION
## なぜこの修正が必要か

Closes #675

Wasm upload preflightとnative server processingを組み合わせる推奨構成で、同じExxxが別の意味を持ち、category語彙も異なっていました。利用者がerror code/categoryで分岐すると、入力エラー・codec失敗・resource limitを誤分類します。

## 変更前

- Wasm category: Input / Processing / Output / Config / Internal
- code rangeからcategoryを推測
- E101、E202、E301、E402などがnativeと別の意味
- browser.js側のE102/E201/E303もnativeと衝突
- Wasm code表が公開docsに存在しない

## 変更後

- categoryをnativeと同じUserError / CodecError / ResourceLimit / InternalBugへ統一
- code→categoryを明示表にし、nativeの回復可能性と一致
- 共通エラーはnative codeへ統一
  - unsupported format E111
  - pixel limit E122
  - policy timeout/maxBytes E123
  - decode failure E131
  - resize dimensions/fit E203/E204
  - encode failure E300
  - invalid argument E400
- Wasm固有境界をE5xxへ分離
  - E500 AbortSignal
  - E501 runtimeにBlobがない
  - E502 strict targetBytes未達
- Edge exampleはE111を引き続きHTTP 400として扱う
- TypeScript型、Wasm API docs、ERROR_CODES、package README、CHANGELOGを同期

## TDD

最初に次の失敗を再現しました。

- category語彙がnativeと一致しない
- 非E5xx Wasm codeがnative registryに存在しない
- unsupported input、timeout、strict byte budgetが旧code/categoryを返す

その後、実装修正で同じテストをgreenにしています。同期テストはsrc/error.rsのcode集合を読み、将来の独自採番driftも検出します。

## 追加で見つけて修正した範囲

Issue本文のshared.jsだけでなく、browser.jsにもE102/E201/E303の衝突があったため、decode E131、encode E300、target budget E502として同時に修正しました。

## 互換性と意思決定

Wasm error code/categoryを利用しているcallerには移行が必要です。CHANGELOGのUnreleasedに旧→新対応をBREAKINGとして記録しました。

現行SEMVER_POLICYではBREAKING markerは次のmajor boundaryを要求します。本PRではversion bump、npm publish、GitHub Releaseは行いません。リリースversionの決定は別gateです。

## 検証

- npm run build
- npm test
  - JS integration 27 files
  - Rust 273 unit + integration/property suites
  - Wasm package tests
  - tsc --noEmit
  - pack contract / examples
- npm audit --audit-level=high: 0 vulnerabilities
- cargo audit: vulnerability 0、既知の許容済みunmaintained warning 1件
- git diff --check

## セキュリティ

- 新規依存なし
- input/codec/resource/internalの分類をnativeと一致させ、upload preflightで誤った復旧分岐をしないようにした
- unknown codeはInternalBugとしてfail closedする

## スコープ外

- native error codeの変更
- package version bump
- npm publish / GitHub Release
- Wasm codecやruntime adapterの追加