### PR TITLE
fix(docs): Firewall無効時の100 MP上限を正しく記載する

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -82,7 +82,8 @@ For vulnerability reporting and supported versions, see [SECURITY.md](../SECURIT
 
 ### Decompression bomb protection
 
-- Max dimension 32768×32768 by default.
+- Always-on decode limits: 32,768 pixels per side and 100 MP total, even when
+  Image Firewall sanitization is not enabled.
 - Progressive decode aborts on invalid data.
 - Allocation bounded by the Rust runtime.
 
@@ -110,12 +111,17 @@ Input sanitization for untrusted images (decompression bombs, slowloris-style in
 
 | Limit       | Strict   | Lenient  | No firewall   |
 |------------|----------|----------|----------------|
-| Max pixels | 40 MP    | 75 MP    | 1 GP           |
+| Max pixels | 40 MP    | 75 MP    | 100 MP         |
 | Max bytes  | 32 MB    | 48 MB    | Unlimited      |
 | Timeout¹   | 5 s      | 30 s     | Unlimited      |
 | ICC        | Blocked  | 512 KB   | Allowed        |
 
 ¹ **Best-effort, inter-stage.** Timeout is checked between decode → process → encode stages, not during them. A single slow codec call (e.g. large AVIF encode) can exceed the limit. For hard wall-clock guarantees wrap the call in an external watchdog (`setTimeout` / `AbortController`).
+
+The no-firewall column removes the policy-specific input-byte and timeout
+limits; it does not disable the always-on 100 MP total-pixel limit or the
+32,768-pixel per-side decode limit. `.limits({ maxPixels: 0 })` disables only
+the additional custom policy limit, not these global decode safety limits.
 
 Override with `.limits({ maxPixels, maxBytes, timeoutMs })`. Violations throw with clear messages and recovery hints.
 

--- a/test/integration/docs-contract.test.js
+++ b/test/integration/docs-contract.test.js
@@ -1,0 +1,42 @@
+/**
+ * Public documentation contract checks for safety limits.
+ *
+ * These assertions intentionally read the Rust constants instead of copying
+ * their values into JavaScript. Security documentation must fail when the
+ * always-on decode limit and the published Image Firewall table drift apart.
+ */
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const engineSource = fs.readFileSync(path.join(ROOT, 'src', 'engine.rs'), 'utf8');
+const architecture = fs.readFileSync(path.join(ROOT, 'docs', 'ARCHITECTURE.md'), 'utf8');
+
+const maxPixelsMatch = engineSource.match(
+  /pub const MAX_PIXELS:\s*u64\s*=\s*([\d_]+);/
+);
+assert(maxPixelsMatch, 'src/engine.rs must declare MAX_PIXELS');
+
+const maxPixels = Number(maxPixelsMatch[1].replaceAll('_', ''));
+const maxPixelsInMegapixels = maxPixels / 1_000_000;
+
+assert.equal(maxPixels, 100_000_000, 'global decode limit changed; review the public contract');
+assert.match(
+  architecture,
+  new RegExp(`\\| Max pixels \\| 40 MP\\s+\\| 75 MP\\s+\\| ${maxPixelsInMegapixels} MP`),
+  'No firewall column must match the always-on MAX_PIXELS value'
+);
+assert.doesNotMatch(
+  architecture,
+  /\b1 GP\b/,
+  'architecture must not claim a 1 GP limit when decode rejects above 100 MP'
+);
+assert.match(
+  architecture,
+  /always-on.*100 MP.*32,768/si,
+  'architecture must explain that global pixel and dimension limits stay enabled'
+);
+
+console.log('docs safety-limit contract passed');


### PR DESCRIPTION
## なぜこの修正が必要か

Closes #770

docs/ARCHITECTURE.mdはImage Firewall無効時の上限を1 GPと記載していましたが、実装はsanitizeの有無にかかわらず100 MP total / 32,768 pixels per sideを常時強制しています。公開されたsecurity contractが実装より緩く見え、利用者の容量設計とエラー処理を誤らせる状態でした。

## 変更前

- No firewall: 1 GPと記載
- 32,768×32,768が可能に見える
- .limits({ maxPixels: 0 })でglobal上限まで無効化できるか不明確
- docsとRust定数のdriftを検出するtestなし

## 変更後

- No firewall列を100 MPへ修正
- 常時有効な100 MP total / 32,768 per sideを明記
- strict 40 MP / lenient 75 MPは追加policy制限であることを明確化
- maxPixels: 0はcustom policy limitだけを無効化し、global decode safety limitは残ると明記
- src/engine.rsのMAX_PIXELSを読み、ARCHITECTUREの表と説明を検証するcontract testを追加

## TDD

1. 現行docsの1 GP表記に対してdocs-contract.test.jsが失敗することを確認
2. docsを実装契約へ修正
3. targeted testと全testをgreenにした

## 検証

- node test/integration/docs-contract.test.js
- npm run build
- npm test
  - JS integration 28 files
  - Rust test suites
  - Wasm package tests
  - TypeScript / pack contract / examples
- git diff --check

依存変更はありません。直前の同一mainに対するsecurity auditはnpm vulnerability 0、Rust vulnerability 0（許容済みunmaintained warning 1件）です。

## スコープ外

- 100 MP global limit自体の変更
- Image Firewall APIの変更
- release / publish作業