### PR TITLE
test(reliability): stress public upload NAPI paths

### DIFF
--- a/test/integration/napi-stress-corpus.test.js
+++ b/test/integration/napi-stress-corpus.test.js
@@ -72,6 +72,8 @@ test('stress smoke includes generated malformed fuzz seeds and writes summaries'
   assert.equal(summary.options.malformedRounds, 1);
   assert.equal(summary.options.targetBytesRounds, 1);
   assert.equal(summary.boundaryCoverage.cloneMultiOutputRounds, 1);
+  assert.equal(summary.boundaryCoverage.publicUploadCloneRounds, 1);
+  assert.equal(summary.boundaryCoverage.publicUploadMalformedBufferAttempts, 30);
   assert.equal(summary.boundaryCoverage.targetBytesSearchRounds, 1);
   assert.equal(summary.boundaryCoverage.targetBytesSearches, 2);
   assert.equal(summary.malformedInputs.total, 30);
@@ -86,6 +88,8 @@ test('stress smoke includes generated malformed fuzz seeds and writes summaries'
   assert.match(markdown, /NAPI Boundary Stress Summary/);
   assert.match(markdown, /targetBytesRounds: 1/);
   assert.match(markdown, /cloneMultiOutputRounds: 1/);
+  assert.match(markdown, /publicUploadCloneRounds: 1/);
+  assert.match(markdown, /publicUploadMalformedBufferAttempts: 30/);
   assert.match(markdown, /targetBytesSearches: 2/);
   assert.match(markdown, /generatedFuzzSeeds: 25/);
   assert.match(markdown, /generatedFuzzFilePathSeeds: 25/);

--- a/test/stress/napi-boundary.stress.js
+++ b/test/stress/napi-boundary.stress.js
@@ -6,6 +6,7 @@ const { resolveFixture, resolveRoot, resolveTemp } = require('../helpers/paths')
 
 const INPUT_JPEG = resolveFixture('test_input.jpg');
 const INPUT_PNG = resolveFixture('test_input.png');
+const INPUT_EXIF_JPEG = resolveFixture('test_with_exif.jpg');
 const FUZZ_SEED_SCRIPT = resolveRoot('scripts/fuzz/write-seed-corpus.mjs');
 
 function parsePositiveInt(value, optionName) {
@@ -291,8 +292,10 @@ async function runIteration(iteration, rootDir, includeTargetBytesRound) {
     throw new Error(`iteration ${iteration}: file output wrote no bytes`);
   }
 
-  const cloneEngine = ImageEngine.fromPath(INPUT_PNG)
-    .sanitize({ policy: 'strict' })
+  const cloneEngine = ImageEngine.fromPath(INPUT_EXIF_JPEG)
+    .keepMetadata({ icc: true, exif: true, stripGps: false })
+    .autoOrient(false)
+    .sanitize({ policy: 'public-upload' })
     .resize({ width: 160, fit: 'inside' });
   const [cloneJpeg, cloneWebp, cloneMetrics] = await Promise.all([
     cloneEngine.clone().toBuffer('jpeg', 76),
@@ -302,6 +305,9 @@ async function runIteration(iteration, rootDir, includeTargetBytesRound) {
 
   if (!Buffer.isBuffer(cloneJpeg) || cloneJpeg.length === 0) {
     throw new Error(`iteration ${iteration}: clone JPEG output returned no bytes`);
+  }
+  if (cloneJpeg.includes(Buffer.from('Exif\0\0'))) {
+    throw new Error(`iteration ${iteration}: public-upload clone retained EXIF`);
   }
   if (!Buffer.isBuffer(cloneWebp) || cloneWebp.length === 0) {
     throw new Error(`iteration ${iteration}: clone WebP output returned no bytes`);
@@ -336,7 +342,7 @@ async function runMalformedRound(round, malformedInputs) {
   for (const input of malformedInputs) {
     await expectRejects(`malformed round ${round}: ${input.name}`, () => (
       ImageEngine.from(input.data)
-        .sanitize({ policy: 'strict' })
+        .sanitize({ policy: 'public-upload' })
         .resize({ width: 64, fit: 'inside' })
         .toBufferWithMetrics('jpeg', 80)
     ));
@@ -433,6 +439,8 @@ function buildSummary(options, malformedInputs, memorySamples) {
     },
     boundaryCoverage: {
       cloneMultiOutputRounds: options.iterations,
+      publicUploadCloneRounds: options.iterations,
+      publicUploadMalformedBufferAttempts: options.malformedRounds * malformedInputs.length,
       targetBytesSearchRounds: options.targetBytesRounds,
       targetBytesSearches: options.targetBytesRounds * 2,
     },
@@ -460,6 +468,8 @@ function formatSummaryMarkdown(summary) {
     `- malformedRounds: ${summary.options.malformedRounds}`,
     `- targetBytesRounds: ${summary.options.targetBytesRounds}`,
     `- cloneMultiOutputRounds: ${summary.boundaryCoverage.cloneMultiOutputRounds}`,
+    `- publicUploadCloneRounds: ${summary.boundaryCoverage.publicUploadCloneRounds}`,
+    `- publicUploadMalformedBufferAttempts: ${summary.boundaryCoverage.publicUploadMalformedBufferAttempts}`,
     `- targetBytesSearches: ${summary.boundaryCoverage.targetBytesSearches}`,
     `- malformedInputs: ${summary.malformedInputs.total}`,
     `- generatedFuzzSeeds: ${summary.malformedInputs.generatedFuzzSeeds}`,


### PR DESCRIPTION
## 背景

`public-upload` policyは #807 で追加されましたが、長時間ASan/LSan NAPI stress runnerはstrict経路だけを反復しており、新しいtrust boundaryとcoverageが同期していませんでした。

## 変更前後

- 変更前: clone/malformed stressはstrict policyのみ
- 変更後: EXIF入力のpublic-upload cloneと、malformed bufferのpublic-upload拒否経路を既存反復内で検証

## 意思決定と変更内容

- 新規workflow、fixture、依存は追加しない
- 既存clone roundをpublic-uploadへ切り替え、`keepMetadata`と`autoOrient(false)`後でもEXIFが残らないことを確認
- 既存buffer malformed loopをpublic-uploadへ切り替え、file malformed/target-bytesのstrict coverageは維持
- stress artifactへpublicUploadCloneRoundsとpublicUploadMalformedBufferAttemptsを記録

## 検証

- node test/integration/napi-stress-corpus.test.js
- npm run build
- npm test
- npm run test:stress:napi -- --iterations 3 --malformed-rounds 3 --target-bytes-rounds 0 --rss-growth-limit-mb 0
- git diff --check

3反復でpublic-upload clone 3回、malformed buffer 90回を実行しました。

## 残る制約

ローカル確認は通常bindingです。ASan/LSan instrumentationはこのPRの既存hosted Memory Leak Detection jobで最終確認します。

Refs #646