### PR TITLE
chore(release): 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [1.0.0] - 2026-08-22
+
 ### Added
 - **Public upload firewall policy**: `sanitize({ policy: 'public-upload' })`
   combines the strict 32 MiB / 40 MP / 5-second limits with validated ICC
@@ -16,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   report `hasAlpha`, `isAnimated`, and optional EXIF `orientation` for
   JPEG/PNG/WebP without decoding pixels. Unknown or malformed traits fail
   through the typed error contract instead of being treated as safe defaults.
+- **Event-loop-safe file input**: `ImageEngine.fromPathAsync()` moves file open,
+  read, and mmap setup off the Node.js main thread while preserving the same
+  locking, memory limits, and typed errors as `fromPath()`.
 
 ### Changed
 - **BREAKING (Node.js runtime)**: dropped EOL Node.js 18 and 20. The native and
@@ -28,6 +35,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `E105→E122`, fit-related `E202→E203/E204`, `E201→E502`, abort
   `E204→E500`, timeout `E205→E123`, `E301/E302→E400`, encode
   `E303→E300`, unavailable Blob `E303→E501`, and validation `E402→E400`.
+
+### Fixed
+- **Preset output isolation**: self-contained preset output methods no longer
+  mutate the source pipeline or affect later outputs from the same engine.
+
+### Performance
+- **Native target-byte file output**: `toFileTargetBytes()` keeps the selected
+  encoded candidate in Rust and writes it atomically without copying the full
+  result through a V8 `Buffer`.
+
+### Security
+- Removed an unused vulnerable EXIF dependency and its affected transitive
+  packages without changing the existing metadata implementation.
 
 ---
 
@@ -557,7 +577,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[Unreleased]: https://github.com/albert-einshutoin/lazy-image/compare/v0.16.0...HEAD
+[Unreleased]: https://github.com/albert-einshutoin/lazy-image/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/albert-einshutoin/lazy-image/compare/v0.16.0...v1.0.0
 [0.16.0]: https://github.com/albert-einshutoin/lazy-image/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/albert-einshutoin/lazy-image/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/albert-einshutoin/lazy-image/compare/v0.13.0...v0.14.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "lazy-image"
-version = "0.16.0"
+version = "1.0.0"
 dependencies = [
  "bitflags",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lazy-image"
-version = "0.16.0"
+version = "1.0.0"
 edition = "2021"
 description = "Web image optimization engine for Node.js with secure defaults and smaller browser-facing JPEG outputs, powered by Rust + mozjpeg"
 license = "MIT"

--- a/docs/VERSIONING_PLAN.md
+++ b/docs/VERSIONING_PLAN.md
@@ -1,6 +1,6 @@
 # 📋 Versioning Plan & Priorities
 
-> **Current package version**: v0.16.x
+> **Current package version**: v1.0.x
 > **Working baseline**: `main`
 
 このドキュメントは、古い issue 番号ベースの固定計画ではなく、`main` の現状に合った優先順位を簡潔に示します。
@@ -28,8 +28,8 @@
 
 - patch/minor: additive changes, docs alignment, performance/safety improvements
 - major: API removal, semantic shifts, or new execution-model assumptions
-- 現在の `Unreleased` には Wasm error contract と Node.js runtime floor の
-  breaking marker があるため、そのまま公開する次リリースは `1.0.0` とする。
+- `1.0.0` は Wasm error contract と Node.js runtime floor の breaking change を
+  major boundary として公開する。
 - release branch では version/changelog 更新後に `npm run release:check` を実行し、
   breaking marker を含む non-major release を拒否する。
 

--- a/index.js
+++ b/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-android-arm64')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-android-arm-eabi')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-win32-x64-gnu')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-win32-x64-msvc')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-win32-ia32-msvc')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-win32-arm64-msvc')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@alberteinshutoin/lazy-image-darwin-universal')
       const bindingPackageVersion = require('@alberteinshutoin/lazy-image-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-darwin-x64')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-darwin-arm64')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-freebsd-x64')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-freebsd-arm64')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-x64-musl')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-x64-gnu')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-arm64-musl')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-arm64-gnu')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-arm-musleabihf')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-loong64-musl')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-loong64-gnu')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-riscv64-musl')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-riscv64-gnu')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-linux-ppc64-gnu')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-linux-s390x-gnu')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-openharmony-arm64')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-openharmony-x64')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-openharmony-arm')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.16.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.16.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alberteinshutoin/lazy-image",
-  "version": "0.16.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@alberteinshutoin/lazy-image",
-      "version": "0.16.0",
+      "version": "1.0.0",
       "license": "MIT",
       "workspaces": [
         "packages/lazy-image-wasm"
@@ -22,32 +22,32 @@
         "node": ">= 22"
       },
       "optionalDependencies": {
-        "@alberteinshutoin/lazy-image-darwin-arm64": "0.16.0",
-        "@alberteinshutoin/lazy-image-darwin-x64": "0.16.0",
-        "@alberteinshutoin/lazy-image-linux-arm64-gnu": "0.16.0",
-        "@alberteinshutoin/lazy-image-linux-x64-gnu": "0.16.0",
-        "@alberteinshutoin/lazy-image-linux-x64-musl": "0.16.0",
-        "@alberteinshutoin/lazy-image-win32-x64-msvc": "0.16.0"
+        "@alberteinshutoin/lazy-image-darwin-arm64": "1.0.0",
+        "@alberteinshutoin/lazy-image-darwin-x64": "1.0.0",
+        "@alberteinshutoin/lazy-image-linux-arm64-gnu": "1.0.0",
+        "@alberteinshutoin/lazy-image-linux-x64-gnu": "1.0.0",
+        "@alberteinshutoin/lazy-image-linux-x64-musl": "1.0.0",
+        "@alberteinshutoin/lazy-image-win32-x64-msvc": "1.0.0"
       }
     },
     "node_modules/@alberteinshutoin/lazy-image-darwin-arm64": {
-      "version": "0.16.0",
+      "version": "1.0.0",
       "optional": true
     },
     "node_modules/@alberteinshutoin/lazy-image-darwin-x64": {
-      "version": "0.16.0",
+      "version": "1.0.0",
       "optional": true
     },
     "node_modules/@alberteinshutoin/lazy-image-linux-arm64-gnu": {
-      "version": "0.16.0",
+      "version": "1.0.0",
       "optional": true
     },
     "node_modules/@alberteinshutoin/lazy-image-linux-x64-gnu": {
-      "version": "0.16.0",
+      "version": "1.0.0",
       "optional": true
     },
     "node_modules/@alberteinshutoin/lazy-image-linux-x64-musl": {
-      "version": "0.16.0",
+      "version": "1.0.0",
       "optional": true
     },
     "node_modules/@alberteinshutoin/lazy-image-wasm": {
@@ -55,7 +55,7 @@
       "link": true
     },
     "node_modules/@alberteinshutoin/lazy-image-win32-x64-msvc": {
-      "version": "0.16.0",
+      "version": "1.0.0",
       "optional": true
     },
     "node_modules/@emnapi/core": {
@@ -2488,7 +2488,7 @@
     },
     "packages/lazy-image-wasm": {
       "name": "@alberteinshutoin/lazy-image-wasm",
-      "version": "0.16.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@jsquash/jpeg": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alberteinshutoin/lazy-image",
-  "version": "0.16.0",
+  "version": "1.0.0",
   "description": "Web image optimization engine for Node.js with Image Firewall-backed secure upload defaults and smaller JPEG outputs in canonical PNG → JPEG benchmarks, powered by Rust + mozjpeg",
   "main": "index.js",
   "exports": {
@@ -112,12 +112,12 @@
     ]
   },
   "optionalDependencies": {
-    "@alberteinshutoin/lazy-image-darwin-arm64": "0.16.0",
-    "@alberteinshutoin/lazy-image-darwin-x64": "0.16.0",
-    "@alberteinshutoin/lazy-image-linux-x64-gnu": "0.16.0",
-    "@alberteinshutoin/lazy-image-linux-x64-musl": "0.16.0",
-    "@alberteinshutoin/lazy-image-linux-arm64-gnu": "0.16.0",
-    "@alberteinshutoin/lazy-image-win32-x64-msvc": "0.16.0"
+    "@alberteinshutoin/lazy-image-darwin-arm64": "1.0.0",
+    "@alberteinshutoin/lazy-image-darwin-x64": "1.0.0",
+    "@alberteinshutoin/lazy-image-linux-x64-gnu": "1.0.0",
+    "@alberteinshutoin/lazy-image-linux-x64-musl": "1.0.0",
+    "@alberteinshutoin/lazy-image-linux-arm64-gnu": "1.0.0",
+    "@alberteinshutoin/lazy-image-win32-x64-msvc": "1.0.0"
   },
   "engines": {
     "node": ">= 22"

--- a/packages/lazy-image-wasm/package.json
+++ b/packages/lazy-image-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alberteinshutoin/lazy-image-wasm",
-  "version": "0.16.0",
+  "version": "1.0.0",
   "description": "Browser and Edge upload-preflight optimizer for lazy-image policy APIs",
   "type": "module",
   "sideEffects": false,

--- a/packages/lazy-image-wasm/shared.js
+++ b/packages/lazy-image-wasm/shared.js
@@ -1,4 +1,4 @@
-export const VERSION = '0.16.0';
+export const VERSION = '1.0.0';
 
 export const ERROR_CATEGORIES = Object.freeze({
   UserError: 'UserError',


### PR DESCRIPTION
## 背景

`Unreleased` には Node.js runtime floor と Wasm error contract の breaking change があり、release policy 上の次版は major boundary の `1.0.0` が必要です。v1.x milestone の最後の reliability issue #646 も #808 と main ASan 成功で完了しました。

## 変更前後

- 変更前: package/Cargo/Wasm/native loader は `0.16.0`、Changelog は Unreleased のまま
- 変更後: 公開 package・lockfile・Cargo・Wasm VERSION・native loader を `1.0.0` へ同期し、2026-08-22 の release section を確定

## 意思決定

- breaking marker を再分類せず SemVer major として公開する
- #769 と #696–#698 は継続課題であり、1.0.0 の公開ブロッカーには含めない
- v0.16.0 以降のユーザー向け追加・修正・性能・security変更を Changelog に補完する
- 新機能、依存更新、workflow変更はこの release prep に追加しない

## 変更内容

- root / platform optional dependencies / Wasm workspace / Cargo / lockfile を 1.0.0 へ同期
- `index.js` の生成済みnative package version checkを 1.0.0 へ更新
- Changelog に public-upload、authoritative inspect traits、fromPathAsync、preset isolation、native target-byte file output、security dependency cleanup、2件のbreaking migrationを記録
- versioning plan のcurrent packageと1.0.0方針を同期

## 検証

- `npm run build`
- build再実行後の `index.js` / `index.d.ts` 差分hashが不変
- `npm test`（Rust 291件、JS/型/pack contract/Wasmを含む）
- `npm run release:check`
- `npm audit --omit=dev --audit-level=high`（runtime vulnerability 0）
- 全release versionの同期assertion
- `git diff --check`

## 残る制約

- default branchの既知のhigh advisory 2件はdevelopment-only codec oracle経路で、公開runtime graphは0件です。既存Security Auditはruntime highとdevelopment criticalを別gateにしています。
- このPRはrelease prepのみです。tag push、npm publish、GitHub Release作成はmerge後の別工程です。