### PR TITLE
feat(security): add public upload sanitization policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Public upload firewall policy**: `sanitize({ policy: 'public-upload' })`
+  combines the strict 32 MiB / 40 MP / 5-second limits with validated ICC
+  preservation up to 512 KiB, while forcing EXIF/GPS/XMP removal regardless of
+  `keepMetadata()` call order. Metrics now report `iccOutcome`.
 - **Authoritative upload preflight traits**: `inspect()` and `inspectFile()` now
   report `hasAlpha`, `isAnimated`, and optional EXIF `orientation` for
   JPEG/PNG/WebP without decoding pixels. Unknown or malformed traits fail

--- a/docs/API.md
+++ b/docs/API.md
@@ -37,7 +37,7 @@ const bytes = await engine.resize(800).toFile('output.jpg', 'jpeg', 80);
 | `.normalizePixelFormat()` | Normalize pixel format to RGB/RGBA without color space conversion. |
 | `.toColorspace(space)` | ⚠️ **DEPRECATED** - Use `.normalizePixelFormat()` instead. |
 | `.preset(name)` | ⚠️ **DEPRECATED** - Applies a preset (`'thumbnail'`, `'avatar'`, `'hero'`, `'social'`) by mutating the pipeline and returning a separate `PresetResult`. Prefer `encode({ preset: name })`, `.toBufferWithPreset(name)`, or `.toFileWithPreset(path, name)` for self-contained preset output. |
-| `.sanitize({ policy?, ... })` | Image Firewall: apply strict/lenient limits. See [ARCHITECTURE.md](./ARCHITECTURE.md#image-firewall-mode-strict--lenient). |
+| `.sanitize({ policy? })` | Image Firewall: apply `strict`, `lenient`, or `public-upload`. The public-upload policy keeps strict resource limits, preserves only validated ICC up to 512 KiB, and always strips EXIF/GPS/XMP. See [METADATA_SUPPORT.md](./METADATA_SUPPORT.md). |
 | `.limits({ maxPixels?, maxBytes?, timeoutMs? })` | Override firewall limits. |
 
 For preset-based output, prefer the self-contained APIs above the deprecated `.preset(name)` command/query mix:
@@ -218,6 +218,7 @@ interface ProcessingMetrics {
   formatIn?: string | null;
   formatOut: string;
   iccPreserved: boolean;
+  iccOutcome: 'absent' | 'preserved' | 'unsafe-stripped' | 'policy-stripped' | 'unsupported';
   metadataStripped: boolean;
   policyViolations: string[];
   /** @deprecated use decodeMs */

--- a/docs/METADATA_SUPPORT.md
+++ b/docs/METADATA_SUPPORT.md
@@ -19,6 +19,13 @@ await ImageEngine.fromPath('input.jpg')
   .toFile('output.jpg', 'jpeg', 85);
 ```
 
+For untrusted public uploads, use `sanitize({ policy: 'public-upload' })`.
+It keeps the strict 32 MiB / 40 MP / cooperative 5-second resource limits,
+preserves only structurally valid ICC profiles up to 512 KiB, and forces all
+EXIF (including GPS), XMP, comments, and unknown ancillary metadata out of the
+re-encoded output. Calling `keepMetadata()` before or after cannot weaken this
+policy; `.limits()` may only tighten its fixed resource limits.
+
 ## Feature Matrix
 
 | Metadata type | Default | Opt-in API | Current status |
@@ -45,6 +52,7 @@ await ImageEngine.fromPath('input.jpg')
 - EXIF Orientation is reset to `1` after auto-orient for JPEG, PNG, and WebP outputs to avoid downstream double rotation.
 - GPS data inside EXIF is stripped by default for JPEG, PNG, and WebP outputs. Use `keepMetadata({ exif: true, stripGps: false })` only when location metadata must be retained.
 - `sanitize({ policy: 'strict' })` can override metadata preservation and strip metadata for safety.
+- `sanitize({ policy: 'public-upload' })` forces ICC-only output metadata. Malformed ICC is reported as `unsafe-stripped`; oversized ICC is rejected by the firewall.
 - For workflows that depend on exact metadata retention, validate behavior in integration tests against your target output format.
 
 ## Inspection is separate from preservation

--- a/docs/metrics-api.md
+++ b/docs/metrics-api.md
@@ -1,4 +1,4 @@
-# Metrics API (v1.0.0)
+# Metrics API (v1.1.0)
 
 lazy-image exposes structured telemetry via `ImageEngine.toBufferWithMetrics()`, `ImageEngine.toFileWithMetrics()`, and `ImageEngine.processBatchWithMetrics()`. The single-image payload is versioned and validated so that downstream services can ingest it safely.
 
@@ -6,7 +6,7 @@ lazy-image exposes structured telemetry via `ImageEngine.toBufferWithMetrics()`,
 
 ```jsonc
 {
-  "version": "1.0.0",
+  "version": "1.1.0",
   "decodeMs": 12.4,
   "opsMs": 8.1,
   "encodeMs": 15.3,
@@ -20,6 +20,7 @@ lazy-image exposes structured telemetry via `ImageEngine.toBufferWithMetrics()`,
   "formatIn": "jpeg",
   "formatOut": "webp",
   "iccPreserved": false,
+  "iccOutcome": "absent",
   "metadataStripped": true,
   "policyViolations": ["firewall_rejected_metadata"],
   // Legacy aliases kept for backward compatibility
@@ -34,13 +35,14 @@ lazy-image exposes structured telemetry via `ImageEngine.toBufferWithMetrics()`,
 
 ## Field guide
 
-- **version**: Schema version. Current value: `1.0.0`.
+- **version**: Schema version. Current value: `1.1.0`.
 - **decodeMs / opsMs / encodeMs / totalMs**: Wall-clock timings in milliseconds.
 - **peakRss**: Peak resident set size (bytes) during the operation.
 - **cpuTime**: CPU time (user + system) in seconds.
 - **bytesIn / bytesOut / compressionRatio**: I/O sizes and ratio (`bytesOut / bytesIn`).
 - **formatIn / formatOut**: Detected input format (nullable) and requested output format.
-- **iccPreserved / metadataStripped**: Whether ICC profile was preserved or stripped.
+- **iccPreserved / metadataStripped**: Whether ICC profile was preserved or metadata was stripped.
+- **iccOutcome**: `absent`, `preserved`, `unsafe-stripped`, `policy-stripped`, or `unsupported`; use this instead of inferring ICC presence from `iccPreserved: false`.
 - **policyViolations**: Non-fatal Image Firewall actions that altered output (e.g., forced metadata strip under strict policy).
 - **Legacy aliases** (deprecated): `decodeTime`, `processTime`, `encodeTime`, `memoryPeak`, `inputSize`, `outputSize` map 1:1 to the new fields. They will be removed in v2.0.0; migrate to `decodeMs`, `opsMs`, `encodeMs`, `peakRss`, `bytesIn`, `bytesOut`.
 

--- a/docs/metrics-schema.json
+++ b/docs/metrics-schema.json
@@ -18,6 +18,7 @@
     "compressionRatio",
     "formatOut",
     "iccPreserved",
+    "iccOutcome",
     "metadataStripped",
     "policyViolations",
     "decodeTime",
@@ -30,7 +31,7 @@
   "properties": {
     "version": {
       "type": "string",
-      "const": "1.0.0",
+      "const": "1.1.0",
       "description": "Schema version for compatibility negotiation"
     },
     "decodeMs": { "type": "number", "minimum": 0, "description": "Decode stage duration (ms)" },
@@ -49,6 +50,11 @@
     },
     "formatOut": { "type": "string", "description": "Output format (jpeg, png, webp, avif)" },
     "iccPreserved": { "type": "boolean", "description": "True when ICC profile existed and was preserved" },
+    "iccOutcome": {
+      "type": "string",
+      "enum": ["absent", "preserved", "unsafe-stripped", "policy-stripped", "unsupported"],
+      "description": "Outcome of ICC detection, validation, and output support"
+    },
     "metadataStripped": { "type": "boolean", "description": "True when metadata was stripped" },
     "policyViolations": {
       "type": "array",

--- a/index.d.ts
+++ b/index.d.ts
@@ -178,7 +178,7 @@ export declare class ImageEngine {
    */
   keepMetadata(options?: KeepMetadataOptions | undefined | null): ImageEngine
   /**
-   * Enable Image Firewall mode with built-in policies (strict or lenient).
+   * Enable Image Firewall mode with a built-in policy.
    * Strict mode enforces aggressive limits and rejects dangerous metadata (best for zero-trust inputs).
    * Lenient mode keeps generous limits but still guards against decompression bombs.
    */
@@ -505,6 +505,8 @@ export interface ProcessingMetrics {
   formatOut: CanonicalOutputFormat
   /** True when ICC profile was present and preserved */
   iccPreserved: boolean
+  /** ICC handling result: absent, preserved, unsafe-stripped, policy-stripped, or unsupported */
+  iccOutcome: IccOutcome
   /** True when metadata was stripped (either by default or policy) */
   metadataStripped: boolean
   /** Non-fatal policy rejections (e.g., strict policy forcing metadata strip) */
@@ -567,7 +569,8 @@ export type OutputFormat = CaseInsensitive<CanonicalOutputFormat>
 export type TargetBytesFormat = CaseInsensitive<'jpeg' | 'jpg' | 'webp' | 'avif'>
 export type PresetName = CaseInsensitive<CanonicalPresetName>
 export type ResizeFit = 'inside' | 'cover' | 'fill'
-export type FirewallPolicy = 'strict' | 'lenient'
+export type FirewallPolicy = 'strict' | 'lenient' | 'public-upload'
+export type IccOutcome = 'absent' | 'preserved' | 'unsafe-stripped' | 'policy-stripped' | 'unsupported'
 export type EncodeProfile = 'size-first' | 'balanced' | 'speed-first'
 
 export interface ResolvedEncodeProfile {

--- a/scripts/postbuild-fixup.js
+++ b/scripts/postbuild-fixup.js
@@ -22,7 +22,8 @@ export type OutputFormat = CaseInsensitive<CanonicalOutputFormat>
 export type TargetBytesFormat = CaseInsensitive<'jpeg' | 'jpg' | 'webp' | 'avif'>
 export type PresetName = CaseInsensitive<CanonicalPresetName>
 export type ResizeFit = 'inside' | 'cover' | 'fill'
-export type FirewallPolicy = 'strict' | 'lenient'
+export type FirewallPolicy = 'strict' | 'lenient' | 'public-upload'
+export type IccOutcome = 'absent' | 'preserved' | 'unsafe-stripped' | 'policy-stripped' | 'unsupported'
 export type EncodeProfile = 'size-first' | 'balanced' | 'speed-first'
 
 export interface ResolvedEncodeProfile {
@@ -261,6 +262,7 @@ function patchIndexDts() {
   content = replaceIfNeeded(content, 'export interface PresetResult {\n  /** Recommended output format */\n  format: string', 'export interface PresetResult {\n  /** Recommended output format */\n  format: CanonicalOutputFormat');
   content = replaceIfNeeded(content, '  /** Detected input format (lowercase: jpeg, png, webp, avif, etc.) */\n  formatIn?: string', '  /** Detected input format reported by runtime metrics */\n  formatIn?: InputFormat');
   content = replaceIfNeeded(content, '  /** Output format */\n  formatOut: string', '  /** Output format */\n  formatOut: CanonicalOutputFormat');
+  content = replaceIfNeeded(content, '  iccOutcome: string', '  iccOutcome: IccOutcome');
   content = replaceIfNeeded(content, '  toFileWithMetrics(path: string, format: string,', '  toFileWithMetrics(path: string, format: OutputFormat,');
   content = replaceIfNeeded(content, '  encode(options: EncodeOptions): Promise<EncodeResult>', '  encode(options: EncodeOptionsInput): Promise<EncodeResult>');
   content = replaceIfNeeded(content, '  encodeToFile(path: string, options: EncodeOptions): Promise<FileEncodeResult>', '  encodeToFile(path: string, options: EncodeOptionsInput): Promise<FileEncodeResult>');

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -131,6 +131,7 @@ pub use stress::run_stress_iteration;
 mod tests {
     use crate::engine::api::MetadataPolicy;
     use crate::engine::firewall::FirewallConfig;
+    use crate::engine::io::IccSourceState;
     use crate::engine::tasks::{EncodeTask, TaskContext};
     use crate::engine::test_support::create_test_image;
     use crate::error::LazyImageError;
@@ -164,7 +165,7 @@ mod tests {
                     ops: vec![],
                     format: OutputFormat::Png,
                     icc_profile: None,
-                    icc_present: false,
+                    icc_state: IccSourceState::Absent,
                     exif_data: None,
                     auto_orient: true,
                     metadata_policy: MetadataPolicy::default_policy(),
@@ -190,7 +191,7 @@ mod tests {
                     ops: vec![],
                     format: OutputFormat::Png,
                     icc_profile: None,
-                    icc_present: false,
+                    icc_state: IccSourceState::Absent,
                     exif_data: None,
                     auto_orient: true,
                     metadata_policy: MetadataPolicy::default_policy(),
@@ -214,7 +215,7 @@ mod tests {
                     ops: vec![],
                     format: OutputFormat::Png,
                     icc_profile: None,
-                    icc_present: false,
+                    icc_state: IccSourceState::Absent,
                     exif_data: None,
                     auto_orient: true,
                     metadata_policy: MetadataPolicy::default_policy(),
@@ -245,7 +246,7 @@ mod tests {
                     ops: vec![],
                     format: OutputFormat::Png,
                     icc_profile: None,
-                    icc_present: false,
+                    icc_state: IccSourceState::Absent,
                     exif_data: None,
                     auto_orient: true,
                     metadata_policy: MetadataPolicy::default_policy(),
@@ -272,7 +273,7 @@ mod tests {
                     ops: vec![],
                     format: OutputFormat::Png,
                     icc_profile: None,
-                    icc_present: false,
+                    icc_state: IccSourceState::Absent,
                     exif_data: None,
                     auto_orient: true,
                     metadata_policy: MetadataPolicy::default_policy(),

--- a/src/engine/api/batch_ops.rs
+++ b/src/engine/api/batch_ops.rs
@@ -174,7 +174,7 @@ impl ImageEngine {
             .map_err(|e| napi_err(&env, e))?;
         let ops = self.ops.clone();
         let mut policy = self.metadata_policy;
-        policy.apply_firewall(self.firewall.reject_metadata);
+        policy.apply_firewall(self.firewall.policy);
         Ok(AsyncTask::new(BatchTask {
             inputs,
             output_dir,
@@ -182,7 +182,8 @@ impl ImageEngine {
             format: output_format,
             concurrency,
             metadata_policy: policy,
-            auto_orient: self.auto_orient,
+            auto_orient: self.auto_orient
+                || self.firewall.policy == crate::engine::firewall::FirewallPolicy::PublicUpload,
             firewall: self.firewall,
             #[cfg(feature = "napi")]
             last_error: None,
@@ -238,7 +239,7 @@ impl ImageEngine {
             .map_err(|e| napi_err(&env, e))?;
         let ops = self.ops.clone();
         let mut policy = self.metadata_policy;
-        policy.apply_firewall(self.firewall.reject_metadata);
+        policy.apply_firewall(self.firewall.policy);
 
         Ok(AsyncTask::new(BatchWithMetricsTask {
             inputs,
@@ -247,7 +248,8 @@ impl ImageEngine {
             format: output_format,
             concurrency,
             metadata_policy: policy,
-            auto_orient: self.auto_orient,
+            auto_orient: self.auto_orient
+                || self.firewall.policy == crate::engine::firewall::FirewallPolicy::PublicUpload,
             firewall: self.firewall,
             #[cfg(feature = "napi")]
             last_error: None,

--- a/src/engine/api/output_ops.rs
+++ b/src/engine/api/output_ops.rs
@@ -13,6 +13,8 @@
 #[cfg(feature = "napi")]
 use super::engine::{napi_err, ImageEngine};
 #[cfg(feature = "napi")]
+use crate::engine::io::{classify_icc_profile, classify_public_upload_icc, IccSourceState};
+#[cfg(feature = "napi")]
 use crate::engine::tasks::{
     EncodeTargetBytesTask, EncodeTask, EncodeWithMetricsTask, TaskContext, WriteFileTask,
     WriteFileWithMetricsTask, WriteTargetBytesTask,
@@ -26,6 +28,8 @@ use crate::ops::{Operation, OutputFormat, PresetConfig, ResizeFit};
 
 #[cfg(feature = "napi")]
 use napi::bindgen_prelude::*;
+#[cfg(feature = "napi")]
+use std::sync::Arc;
 
 // =============================================================================
 // INTERNAL HELPER
@@ -55,11 +59,31 @@ impl ImageEngine {
         let source = self.source.clone();
         let decoded = self.decoded.clone();
         let mut policy = self.metadata_policy;
-        policy.apply_firewall(self.firewall.reject_metadata);
-        let auto_orient = self.auto_orient;
-        let icc_present = self.icc_profile().is_some();
+        policy.apply_firewall(self.firewall.policy);
+        let auto_orient = self.auto_orient
+            || self.firewall.policy == crate::engine::firewall::FirewallPolicy::PublicUpload;
+        let classified_icc = source
+            .as_ref()
+            .and_then(|value| value.as_bytes())
+            .map(|bytes| {
+                if self.firewall.policy == crate::engine::firewall::FirewallPolicy::PublicUpload {
+                    classify_public_upload_icc(bytes)
+                } else {
+                    classify_icc_profile(bytes)
+                }
+            });
+        let icc_state = classified_icc
+            .as_ref()
+            .map(|value| value.state)
+            .unwrap_or_else(|| {
+                if self.icc_profile().is_some() {
+                    IccSourceState::Valid
+                } else {
+                    IccSourceState::Absent
+                }
+            });
         let icc_profile = if policy.effective_icc() {
-            self.icc_profile().cloned()
+            classified_icc.and_then(|value| value.profile).map(Arc::new)
         } else {
             None
         };
@@ -75,7 +99,7 @@ impl ImageEngine {
             ops,
             format,
             icc_profile,
-            icc_present,
+            icc_state,
             exif_data,
             auto_orient,
             metadata_policy: policy,

--- a/src/engine/api/pipeline_ops.rs
+++ b/src/engine/api/pipeline_ops.rs
@@ -188,7 +188,7 @@ impl ImageEngine {
         Ok(this)
     }
 
-    /// Enable Image Firewall mode with built-in policies (strict or lenient).
+    /// Enable Image Firewall mode with a built-in policy.
     /// Strict mode enforces aggressive limits and rejects dangerous metadata (best for zero-trust inputs).
     /// Lenient mode keeps generous limits but still guards against decompression bombs.
     #[napi]
@@ -205,6 +205,7 @@ impl ImageEngine {
         let policy = match lowered.as_str() {
             "strict" => FirewallPolicy::Strict,
             "lenient" => FirewallPolicy::Lenient,
+            "public-upload" => FirewallPolicy::PublicUpload,
             _ => {
                 return Err(napi_err(
                     &env,
@@ -214,11 +215,9 @@ impl ImageEngine {
         };
 
         self.firewall = FirewallConfig::apply_policy(policy);
-        if self.firewall.reject_metadata {
-            self.metadata_policy.apply_firewall(true);
-            // No need to clear the OnceLock fields: output methods already
-            // check metadata_policy and skip metadata when firewall is active.
-        }
+        self.metadata_policy.apply_firewall(policy);
+        // No need to clear the OnceLock fields: output methods apply the policy
+        // again when creating their immutable task snapshot.
 
         if let Some(decoded) = &self.decoded {
             self.firewall
@@ -264,32 +263,59 @@ impl ImageEngine {
         this: Reference<ImageEngine>,
         options: FirewallLimitOptions,
     ) -> Result<Reference<ImageEngine>> {
+        let public_upload = self.firewall.policy == FirewallPolicy::PublicUpload;
+        let max_pixels = validation::sanitize_limit("maxPixels", options.max_pixels)
+            .map_err(|e| napi_err(&env, e))?;
+        let max_bytes = validation::sanitize_limit("maxBytes", options.max_bytes)
+            .map_err(|e| napi_err(&env, e))?;
+        let timeout_ms = validation::sanitize_limit("timeoutMs", options.timeout_ms)
+            .map_err(|e| napi_err(&env, e))?;
+
+        if public_upload {
+            for (name, update, current) in [
+                ("maxPixels", &max_pixels, self.firewall.max_pixels),
+                ("maxBytes", &max_bytes, self.firewall.max_bytes),
+                ("timeoutMs", &timeout_ms, self.firewall.timeout_ms),
+            ] {
+                let invalid = match update {
+                    validation::LimitUpdate::Disable => {
+                        Some(("0".to_string(), "public-upload limits cannot be disabled"))
+                    }
+                    validation::LimitUpdate::Set(value) if Some(*value) > current => Some((
+                        value.to_string(),
+                        "public-upload limits can only be tightened",
+                    )),
+                    _ => None,
+                };
+                if let Some((value, reason)) = invalid {
+                    return Err(napi_err(
+                        &env,
+                        LazyImageError::invalid_argument(name, value, reason),
+                    ));
+                }
+            }
+        }
+
         if !self.firewall.enabled || matches!(self.firewall.policy, FirewallPolicy::Disabled) {
             self.firewall = FirewallConfig::custom();
-        } else {
+        } else if !public_upload {
             self.firewall.enabled = true;
             self.firewall.policy = FirewallPolicy::Custom;
         }
 
-        match validation::sanitize_limit("maxPixels", options.max_pixels)
-            .map_err(|e| napi_err(&env, e))?
-        {
+        match max_pixels {
             validation::LimitUpdate::Unchanged => {}
             validation::LimitUpdate::Disable => self.firewall.max_pixels = None,
             validation::LimitUpdate::Set(value) => self.firewall.max_pixels = Some(value),
         }
 
-        match validation::sanitize_limit("maxBytes", options.max_bytes)
-            .map_err(|e| napi_err(&env, e))?
-        {
+        match max_bytes {
             validation::LimitUpdate::Unchanged => {}
             validation::LimitUpdate::Disable => self.firewall.max_bytes = None,
             validation::LimitUpdate::Set(value) => self.firewall.max_bytes = Some(value),
         }
 
-        match validation::sanitize_limit("timeoutMs", options.timeout_ms)
-            .map_err(|e| napi_err(&env, e))?
-        {
+        match timeout_ms {
             validation::LimitUpdate::Unchanged => {}
             validation::LimitUpdate::Disable => self.firewall.timeout_ms = None,
             validation::LimitUpdate::Set(value) => self.firewall.timeout_ms = Some(value),

--- a/src/engine/firewall.rs
+++ b/src/engine/firewall.rs
@@ -2,7 +2,7 @@
 //
 // Image Firewall configuration and enforcement helpers.
 
-use crate::engine::io::extract_icc_profile;
+use crate::engine::io::{classify_public_upload_icc, extract_icc_profile};
 use crate::error::LazyImageError;
 use std::time::Instant;
 
@@ -29,6 +29,7 @@ pub enum FirewallPolicy {
     Disabled,
     Strict,
     Lenient,
+    PublicUpload,
     Custom,
 }
 
@@ -93,6 +94,20 @@ impl FirewallConfig {
         }
     }
 
+    /// Strict resource limits with bounded, validated ICC preservation.
+    pub fn public_upload() -> Self {
+        Self {
+            enabled: true,
+            policy: FirewallPolicy::PublicUpload,
+            max_pixels: Some(STRICT_MAX_PIXELS),
+            max_bytes: Some(STRICT_MAX_BYTES),
+            timeout_ms: Some(STRICT_TIMEOUT_MS),
+            reject_metadata: false,
+            metadata_max_bytes: Some(LENIENT_METADATA_LIMIT),
+            exif_max_bytes: Some(STRICT_MAX_EXIF_BYTES),
+        }
+    }
+
     pub fn custom() -> Self {
         Self {
             enabled: true,
@@ -111,6 +126,7 @@ impl FirewallConfig {
             FirewallPolicy::Disabled => Self::disabled(),
             FirewallPolicy::Strict => Self::strict(),
             FirewallPolicy::Lenient => Self::lenient(),
+            FirewallPolicy::PublicUpload => Self::public_upload(),
             FirewallPolicy::Custom => Self::custom(),
         }
     }
@@ -221,7 +237,12 @@ impl FirewallConfig {
     /// disabled.  This catches obviously malicious payloads without requiring
     /// the caller to opt-in via `sanitize()`.
     pub fn scan_metadata_base(&self, data: &[u8]) -> Result<(), LazyImageError> {
-        if let Some(icc) = extract_icc_profile(data)? {
+        let icc = if self.policy == FirewallPolicy::PublicUpload {
+            classify_public_upload_icc(data).profile
+        } else {
+            extract_icc_profile(data)?
+        };
+        if let Some(icc) = icc {
             let icc_len = icc.len() as u64;
             if icc_len > BASE_METADATA_LIMIT {
                 return Err(LazyImageError::firewall_violation(format!(
@@ -247,7 +268,12 @@ impl FirewallConfig {
         }
 
         // --- ICC profile scanning ---
-        if let Some(icc) = extract_icc_profile(data)? {
+        let icc = if self.policy == FirewallPolicy::PublicUpload {
+            classify_public_upload_icc(data).profile
+        } else {
+            extract_icc_profile(data)?
+        };
+        if let Some(icc) = icc {
             if self.reject_metadata {
                 return Err(LazyImageError::firewall_violation(
                     "Image Firewall: embedded ICC profile blocked under strict policy. \
@@ -354,7 +380,7 @@ mod tests {
     use img_parts::{png::Png, Bytes, ImageICC};
 
     fn build_icc_payload(len: usize) -> Vec<u8> {
-        let size = len.max(128);
+        let size = len.max(132).next_multiple_of(4);
         let mut data = vec![0u8; size];
         data[..4].copy_from_slice(&(size as u32).to_be_bytes());
         data[4..8].copy_from_slice(b"TEST");
@@ -362,6 +388,7 @@ mod tests {
         data[12..16].copy_from_slice(b"mntr");
         data[16..20].copy_from_slice(b"RGB ");
         data[20..24].copy_from_slice(b"XYZ ");
+        data[36..40].copy_from_slice(b"acsp");
         data
     }
 
@@ -477,6 +504,20 @@ mod tests {
         assert!(cfg.scan_metadata(&safe_png).is_ok());
         let oversized_png = png_with_icc((LENIENT_METADATA_LIMIT + 1) as usize);
         assert!(cfg.scan_metadata(&oversized_png).is_err());
+    }
+
+    #[test]
+    fn public_upload_uses_strict_limits_and_bounded_icc() {
+        let cfg = FirewallConfig::public_upload();
+        assert_eq!(cfg.policy, FirewallPolicy::PublicUpload);
+        assert_eq!(cfg.max_pixels, Some(STRICT_MAX_PIXELS));
+        assert_eq!(cfg.max_bytes, Some(STRICT_MAX_BYTES));
+        assert_eq!(cfg.timeout_ms, Some(STRICT_TIMEOUT_MS));
+        assert!(!cfg.reject_metadata);
+        assert!(cfg.scan_metadata(&png_with_icc(256)).is_ok());
+        assert!(cfg
+            .scan_metadata(&png_with_icc((LENIENT_METADATA_LIMIT + 1) as usize))
+            .is_err());
     }
 
     #[test]

--- a/src/engine/io/icc.rs
+++ b/src/engine/io/icc.rs
@@ -14,8 +14,23 @@ use libavif_sys::*;
 /// Hard cap on input size to keep fuzz inputs bounded without breaking large
 /// images. Inputs larger than this skip ICC parsing entirely.
 const MAX_ICC_SOURCE_BYTES: usize = 8 * 1024 * 1024;
+// Bounds decompression before policy-specific checks; profiles above the
+// always-on 10 MiB ceiling can never be accepted.
+const MAX_EXTRACTED_ICC_BYTES: u64 = 10 * 1024 * 1024 + 4096;
 
 pub type IccExtractionResult = std::result::Result<Option<Vec<u8>>, LazyImageError>;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum IccSourceState {
+    Absent,
+    Valid,
+    Unsafe,
+}
+
+pub struct ClassifiedIcc {
+    pub state: IccSourceState,
+    pub profile: Option<Vec<u8>>,
+}
 
 fn icc_decode_error(format: &str, reason: &str) -> LazyImageError {
     LazyImageError::decode_failed(format!("{format} ICC extraction failed: {reason}"))
@@ -154,6 +169,122 @@ pub fn extract_icc_profile(data: &[u8]) -> IccExtractionResult {
     extract_and_validate_icc(extractor, data)
 }
 
+fn has_icc_payload(data: &[u8]) -> bool {
+    if data.starts_with(&[0xFF, 0xD8]) {
+        let mut offset = 2;
+        while offset + 1 < data.len() {
+            if data[offset] != 0xFF {
+                return false;
+            }
+            while offset < data.len() && data[offset] == 0xFF {
+                offset += 1;
+            }
+            if offset >= data.len() {
+                return false;
+            }
+            let marker = data[offset];
+            offset += 1;
+            if marker == 0xDA || marker == 0xD9 {
+                break;
+            }
+            if (0xD0..=0xD7).contains(&marker) || marker == 0x01 {
+                continue;
+            }
+            if offset + 1 >= data.len() {
+                return false;
+            }
+            let size = u16::from_be_bytes([data[offset], data[offset + 1]]) as usize;
+            let Some(end) = offset.checked_add(size) else {
+                return false;
+            };
+            if size < 2 || end > data.len() {
+                return false;
+            }
+            if marker == 0xE2 && data[offset + 2..end].starts_with(b"ICC_PROFILE\0") {
+                return true;
+            }
+            offset = end;
+        }
+        return false;
+    }
+
+    let (mut offset, kind, is_png) = if data.starts_with(&[0x89, 0x50, 0x4E, 0x47]) {
+        (8usize, b"iCCP".as_slice(), true)
+    } else if data.starts_with(b"RIFF") && data.len() >= 12 && &data[8..12] == b"WEBP" {
+        (12usize, b"ICCP".as_slice(), false)
+    } else {
+        return false;
+    };
+
+    while offset + 8 <= data.len() {
+        let (chunk_kind, payload_start, padded) = if is_png {
+            let size = u32::from_be_bytes(data[offset..offset + 4].try_into().unwrap()) as usize;
+            (
+                &data[offset + 4..offset + 8],
+                offset + 8,
+                size.saturating_add(4),
+            )
+        } else {
+            let size =
+                u32::from_le_bytes(data[offset + 4..offset + 8].try_into().unwrap()) as usize;
+            (
+                &data[offset..offset + 4],
+                offset + 8,
+                size.next_multiple_of(2),
+            )
+        };
+        let Some(end) = payload_start.checked_add(padded) else {
+            break;
+        };
+        if end > data.len() {
+            break;
+        }
+        if chunk_kind == kind {
+            return true;
+        }
+        offset = end;
+    }
+    false
+}
+
+fn classify_icc_profile_inner(data: &[u8], allow_public_source_size: bool) -> ClassifiedIcc {
+    if !has_icc_payload(data) {
+        return ClassifiedIcc {
+            state: IccSourceState::Absent,
+            profile: None,
+        };
+    }
+    if (!allow_public_source_size && data.len() > MAX_ICC_SOURCE_BYTES)
+        || (allow_public_source_size && data.len() > 32 * 1024 * 1024)
+    {
+        return ClassifiedIcc {
+            state: IccSourceState::Unsafe,
+            profile: None,
+        };
+    }
+
+    let profile = select_icc_extractor(data)
+        .and_then(|extractor| extract_and_validate_icc(extractor, data).ok().flatten());
+    match profile {
+        Some(profile) => ClassifiedIcc {
+            state: IccSourceState::Valid,
+            profile: Some(profile),
+        },
+        None => ClassifiedIcc {
+            state: IccSourceState::Unsafe,
+            profile: None,
+        },
+    }
+}
+
+pub fn classify_icc_profile(data: &[u8]) -> ClassifiedIcc {
+    classify_icc_profile_inner(data, false)
+}
+
+pub fn classify_public_upload_icc(data: &[u8]) -> ClassifiedIcc {
+    classify_icc_profile_inner(data, true)
+}
+
 /// Lossy helper for callers that cannot propagate errors (legacy NAPI constructor).
 /// Panics are still trapped and converted to `None` via the guard.
 pub fn extract_icc_profile_lossy(data: &[u8]) -> Option<Vec<u8>> {
@@ -177,8 +308,11 @@ fn is_printable_ascii_field(bytes: &[u8]) -> bool {
 }
 
 pub(crate) fn validate_icc_profile(icc_data: &[u8]) -> bool {
-    // Minimum ICC profile size is 128 bytes (header)
-    if icc_data.len() < 128 {
+    const TAG_TABLE_START: usize = 132;
+    const MAX_TAGS: usize = 4096;
+
+    // Header plus the required tag-count field, padded to a 4-byte boundary.
+    if icc_data.len() < TAG_TABLE_START || !icc_data.len().is_multiple_of(4) {
         return false;
     }
 
@@ -191,27 +325,69 @@ pub(crate) fn validate_icc_profile(icc_data: &[u8]) -> bool {
         return false;
     }
 
-    // Check printable ASCII tag fields:
-    // - preferred CMM type (bytes 4-7), common values: "ADBE", "appl", "lcms"
-    // - profile class signature (bytes 12-15), common values: "mntr", "prtr", "scnr", "spac"
-    // - data color space (bytes 16-19)
-    // - PCS (Profile Connection Space) signature (bytes 20-23)
     if !is_printable_ascii_field(&icc_data[4..8])
-        || !is_printable_ascii_field(&icc_data[12..16])
-        || !is_printable_ascii_field(&icc_data[16..20])
-        || !is_printable_ascii_field(&icc_data[20..24])
+        || !matches!(&icc_data[12..16], b"mntr" | b"scnr" | b"prtr")
+        || !matches!(&icc_data[16..20], b"RGB " | b"GRAY")
+        || !matches!(&icc_data[20..24], b"XYZ " | b"Lab ")
+        || &icc_data[36..40] != b"acsp"
+        || icc_data[100..128].iter().any(|&byte| byte != 0)
     {
         return false;
     }
 
-    // Check profile version (bytes 8-11)
-    // Major version should be reasonable (typically 2, 4, or 5)
-    let major_version = icc_data[8];
-    if major_version > 10 {
+    if !matches!(icc_data[8], 2 | 4 | 5) {
         return false;
     }
 
-    // Basic validation passed
+    let tag_count = u32::from_be_bytes(icc_data[128..132].try_into().unwrap()) as usize;
+    if tag_count > MAX_TAGS {
+        return false;
+    }
+    let Some(table_end) = tag_count
+        .checked_mul(12)
+        .and_then(|bytes| TAG_TABLE_START.checked_add(bytes))
+    else {
+        return false;
+    };
+    if table_end > icc_data.len() {
+        return false;
+    }
+
+    let mut signatures = std::collections::HashSet::with_capacity(tag_count);
+    let mut ranges = Vec::with_capacity(tag_count);
+    for entry in icc_data[TAG_TABLE_START..table_end].chunks_exact(12) {
+        let signature: [u8; 4] = entry[0..4].try_into().unwrap();
+        if !signature.iter().all(|byte| (32..=126).contains(byte)) || !signatures.insert(signature)
+        {
+            return false;
+        }
+
+        let offset = u32::from_be_bytes(entry[4..8].try_into().unwrap()) as usize;
+        let size = u32::from_be_bytes(entry[8..12].try_into().unwrap()) as usize;
+        let Some(end) = offset.checked_add(size) else {
+            return false;
+        };
+        if offset < table_end
+            || !offset.is_multiple_of(4)
+            || size < 8
+            || end > icc_data.len()
+            || icc_data[offset + 4..offset + 8]
+                .iter()
+                .any(|&byte| byte != 0)
+        {
+            return false;
+        }
+        ranges.push((offset, end));
+    }
+
+    ranges.sort_unstable_by_key(|range| range.0);
+    if ranges
+        .windows(2)
+        .any(|pair| pair[0] != pair[1] && pair[0].1 > pair[1].0)
+    {
+        return false;
+    }
+
     true
 }
 
@@ -430,9 +606,13 @@ pub(crate) fn extract_icc_from_png_direct(data: &[u8]) -> Option<Vec<u8>> {
             let compressed_data = &data[compressed_start..compressed_end];
 
             // Decompress zlib data
-            let mut decoder = ZlibDecoder::new(compressed_data);
+            let decoder = ZlibDecoder::new(compressed_data);
             let mut decompressed = Vec::new();
-            if decoder.read_to_end(&mut decompressed).is_ok() {
+            if decoder
+                .take(MAX_EXTRACTED_ICC_BYTES)
+                .read_to_end(&mut decompressed)
+                .is_ok()
+            {
                 return Some(decompressed);
             }
             break;

--- a/src/engine/io/icc_tests.rs
+++ b/src/engine/io/icc_tests.rs
@@ -23,13 +23,13 @@ fn test_validate_icc_profile_too_small() {
 
 #[test]
 fn test_validate_icc_profile_minimal_valid() {
-    // Minimal valid ICC profile (128 bytes)
-    let mut data = vec![0u8; 128];
+    // Minimal valid ICC profile (128-byte header + zero-entry tag table)
+    let mut data = vec![0u8; 132];
     // Profile size (first 4 bytes, big-endian)
     data[0] = 0x00;
     data[1] = 0x00;
     data[2] = 0x00;
-    data[3] = 0x80; // 128 bytes
+    data[3] = 0x84; // 132 bytes
                     // CMM type (bytes 4-7): "ADBE" (ASCII)
     data[4] = b'A';
     data[5] = b'D';
@@ -52,8 +52,42 @@ fn test_validate_icc_profile_minimal_valid() {
     data[21] = b'Y';
     data[22] = b'Z';
     data[23] = b' ';
+    data[36..40].copy_from_slice(b"acsp");
 
     assert!(validate_icc_profile(&data));
+}
+
+#[test]
+fn test_validate_icc_profile_rejects_missing_signature_and_bad_tag_table() {
+    let mut missing_signature = create_minimal_srgb_icc();
+    missing_signature[36..40].fill(0);
+    assert!(!validate_icc_profile(&missing_signature));
+
+    let mut truncated_tag_table = create_minimal_srgb_icc();
+    truncated_tag_table[128..132].copy_from_slice(&1u32.to_be_bytes());
+    assert!(!validate_icc_profile(&truncated_tag_table));
+}
+
+#[test]
+fn test_validate_icc_profile_allows_shared_tag_data_but_rejects_partial_overlap() {
+    let mut shared = create_minimal_srgb_icc();
+    shared.resize(164, 0);
+    shared[0..4].copy_from_slice(&164u32.to_be_bytes());
+    shared[128..132].copy_from_slice(&2u32.to_be_bytes());
+    shared[132..136].copy_from_slice(b"rTRC");
+    shared[136..140].copy_from_slice(&156u32.to_be_bytes());
+    shared[140..144].copy_from_slice(&8u32.to_be_bytes());
+    shared[144..148].copy_from_slice(b"gTRC");
+    shared[148..152].copy_from_slice(&156u32.to_be_bytes());
+    shared[152..156].copy_from_slice(&8u32.to_be_bytes());
+    shared[156..160].copy_from_slice(b"curv");
+    assert!(validate_icc_profile(&shared));
+
+    let mut overlapping = shared;
+    overlapping.resize(168, 0);
+    overlapping[0..4].copy_from_slice(&168u32.to_be_bytes());
+    overlapping[148..152].copy_from_slice(&160u32.to_be_bytes());
+    assert!(!validate_icc_profile(&overlapping));
 }
 
 #[test]
@@ -127,6 +161,37 @@ fn test_extract_icc_profile_large_input_skips_icc() {
 }
 
 #[test]
+fn classification_distinguishes_unsafe_and_public_large_valid_icc() {
+    let icc = create_minimal_srgb_icc();
+    let mut incomplete = create_jpeg_with_icc(&icc);
+    let marker = incomplete
+        .windows(12)
+        .position(|window| window == b"ICC_PROFILE\0")
+        .unwrap();
+    incomplete[marker + 13] = 2;
+    assert_eq!(
+        classify_icc_profile(&incomplete).state,
+        IccSourceState::Unsafe
+    );
+
+    let mut large = create_webp_with_icc(&icc);
+    large.extend_from_slice(b"JUNK");
+    large.extend_from_slice(&(9 * 1024 * 1024u32).to_le_bytes());
+    large.resize(large.len() + 9 * 1024 * 1024, 0);
+    let riff_size = (large.len() - 8) as u32;
+    large[4..8].copy_from_slice(&riff_size.to_le_bytes());
+    assert_eq!(classify_icc_profile(&large).state, IccSourceState::Unsafe);
+    assert_eq!(
+        classify_public_upload_icc(&large).state,
+        IccSourceState::Valid
+    );
+
+    let mut filled = create_jpeg_with_icc(&icc);
+    filled.insert(2, 0xFF);
+    assert_eq!(classify_icc_profile(&filled).state, IccSourceState::Valid);
+}
+
+#[test]
 fn test_extract_icc_profile_jpeg() {
     let jpeg_data = create_minimal_jpeg();
     // Extract ICC profile from JPEG (when not present)
@@ -138,13 +203,13 @@ fn test_extract_icc_profile_jpeg() {
 
 // Helper function to create a minimal valid ICC profile (sRGB)
 fn create_minimal_srgb_icc() -> Vec<u8> {
-    // Minimal valid sRGB ICC profile (128 bytes)
-    let mut data = vec![0u8; 128];
+    // Minimal valid sRGB ICC profile (128-byte header + zero-entry tag table)
+    let mut data = vec![0u8; 132];
     // Profile size (first 4 bytes, big-endian)
     data[0] = 0x00;
     data[1] = 0x00;
     data[2] = 0x00;
-    data[3] = 0x80; // 128 bytes
+    data[3] = 0x84; // 132 bytes
                     // CMM type (bytes 4-7): "ADBE" (ASCII)
     data[4] = b'A';
     data[5] = b'D';
@@ -167,6 +232,7 @@ fn create_minimal_srgb_icc() -> Vec<u8> {
     data[21] = b'Y';
     data[22] = b'Z';
     data[23] = b' ';
+    data[36..40].copy_from_slice(b"acsp");
     data
 }
 

--- a/src/engine/io/mod.rs
+++ b/src/engine/io/mod.rs
@@ -25,7 +25,10 @@ pub use exif::{exif_has_gps, extract_exif_raw, has_exif};
 // `exif_embed`'s public fns are reached via the module path
 // (`crate::engine::io::exif_embed::...`) from `encoder.rs` and `processing.rs`;
 // no flat re-export is needed here.
-pub use icc::{extract_icc_profile, extract_icc_profile_lossy};
+pub use icc::{
+    classify_icc_profile, classify_public_upload_icc, extract_icc_profile,
+    extract_icc_profile_lossy, IccSourceState,
+};
 // `IccExtractionResult` only appears in the signature of `extract_icc_profile`,
 // `MmapGuard` and `MemoryGuard` only inside `Source` variants. They're still
 // part of the public surface (downstream Rust consumers may name them), so

--- a/src/engine/metadata.rs
+++ b/src/engine/metadata.rs
@@ -5,6 +5,8 @@
 // MetadataPolicy: single source of truth for which metadata to preserve
 // in output images. Extracted from api.rs to keep the NAPI surface thin.
 
+use crate::engine::firewall::FirewallPolicy;
+
 /// Policy for which metadata to preserve in output images.
 ///
 /// Modeled as a sum type so that incoherent combinations are *unrepresentable*:
@@ -52,10 +54,12 @@ impl MetadataPolicy {
         }
     }
 
-    /// Apply firewall override: if reject_metadata is true, strip everything.
-    pub fn apply_firewall(&mut self, reject_metadata: bool) {
-        if reject_metadata {
-            *self = Self::StripAll;
+    /// Apply the output metadata invariant owned by a built-in firewall policy.
+    pub fn apply_firewall(&mut self, firewall: FirewallPolicy) {
+        match firewall {
+            FirewallPolicy::Strict => *self = Self::StripAll,
+            FirewallPolicy::PublicUpload => *self = Self::KeepIcc,
+            _ => {}
         }
     }
 
@@ -134,7 +138,18 @@ mod tests {
     #[test]
     fn firewall_override_strips_all() {
         let mut p = MetadataPolicy::KeepAll { strip_gps: false };
-        p.apply_firewall(true);
+        p.apply_firewall(FirewallPolicy::Strict);
         assert_eq!(p, MetadataPolicy::StripAll);
+    }
+
+    #[test]
+    fn public_upload_forces_icc_only_regardless_of_prior_policy() {
+        for mut policy in [
+            MetadataPolicy::StripAll,
+            MetadataPolicy::KeepAll { strip_gps: false },
+        ] {
+            policy.apply_firewall(FirewallPolicy::PublicUpload);
+            assert_eq!(policy, MetadataPolicy::KeepIcc);
+        }
     }
 }

--- a/src/engine/tasks/batch.rs
+++ b/src/engine/tasks/batch.rs
@@ -13,7 +13,7 @@ use super::atomic::write_encoded_output;
 #[cfg(feature = "napi")]
 use super::context::BatchResult;
 use super::processing::{process_and_encode_from_parts, EncodeContext};
-use crate::engine::io::{extract_exif_raw, extract_icc_profile};
+use crate::engine::io::{classify_icc_profile, classify_public_upload_icc, extract_exif_raw};
 #[cfg(feature = "napi")]
 use crate::engine::pool;
 use crate::error::LazyImageError;
@@ -73,10 +73,15 @@ fn process_batch_file(
 
     ctx.firewall.scan_metadata(data)?;
 
-    let extracted_icc = extract_icc_profile(data)?;
-    let icc_present = extracted_icc.is_some();
+    let classified_icc =
+        if ctx.firewall.policy == super::super::firewall::FirewallPolicy::PublicUpload {
+            classify_public_upload_icc(data)
+        } else {
+            classify_icc_profile(data)
+        };
+    let icc_state = classified_icc.state;
     let icc_profile = if keep_icc {
-        extracted_icc.map(Arc::new)
+        classified_icc.profile.map(Arc::new)
     } else {
         None
     };
@@ -93,7 +98,7 @@ fn process_batch_file(
         ops: ctx.ops,
         format: ctx.format,
         icc_profile: icc_profile.as_ref(),
-        icc_present,
+        icc_state,
         exif_data: exif_data.as_ref(),
         auto_orient: ctx.auto_orient,
         policy: ctx.policy,

--- a/src/engine/tasks/context.rs
+++ b/src/engine/tasks/context.rs
@@ -12,6 +12,7 @@ use super::processing::{process_and_encode_from_parts, EncodeContext};
 use crate::engine::decoder::{
     check_dimensions, decode_image, detect_format, ensure_dimensions_safe,
 };
+use crate::engine::io::IccSourceState;
 #[allow(unused_imports)]
 use crate::engine::io::Source;
 #[allow(unused_imports)]
@@ -78,8 +79,7 @@ pub struct TaskContext {
     pub ops: Vec<Operation>,
     pub format: OutputFormat,
     pub icc_profile: Option<Arc<Vec<u8>>>,
-    /// Whether the input originally had an ICC profile (even if stripped)
-    pub icc_present: bool,
+    pub icc_state: IccSourceState,
     /// Raw EXIF data extracted from source image (for preservation)
     pub exif_data: Option<Arc<Vec<u8>>>,
     pub auto_orient: bool,
@@ -163,7 +163,7 @@ impl TaskContext {
             ops: &self.ops,
             format: &self.format,
             icc_profile: self.icc_profile.as_ref(),
-            icc_present: self.icc_present,
+            icc_state: self.icc_state,
             exif_data: self.exif_data.as_ref(),
             auto_orient: self.auto_orient,
             policy: &self.metadata_policy,

--- a/src/engine/tasks/encode.rs
+++ b/src/engine/tasks/encode.rs
@@ -162,7 +162,7 @@ impl EncodeTargetBytesTask {
             base_ctx.source,
             base_ctx.decoded,
             base_ctx.ops,
-            base_ctx.icc_present,
+            base_ctx.icc_state,
             base_ctx.auto_orient,
             base_ctx.firewall,
             base_ctx.format,

--- a/src/engine/tasks/processing.rs
+++ b/src/engine/tasks/processing.rs
@@ -14,7 +14,7 @@ use super::context::{decode_internal_from_parts, detect_input_format};
 use crate::engine::encoder::{encode_avif, encode_jpeg_with_settings, encode_png, encode_webp};
 use crate::engine::io::exif_embed::{embed_exif_jpeg, embed_exif_png, embed_exif_webp};
 #[allow(unused_imports)]
-use crate::engine::io::{exif_has_gps, has_exif, Source};
+use crate::engine::io::{exif_has_gps, has_exif, IccSourceState, Source};
 use crate::engine::memory;
 use crate::engine::pipeline::{apply_ops_tracked, ColorState, IccState};
 use crate::error::LazyImageError;
@@ -41,7 +41,7 @@ fn get_resource_usage() -> Option<ResourceUsage> {
 /// per-iteration `OutputFormat`).
 ///
 /// `encode_prepared` ignores the prepare-only fields (`source`, `decoded`,
-/// `ops`, `icc_present`); they live here rather than in a separate struct so
+/// `ops`, `icc_state`); they live here rather than in a separate struct so
 /// every callsite builds exactly one context object.
 #[derive(Clone, Copy)]
 pub(super) struct EncodeContext<'a> {
@@ -50,7 +50,7 @@ pub(super) struct EncodeContext<'a> {
     pub(super) ops: &'a [Operation],
     pub(super) format: &'a OutputFormat,
     pub(super) icc_profile: Option<&'a Arc<Vec<u8>>>,
-    pub(super) icc_present: bool,
+    pub(super) icc_state: IccSourceState,
     pub(super) exif_data: Option<&'a Arc<Vec<u8>>>,
     pub(super) auto_orient: bool,
     pub(super) policy: &'a MetadataPolicy,
@@ -91,7 +91,7 @@ pub(super) fn prepare_for_encode(
     source: Option<&Source>,
     decoded: Option<&Arc<DynamicImage>>,
     ops: &[Operation],
-    icc_present: bool,
+    icc_state: IccSourceState,
     auto_orient: bool,
     firewall: &FirewallConfig,
     format_for_memory_estimate: &OutputFormat,
@@ -166,7 +166,7 @@ pub(super) fn prepare_for_encode(
         ops
     };
 
-    let icc_state = if icc_present {
+    let icc_state = if icc_state == IccSourceState::Valid {
         IccState::Present
     } else {
         IccState::Absent
@@ -273,8 +273,16 @@ pub(super) fn encode_prepared(
         // Get final resource usage & finalize metrics
         let final_usage = get_resource_usage();
         // Use tracked color state to reason about ICC preservation.
-        let icc_present = matches!(prepared.final_color_state.icc, IccState::Present);
-        let icc_preserved = keep_icc && icc_present;
+        let valid_icc_present = ctx.icc_profile.is_some()
+            && matches!(prepared.final_color_state.icc, IccState::Present);
+        let icc_preserved = keep_icc && valid_icc_present;
+        let icc_outcome = match (ctx.icc_state, icc_preserved, keep_icc) {
+            (IccSourceState::Absent, _, _) => "absent",
+            (IccSourceState::Unsafe, _, _) => "unsafe-stripped",
+            (IccSourceState::Valid, true, _) => "preserved",
+            (IccSourceState::Valid, false, false) => "policy-stripped",
+            (IccSourceState::Valid, false, true) => "unsupported",
+        };
         // EXIF presence detection: prefer the in-memory copy that the API layer may
         // have already extracted, otherwise fall back to a lightweight presence scan
         // recorded during the prepare phase.
@@ -290,11 +298,12 @@ pub(super) fn encode_prepared(
             .map(|exif| exif_has_gps(exif.as_slice()))
             .unwrap_or(false);
         let gps_stripped_from_exif = exif_preserved && strip_gps && gps_present_in_exif;
-        let metadata_stripped = (icc_present && !icc_preserved)
+        let metadata_stripped = (ctx.icc_state != IccSourceState::Absent && !icc_preserved)
             || (exif_present && !exif_preserved)
             || gps_stripped_from_exif;
-        let metadata_blocked_by_policy =
-            (keep_icc || keep_exif) && firewall.reject_metadata && (icc_present || exif_present);
+        let metadata_blocked_by_policy = (keep_icc || keep_exif)
+            && firewall.reject_metadata
+            && (ctx.icc_state != IccSourceState::Absent || exif_present);
         let mut policy_violations = Vec::new();
         if metadata_blocked_by_policy {
             policy_violations.push("firewall_rejected_metadata".to_string());
@@ -328,6 +337,7 @@ pub(super) fn encode_prepared(
         m.format_in = prepared.input_format.map(|s| s.to_string());
         m.format_out = format.as_str().to_string();
         m.icc_preserved = icc_preserved;
+        m.icc_outcome = icc_outcome.to_string();
         m.metadata_stripped = metadata_stripped;
         m.policy_violations = policy_violations;
     }
@@ -348,7 +358,7 @@ pub(super) fn process_and_encode_from_parts(
         ctx.source,
         ctx.decoded,
         ctx.ops,
-        ctx.icc_present,
+        ctx.icc_state,
         ctx.auto_orient,
         ctx.firewall,
         ctx.format,

--- a/src/engine/tasks/tests.rs
+++ b/src/engine/tasks/tests.rs
@@ -9,7 +9,7 @@ use super::super::firewall::FirewallConfig;
 use super::context::TaskContext;
 use super::encode::{EncodeTargetBytesTask, EncodeTask};
 use super::processing::{encode_prepared, prepare_for_encode, EncodeContext};
-use crate::engine::io::Source;
+use crate::engine::io::{IccSourceState, Source};
 use crate::error::LazyImageError;
 use crate::ops::{Operation, OutputFormat, Quality, ResizeFit};
 use image::{DynamicImage, GenericImageView, ImageBuffer, ImageFormat, Rgba};
@@ -39,7 +39,7 @@ fn make_ctx_with_decoded(format: OutputFormat) -> TaskContext {
         }],
         format,
         icc_profile: None,
-        icc_present: false,
+        icc_state: IccSourceState::Absent,
         exif_data: None,
         auto_orient: true,
         metadata_policy: MetadataPolicy::default_policy(),
@@ -71,7 +71,7 @@ fn decode_internal_errors_when_source_missing() {
             ops: vec![],
             format: OutputFormat::Png,
             icc_profile: None,
-            icc_present: false,
+            icc_state: IccSourceState::Absent,
             exif_data: None,
             auto_orient: true,
             metadata_policy: MetadataPolicy::default_policy(),
@@ -129,7 +129,7 @@ fn firewall_limits_are_enforced_on_decode() {
             ops: vec![],
             format: OutputFormat::Png,
             icc_profile: None,
-            icc_present: false,
+            icc_state: IccSourceState::Absent,
             exif_data: None,
             auto_orient: true,
             metadata_policy: MetadataPolicy::default_policy(),
@@ -154,7 +154,7 @@ fn auto_orient_flag_disables_orientation_lookup() {
             ops: vec![],
             format: OutputFormat::Png,
             icc_profile: None,
-            icc_present: false,
+            icc_state: IccSourceState::Absent,
             exif_data: None,
             auto_orient: false,
             metadata_policy: MetadataPolicy::default_policy(),
@@ -238,7 +238,7 @@ fn target_bytes_search_finds_best_quality_under_budget() {
                 fast_mode: false,
             },
             icc_profile: None,
-            icc_present: false,
+            icc_state: IccSourceState::Absent,
             exif_data: None,
             auto_orient: false,
             metadata_policy: MetadataPolicy::strip_all(),
@@ -258,7 +258,7 @@ fn target_bytes_search_finds_best_quality_under_budget() {
                 fast_mode: false,
             },
             icc_profile: None,
-            icc_present: false,
+            icc_state: IccSourceState::Absent,
             exif_data: None,
             auto_orient: false,
             metadata_policy: MetadataPolicy::strip_all(),
@@ -284,7 +284,7 @@ fn target_bytes_search_finds_best_quality_under_budget() {
                 fast_mode: false,
             },
             icc_profile: None,
-            icc_present: false,
+            icc_state: IccSourceState::Absent,
             exif_data: None,
             auto_orient: false,
             metadata_policy: MetadataPolicy::strip_all(),
@@ -318,7 +318,7 @@ fn target_bytes_strict_policy_fails_when_budget_unmet() {
                 fast_mode: false,
             },
             icc_profile: None,
-            icc_present: false,
+            icc_state: IccSourceState::Absent,
             exif_data: None,
             auto_orient: false,
             metadata_policy: MetadataPolicy::strip_all(),
@@ -353,7 +353,7 @@ fn prepare_for_encode_reuses_decoded_arc_when_ops_empty() {
         None,
         Some(&original),
         &[],
-        false,
+        IccSourceState::Absent,
         false,
         &FirewallConfig::disabled(),
         &OutputFormat::Jpeg {
@@ -388,7 +388,7 @@ fn prepare_for_encode_applies_ops_once_when_ops_nonempty() {
             height: Some(16),
             fit: crate::ops::ResizeFit::Inside,
         }],
-        false,
+        IccSourceState::Absent,
         false,
         &FirewallConfig::disabled(),
         &OutputFormat::Jpeg {
@@ -419,7 +419,7 @@ fn encode_prepared_can_run_multiple_times_against_same_cache() {
         None,
         Some(&Arc::new(dyn_img)),
         &[],
-        false,
+        IccSourceState::Absent,
         false,
         &FirewallConfig::disabled(),
         &OutputFormat::Jpeg {
@@ -444,7 +444,7 @@ fn encode_prepared_can_run_multiple_times_against_same_cache() {
             ops: &[],
             format: &format,
             icc_profile: None,
-            icc_present: false,
+            icc_state: IccSourceState::Absent,
             exif_data: None,
             auto_orient: false,
             policy: &policy,
@@ -491,7 +491,7 @@ fn target_bytes_search_metrics_include_decode_ops_and_encode_timings() {
                 fast_mode: false,
             },
             icc_profile: None,
-            icc_present: false,
+            icc_state: IccSourceState::Absent,
             exif_data: None,
             auto_orient: false,
             metadata_policy: MetadataPolicy::strip_all(),

--- a/src/engine/test_support.rs
+++ b/src/engine/test_support.rs
@@ -21,13 +21,14 @@ pub(crate) fn create_test_image_rgba(width: u32, height: u32) -> DynamicImage {
 
 /// Minimal valid ICC profile used by several encoder tests.
 pub(crate) fn minimal_icc_profile() -> Vec<u8> {
-    let mut icc = vec![0u8; 128];
-    icc[0..4].copy_from_slice(&128u32.to_be_bytes());
+    let mut icc = vec![0u8; 132];
+    icc[0..4].copy_from_slice(&132u32.to_be_bytes());
     icc[4..8].copy_from_slice(b"ADBE");
     icc[8] = 2;
     icc[12..16].copy_from_slice(b"mntr");
     icc[16..20].copy_from_slice(b"RGB ");
     icc[20..24].copy_from_slice(b"XYZ ");
+    icc[36..40].copy_from_slice(b"acsp");
     icc
 }
 
@@ -37,13 +38,14 @@ mod tests {
 
     #[test]
     fn minimal_icc_profile_matches_encoder_fixture() {
-        let mut expected = vec![0u8; 128];
-        expected[0..4].copy_from_slice(&128u32.to_be_bytes()); // 128 bytes
+        let mut expected = vec![0u8; 132];
+        expected[0..4].copy_from_slice(&132u32.to_be_bytes());
         expected[4..8].copy_from_slice(b"ADBE");
         expected[8] = 2;
         expected[12..16].copy_from_slice(b"mntr");
         expected[16..20].copy_from_slice(b"RGB ");
         expected[20..24].copy_from_slice(b"XYZ ");
+        expected[36..40].copy_from_slice(b"acsp");
 
         assert_eq!(minimal_icc_profile(), expected);
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -263,7 +263,7 @@ pub enum LazyImageError {
     #[error("Unknown preset: '{name}'. Available: thumbnail, avatar, hero, social")]
     InvalidPreset { name: Cow<'static, str> },
 
-    #[error("Unknown firewall policy: '{policy}'. Expected strict or lenient")]
+    #[error("Unknown firewall policy: '{policy}'. Expected strict, lenient, or public-upload")]
     InvalidFirewallPolicy { policy: Cow<'static, str> },
 
     #[error("Invalid value for {name}: {value}. {reason}")]
@@ -389,7 +389,9 @@ impl LazyImageError {
             ErrorCode::InvalidPreset => {
                 "Use a supported preset name (thumbnail, avatar, hero, social)."
             }
-            ErrorCode::InvalidFirewallPolicy => "Use firewall policy 'strict' or 'lenient'.",
+            ErrorCode::InvalidFirewallPolicy => {
+                "Use firewall policy 'strict', 'lenient', or 'public-upload'."
+            }
 
             // Internal errors
             ErrorCode::SourceConsumed => "Clone the engine or reload the source before reusing it.",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,7 @@ pub fn supported_output_formats() -> Vec<String> {
 }
 
 /// Metrics payload version. Keep in sync with docs/metrics-schema.json
-pub const PROCESSING_METRICS_VERSION: &str = "1.0.0";
+pub const PROCESSING_METRICS_VERSION: &str = "1.1.0";
 
 /// Processing metrics for performance monitoring
 #[derive(Debug)]
@@ -189,6 +189,8 @@ pub struct ProcessingMetrics {
     pub format_out: String,
     /// True when ICC profile was present and preserved
     pub icc_preserved: bool,
+    /// ICC handling result: absent, preserved, unsafe-stripped, policy-stripped, or unsupported
+    pub icc_outcome: String,
     /// True when metadata was stripped (either by default or policy)
     pub metadata_stripped: bool,
     /// Non-fatal policy rejections (e.g., strict policy forcing metadata strip)
@@ -212,6 +214,7 @@ impl Default for ProcessingMetrics {
             format_in: None,
             format_out: String::new(),
             icc_preserved: false,
+            icc_outcome: "absent".to_string(),
             metadata_stripped: true,
             policy_violations: Vec::new(),
         }
@@ -362,7 +365,7 @@ mod tests {
 
     #[test]
     fn test_processing_metrics_version_constant() {
-        assert_eq!(PROCESSING_METRICS_VERSION, "1.0.0");
+        assert_eq!(PROCESSING_METRICS_VERSION, "1.1.0");
     }
 
     #[test]

--- a/test/integration/basic.test.js
+++ b/test/integration/basic.test.js
@@ -124,7 +124,7 @@ async function runTests() {
         
         assert(data.length > 0, 'output should have content');
         assert(typeof metrics === 'object', 'metrics should be an object');
-        assert.strictEqual(metrics.version, '1.0.0', 'version should be set');
+        assert.strictEqual(metrics.version, '1.1.0', 'version should be set');
 
         // New productized fields
         assert(typeof metrics.decodeMs === 'number', 'decodeMs should be a number');

--- a/test/integration/edge-cases.test.js
+++ b/test/integration/edge-cases.test.js
@@ -411,7 +411,7 @@ async function runTests() {
         assert(result.data, 'should have data');
         assert(result.metrics, 'should have metrics');
         
-        assert.strictEqual(result.metrics.version, '1.0.0', 'version should be set');
+        assert.strictEqual(result.metrics.version, '1.1.0', 'version should be set');
 
         // Productized fields
         assert(typeof result.metrics.decodeMs === 'number', 'decodeMs should be number');

--- a/test/integration/firewall.test.js
+++ b/test/integration/firewall.test.js
@@ -28,6 +28,22 @@ function test(name, fn) {
     }
 }
 
+function jpegWithIcc(jpeg, valid) {
+    const profile = Buffer.alloc(132);
+    profile.writeUInt32BE(132, 0);
+    profile.write('TEST', 4, 'ascii');
+    profile[8] = 2;
+    profile.write('mntr', 12, 'ascii');
+    profile.write('RGB ', 16, 'ascii');
+    profile.write('XYZ ', 20, 'ascii');
+    if (valid) profile.write('acsp', 36, 'ascii');
+    const payload = Buffer.concat([Buffer.from('ICC_PROFILE\0'), Buffer.from([1, 1]), profile]);
+    const marker = Buffer.alloc(4);
+    marker.writeUInt16BE(0xffe2, 0);
+    marker.writeUInt16BE(payload.length + 2, 2);
+    return Buffer.concat([jpeg.subarray(0, 2), marker, payload, jpeg.subarray(2)]);
+}
+
 async function asyncTest(name, fn) {
     try {
         await fn();
@@ -67,6 +83,53 @@ async function runTests() {
             .resize(100)
             .toBuffer('jpeg', 80);
         assert(result.length > 0, 'output should have content');
+    });
+
+    await asyncTest('public-upload forces privacy-safe metadata regardless of call order', async () => {
+        const exifInput = resolveFixture('test_with_exif.jpg');
+        const engines = [
+            ImageEngine.fromPath(exifInput)
+                .keepMetadata({ icc: true, exif: true, stripGps: false })
+                .sanitize({ policy: 'public-upload' }),
+            ImageEngine.fromPath(exifInput)
+                .sanitize({ policy: 'public-upload' })
+                .keepMetadata({ icc: true, exif: true, stripGps: false }),
+            ImageEngine.fromPath(exifInput)
+                .autoOrient(false)
+                .sanitize({ policy: 'public-upload' }),
+            ImageEngine.fromPath(exifInput)
+                .sanitize({ policy: 'public-upload' })
+                .autoOrient(false),
+        ];
+
+        let orientedData;
+        for (const engine of engines) {
+            const { data, metrics } = await engine.toBufferWithMetrics('jpeg', 80);
+            assert(!data.includes(Buffer.from('Exif\0\0')), 'public-upload must strip EXIF/GPS');
+            assert(
+                ['absent', 'preserved', 'unsafe-stripped', 'policy-stripped', 'unsupported'].includes(metrics.iccOutcome),
+                `unexpected ICC outcome: ${metrics.iccOutcome}`,
+            );
+            if (!orientedData) orientedData = data;
+            else assert.deepStrictEqual(data, orientedData, 'public-upload must force auto orientation');
+        }
+
+        const safe = await ImageEngine.from(jpegWithIcc(smallBuffer, true))
+            .sanitize({ policy: 'public-upload' })
+            .toBufferWithMetrics('jpeg', 80);
+        assert.strictEqual(safe.metrics.iccOutcome, 'preserved');
+
+        const malformed = await ImageEngine.from(jpegWithIcc(smallBuffer, false))
+            .sanitize({ policy: 'public-upload' })
+            .toBufferWithMetrics('jpeg', 80);
+        assert.strictEqual(malformed.metrics.iccOutcome, 'unsafe-stripped');
+
+        assert.throws(
+            () => ImageEngine.from(smallBuffer)
+                .sanitize({ policy: 'public-upload' })
+                .limits({ maxBytes: 0 }),
+            /cannot be disabled/,
+        );
     });
 
     await asyncTest('sanitize() defaults to strict policy', async () => {


### PR DESCRIPTION
## 背景

既存のstrictはICCを拒否し、lenientはresource limitsを緩めるため、信頼できないuploadを厳しい上限のままprivacy-safeなWeb成果物へ変換できませんでした。

## 変更前後

- 変更前: strict相当の32 MiB / 40 MP / 5秒と安全なICC保持を両立できない
- 変更後: sanitize({ policy: public-upload })で上限を維持し、構造検証済みICCだけを最大512 KiBまで保持する

## 意思決定と変更内容

- Rustをsecurity decisionのsingle source of truthとする
- EXIF/GPS/XMP/comment/unknown metadataは常に削除し、orientationは画素へ強制適用する
- 呼び出し順、clone、batchでもpolicy invariantを維持する
- ICCを absent / preserved / unsafe-stripped / unsupported-output として観測可能にする
- JPEG/PNG ICC parsingをboundedにし、malformed・partial・oversized payloadを公開成果物へ通さない
- 新規runtime依存は追加しない

## レビュー

セキュリティ専門レビューを複数回実施し、ICC signature/tag bounds、共有tag range、JPEG fill/standalone marker、orientation、8-32 MiB入力、metrics schema driftを修正済みです。最終レビューでCritical/High/Mediumの残存指摘はありません。

## 検証

- npm run build
- npm test（Rust 291件を含む）
- focused ICC tests 29件
- firewall integration tests 17件
- npm audit --omit=dev --audit-level=high（runtime vulnerability 0）
- git diff --check

## 残る制約

timeoutは既存契約どおりstage間のcooperative checkです。Edge/Wasm parity、colour conversion、artifact compiler本体はスコープ外です。

Closes #781