### PR TITLE
fix(ci): complete main full-test contracts

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -156,6 +156,16 @@ jobs:
       - name: Run Rust tests (release mode, without NAPI features)
         run: cargo test --no-default-features --release
 
+      - name: Setup Node.js for selector contract validation
+        if: matrix.host == 'ubuntu-latest'
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: 20
+
+      - name: Validate configured Rust test selectors
+        if: matrix.host == 'ubuntu-latest'
+        run: npm run test:ci-planner:rust-targets
+
       # Note: NAPI tests require Node.js runtime and cannot be run with cargo test alone.
       # NAPI functionality is tested via JavaScript integration tests in the 'test' job.
       # The napi_tests.rs file exists for local development with Node.js installed.
@@ -218,6 +228,9 @@ jobs:
 
       - name: Verify Wasm workspace pack contract
         run: npm --workspace @alberteinshutoin/lazy-image-wasm pack --dry-run
+
+      - name: Run Wasm workspace tests
+        run: npm run test:wasm:package
 
   test:
     name: Test (Node ${{ matrix.node }})

--- a/test/unit/selective-test-planner.test.js
+++ b/test/unit/selective-test-planner.test.js
@@ -8,6 +8,21 @@ const { countMatchingRustTests } = require('../../ci/lib/test-targets');
 const { loadConfig } = require('../../ci/lib/config');
 const { getAdapter } = require('../../ci/lib/adapters');
 
+const fullCiWorkflow = fs.readFileSync(
+  path.join(__dirname, '../../.github/workflows/CI.yml'),
+  'utf8',
+);
+assert.match(
+  fullCiWorkflow,
+  /npm run test:ci-planner:rust-targets/,
+  'main/release/scheduled CI must validate configured Rust selectors',
+);
+assert.match(
+  fullCiWorkflow,
+  /npm run test:wasm:package/,
+  'main/release/scheduled CI must execute Wasm workspace tests',
+);
+
 const fixtureConfig = {
   fullTestRules: [
     { pattern: 'Cargo.lock', reason: 'dependency lock file changed' },


### PR DESCRIPTION
## Why

PR #784 split PR-selective and main full-validation lanes. A post-merge audit found two tests present in the repository but not explicitly executed by the pre-existing split main workflow: the Wasm workspace tests and the Rust selective-filter configuration contract.

## Change

- Run `test:ci-planner:rust-targets` once in the Ubuntu Rust test job, after the full debug/release Rust suites. Node is installed only for that one matrix entry.
- Run `test:wasm:package` in the package-contract job alongside the existing Wasm pack check.
- Add a workflow contract regression test so either command cannot silently disappear from main/release/scheduled full CI.

Before, these checks ran through local/PR full fallback `npm test` but were absent from the split main jobs. After this PR, main, release, tag, manual, and scheduled full validation execute them explicitly without duplicating them across every OS/Node entry.

## Verification

- `npm run test:ci-planner`
- `npm run test:ci-planner:rust-targets`
- `npm run test:wasm:package`
- `actionlint` 1.7.7 on `.github/workflows/CI.yml`
- `git diff --check`
