### PR TITLE
chore(runtime): require Node.js 22 or newer

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,7 +22,7 @@ What actually happened.
 
 ## Environment
 - **OS**: (e.g., macOS 14.0, Ubuntu 22.04, Windows 11)
-- **Node.js version**: (e.g., 18.17.0)
+- **Node.js version**: (e.g., 22.0.0)
 - **lazy-image version**: (e.g., 0.7.8)
 
 ## Code Example
@@ -46,4 +46,3 @@ Paste any error messages here
 - [ ] I have searched existing issues to ensure this is not a duplicate
 - [ ] I have tested with the latest version
 - [ ] I have included a minimal reproducible example
-

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install Rust
@@ -108,7 +108,7 @@ jobs:
         run: ${{ matrix.settings.build }}
         shell: bash
 
-      # Node 20 on Linux x64 is the canonical generator environment for the
+      # Node 22 on Linux x64 is the canonical generator environment for the
       # committed NAPI loader and declarations. Other matrix entries verify
       # platform builds without redefining the reviewed public artifacts.
       - name: Verify committed NAPI artifacts are reproducible
@@ -160,7 +160,7 @@ jobs:
         if: matrix.host == 'ubuntu-latest'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Validate configured Rust test selectors
         if: matrix.host == 'ubuntu-latest'
@@ -217,7 +217,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies
@@ -245,7 +245,7 @@ jobs:
             artifact: bindings-aarch64-apple-darwin
           - host: windows-latest
             artifact: bindings-x86_64-pc-windows-msvc
-        node: [18, 20, 22]
+        node: [22, 24]
 
     runs-on: ${{ matrix.settings.host }}
     timeout-minutes: 20
@@ -289,7 +289,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Setup NASM
@@ -328,7 +328,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Setup NASM
@@ -361,7 +361,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install Rust
@@ -424,7 +424,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies
@@ -457,7 +457,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Setup NASM
@@ -583,7 +583,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org
           scope: '@alberteinshutoin'
           cache: npm
@@ -711,7 +711,7 @@ jobs:
                   url: 'https://github.com/albert-einshutoin/lazy-image.git'
                 },
                 engines: {
-                  node: '>= 18'
+                  node: '>= 22'
                 }
               };
               fs.writeFileSync('npm/$platform/package.json', JSON.stringify(pkg, null, 2));
@@ -737,7 +737,7 @@ jobs:
           echo "=== Verifying package.json contents ==="
           for platform in darwin-x64 darwin-arm64 win32-x64-msvc linux-x64-gnu linux-arm64-gnu linux-x64-musl; do
             echo "Package: $platform"
-            cat "npm/$platform/package.json" | jq -r '.name, .version, .main' || cat "npm/$platform/package.json"
+            node -e "const pkg = require('./npm/$platform/package.json'); if (pkg.engines?.node !== '>= 22') process.exit(1); console.log(pkg.name, pkg.version, pkg.main, pkg.engines.node)"
             echo ""
           done
           

--- a/.github/workflows/benchmark-regression.yml
+++ b/.github/workflows/benchmark-regression.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install Rust

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -61,6 +61,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: 22
+
       - name: Install Rust nightly
         uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       
       - name: Install dependencies

--- a/.github/workflows/selective-pr.yml
+++ b/.github/workflows/selective-pr.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Select test strategy
         id: plan
@@ -67,7 +67,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install Rust
@@ -118,7 +118,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install Rust
@@ -181,7 +181,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install Rust

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   through the typed error contract instead of being treated as safe defaults.
 
 ### Changed
+- **BREAKING (Node.js runtime)**: dropped EOL Node.js 18 and 20. The native and
+  Wasm packages now require Node.js 22 or newer, with CI coverage on Node.js 22
+  and 24. Upgrade your runtime to Node.js 22 or 24 before updating lazy-image.
 - **BREAKING (Wasm error contract)**: aligned
   `@alberteinshutoin/lazy-image-wasm` with the native error taxonomy. Categories
   are now `UserError`, `CodecError`, `ResourceLimit`, and `InternalBug`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ This document explains how to participate in the project.
 
 ### Required Tools
 
-- **Node.js**: >= 18
+- **Node.js**: >= 22
 - **Rust**: stable (latest recommended)
 - **Cargo**: included with Rust
 - **npm**: included with Node.js
@@ -268,7 +268,7 @@ lazy-image へのコントリビューションに興味を持っていただき
 
 ### 必要なツール
 
-- **Node.js**: >= 18
+- **Node.js**: >= 22
 - **Rust**: stable (最新推奨)
 - **Cargo**: Rustに付属
 - **npm**: Node.jsに付属

--- a/README.ja.md
+++ b/README.ja.md
@@ -58,7 +58,7 @@ npm install @alberteinshutoin/lazy-image
 
 | 環境 | 概要 |
 |---|---|
-| ランタイム | platform optional dependencies が自動インストール |
+| ランタイム | Node.js 22+。platform optional dependencies が自動インストール |
 | パッケージサイズ | プラットフォーム別で 6〜9MB 前後 |
 | 自前ビルド | `npm run build` |
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ Platform-specific binaries (~6–9 MB per platform) are installed automatically.
 | Distribution path | Notes |
 |---|---|
 | npm optional binaries | macOS arm64/x64, Linux x64/arm64 GNU, Linux x64 musl, Windows x64 |
-| Source build | Node.js 18+, Rust 1.88+, and the native codec toolchain documented in [CONTRIBUTING.md](./CONTRIBUTING.md) |
+| Runtime requirement | Node.js 22+ for prebuilt binaries and source builds |
+| Source build | Rust 1.88+ and the native codec toolchain documented in [CONTRIBUTING.md](./CONTRIBUTING.md) |
 
 ---
 

--- a/docs/ADOPTION_GUIDE.md
+++ b/docs/ADOPTION_GUIDE.md
@@ -223,7 +223,7 @@ The current product direction is documented in [WASM_STRATEGY.md](./WASM_STRATEG
 ### Docker / Kubernetes
 
 ```dockerfile
-FROM node:20-slim
+FROM node:22-slim
 # No extra apt-get or system libraries needed
 WORKDIR /app
 COPY package*.json ./

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -11,6 +11,11 @@ drop-in replacement for sharp. The API is intentionally smaller and focuses on:
 
 If you need broad image editing features or a sharp-compatible API, use sharp.
 
+## Runtime Support
+
+The native and Wasm packages require Node.js 22 or newer. CI covers Node.js 22
+and 24; Node.js 18 and 20 are unsupported because they are end-of-life.
+
 ## Supported Formats
 
 - **Input**: jpeg/jpg, png, webp

--- a/docs/SELECTIVE_TESTING.md
+++ b/docs/SELECTIVE_TESTING.md
@@ -141,7 +141,7 @@ separate, reviewed policy change. Main, release, tag, and scheduled full runs
 remain after adoption.
 
 The PR workflow caps test-process parallelism at two and uses one canonical
-Linux/Node 20 binding. This limits runner startup overhead and avoids parallel
+Linux/Node 22 binding. This limits runner startup overhead and avoids parallel
 native builds fighting for CPU and memory. Cross-platform and multi-Node
 coverage remains in full CI. npm downloads and Cargo registry/build outputs
 are cached with separate canonical, selective, and shadow keys. To diagnose a

--- a/docs/SEMVER_POLICY.md
+++ b/docs/SEMVER_POLICY.md
@@ -6,7 +6,7 @@ This document defines how **lazy-image** uses Semantic Versioning (SemVer) and h
 - JavaScript/TypeScript API (`@alberteinshutoin/lazy-image`, including `ImageEngine`, `createStreamingPipeline`, and exported types)
 - N-API binary interface (prebuilt platform packages)
 - Documented behaviors in `README.md`, `README.ja.md`, and `spec/` (resize rules, metadata defaults, limits, error taxonomy)
-- Supported Node.js versions (currently `>=18`)
+- Supported Node.js versions (currently `>=22`)
 
 Rust crate internals are not a public surface; they may change without notice as long as the JS API remains stable.
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -41,7 +41,7 @@ Use `error.recoveryHint` when present. Recoverable errors (path, bounds, etc.) c
 
 ## Build / install issues
 
-- **Native build fails**: Ensure Node.js 18+, Rust 1.70+, and (for mozjpeg SIMD) nasm. For libavif, cmake is required.
+- **Native build fails**: Ensure Node.js 22+, Rust 1.70+, and (for mozjpeg SIMD) nasm. For libavif, cmake is required.
 - **Platform binary missing**: Use `npm run build` to build from source, or check [GitHub Actions](https://github.com/albert-einshutoin/lazy-image/actions) that the release for your platform was published.
 
 ## mmap and file modification

--- a/docs/VERSIONING_PLAN.md
+++ b/docs/VERSIONING_PLAN.md
@@ -28,10 +28,8 @@
 
 - patch/minor: additive changes, docs alignment, performance/safety improvements
 - major: API removal, semantic shifts, or new execution-model assumptions
-- 現在の `Unreleased` には PNG `quality` rejection の breaking marker があるため、
-  そのまま公開する次リリースは `1.0.0` 候補として扱う。minor/patch で出す場合は、
-  事前に `CHANGELOG.md` から breaking marker を外し、bug-fix clarification として
-  根拠を明文化する。
+- 現在の `Unreleased` には Wasm error contract と Node.js runtime floor の
+  breaking marker があるため、そのまま公開する次リリースは `1.0.0` とする。
 - release branch では version/changelog 更新後に `npm run release:check` を実行し、
   breaking marker を含む non-major release を拒否する。
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "typescript": "^5.6.3"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 22"
       },
       "optionalDependencies": {
         "@alberteinshutoin/lazy-image-darwin-arm64": "0.16.0",
@@ -2497,7 +2497,7 @@
         "@jsquash/webp": "1.5.0"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 22"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@alberteinshutoin/lazy-image-win32-x64-msvc": "0.16.0"
   },
   "engines": {
-    "node": ">= 18"
+    "node": ">= 22"
   },
   "files": [
     "index.js",

--- a/packages/lazy-image-wasm/package.json
+++ b/packages/lazy-image-wasm/package.json
@@ -44,7 +44,7 @@
     "@jsquash/webp": "1.5.0"
   },
   "engines": {
-    "node": ">= 18"
+    "node": ">= 22"
   },
   "repository": {
     "type": "git",

--- a/test/integration/package-metadata.test.js
+++ b/test/integration/package-metadata.test.js
@@ -8,9 +8,19 @@ const path = require('node:path');
 
 const ROOT = path.resolve(__dirname, '..', '..');
 const packageJson = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
+const wasmPackageJson = JSON.parse(
+  fs.readFileSync(path.join(ROOT, 'packages', 'lazy-image-wasm', 'package.json'), 'utf8'),
+);
 const cargoToml = fs.readFileSync(path.join(ROOT, 'Cargo.toml'), 'utf8');
 const readmeMd = fs.readFileSync(path.join(ROOT, 'README.md'), 'utf8');
 const readmeJa = fs.readFileSync(path.join(ROOT, 'README.ja.md'), 'utf8');
+const contributing = fs.readFileSync(path.join(ROOT, 'CONTRIBUTING.md'), 'utf8');
+const compatibility = fs.readFileSync(path.join(ROOT, 'docs', 'COMPATIBILITY.md'), 'utf8');
+const troubleshooting = fs.readFileSync(path.join(ROOT, 'docs', 'TROUBLESHOOTING.md'), 'utf8');
+const ciWorkflow = fs.readFileSync(path.join(ROOT, '.github', 'workflows', 'CI.yml'), 'utf8');
+const nodeWorkflows = ['CI.yml', 'selective-pr.yml', 'security.yml', 'benchmark-regression.yml', 'fuzz.yml']
+  .map((name) => fs.readFileSync(path.join(ROOT, '.github', 'workflows', name), 'utf8'))
+  .join('\n');
 
 function readmeHeadlineCount(content) {
   return (content.match(/^##\s+.+$/gm) || []).length;
@@ -125,6 +135,19 @@ function test(name, fn) {
       /upload/i.test(packageJson.description),
       'package description should keep upload-focused safety positioning',
     );
+  });
+
+  test('Node runtime contract is consistently Node 22 and 24', () => {
+    assert.equal(packageJson.engines?.node, '>= 22');
+    assert.equal(wasmPackageJson.engines?.node, packageJson.engines.node);
+    assert.match(readmeMd, /Node\.js 22\+/);
+    assert.match(readmeJa, /Node\.js 22\+/);
+    assert.match(contributing, /\*\*Node\.js\*\*: >= 22/);
+    assert.match(compatibility, /Node\.js 22 or newer/);
+    assert.match(troubleshooting, /Node\.js 22\+/);
+    assert.match(ciWorkflow, /node: \[22, 24\]/);
+    assert.doesNotMatch(nodeWorkflows, /node-version: (?:18|20)\b/);
+    assert.match(ciWorkflow, /engines:\s*\{\s*node: '>= 22'/);
   });
 
   console.log(`\n✅ package metadata checks completed: ${passed} passed, ${failed} failed`);

--- a/test/unit/generated-artifact-policy.test.js
+++ b/test/unit/generated-artifact-policy.test.js
@@ -26,7 +26,7 @@ assert.equal(
   packageJson.scripts['check:generated-artifacts'],
   'git diff --exit-code -- index.js index.d.ts',
 )
-assert.match(workflow, /node-version: 20/)
+assert.match(workflow, /node-version: 22/)
 assert.match(
   workflow,
   /Verify committed NAPI artifacts are reproducible[\s\S]*npm run check:generated-artifacts/,


### PR DESCRIPTION
## 背景

Node.js 18/20のEOL後もpackage metadata・CI・公開文書のruntime契約が古いままで、生成platform packageにも契約driftの余地がありました。

## 変更前後

- 変更前: Node.js >=18、CI 18/20/22、生成packageの最低Node検証なし
- 変更後: Node.js >=22、CI 22/24、root/Wasm/生成platform packageと文書を同じ契約へ統一

## 意思決定と変更内容

- Node.js 22をcanonical build環境、22/24をsupport matrixとする
- root metadataだけでなく生成platform packageのenginesも検証する
- CI、security、benchmark、fuzz、selective PR workflowのsetup-nodeを同期する
- README英日、互換性・導入・versioning文書、CHANGELOGへ移行案内を反映する
- package contract testで将来のdriftを検出する

## 検証

- npm run build
- npm test
- node scripts/check-release-policy.js 1.0.0
- focused package metadata / generated artifact tests
- git diff --check
- actionlint（syntax errorなし。既存ShellCheck情報のみ）

## 残る制約

全6 platform artifactのcompile/package契約は検証しています。Node.js 22/24での代表platform runtime loadはhosted CIで最終確認します。

#796はIssue受け入れ条件の一部のみを変更しているため、このPRで置き換えます。

Closes #767