### PR TITLE
fix(ci): harden release publishing guards

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -575,7 +575,7 @@ jobs:
       - leak-detection
     # Publishing requires a release tag. Manual runs may exercise packaging only
     # when both full validation is disabled and dry-run is explicitly enabled.
-    if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && !inputs.full_validation && inputs.dry_run)
+    if: (github.event_name != 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/v')) || (github.event_name == 'workflow_dispatch' && !inputs.full_validation && inputs.dry_run)
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -573,9 +573,9 @@ jobs:
       - supply-chain
       - coverage
       - leak-detection
-    # Manual full validation is safe by default and never enters the publish job.
-    # A deliberate manual publish must disable full_validation (and dry_run).
-    if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && !inputs.full_validation)
+    # Publishing requires a release tag. Manual runs may exercise packaging only
+    # when both full validation is disabled and dry-run is explicitly enabled.
+    if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && !inputs.full_validation && inputs.dry_run)
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -594,6 +594,10 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Verify release tag matches package version
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: node scripts/check-release-policy.js "$(node -p "require('./package.json').version")" "$GITHUB_REF_NAME"
 
       - name: Download all artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -864,8 +868,15 @@ jobs:
       - name: Publish main package
         if: ${{ github.event_name != 'workflow_dispatch' || !inputs.dry_run }}
         run: |
+          pkg_name="$(node -p "require('./package.json').name")"
+          pkg_version="$(node -p "require('./package.json').version")"
+          if npm view "$pkg_name@$pkg_version" version >/dev/null 2>&1; then
+            echo "$pkg_name@$pkg_version already exists; skipping publish."
+            exit 0
+          fi
+
           # Remove .node files from main package (they're in platform packages now)
-          rm -f *.node
+          rm -f -- ./*.node
           # Restore original package.json if napi prepublish modified it
           git checkout package.json || true
           # Publish without running prepublishOnly (we already ran napi prepublish manually)

--- a/scripts/check-release-policy.js
+++ b/scripts/check-release-policy.js
@@ -81,6 +81,12 @@ function isMajorBoundary(version) {
   return version.minor === 0 && version.patch === 0;
 }
 
+function assertTagMatchesVersion(tag, version) {
+  if (tag !== `v${version}`) {
+    throw new Error(`Release tag ${tag} does not match package version ${version}.`);
+  }
+}
+
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -88,6 +94,10 @@ function escapeRegExp(value) {
 function main() {
   const pkg = readJson(pkgPath);
   const version = process.argv[2] || pkg.version;
+  const tag = process.argv[3];
+  if (tag) {
+    assertTagMatchesVersion(tag, version);
+  }
   const parsed = parseVersion(version);
   const changelog = fs.readFileSync(changelogPath, "utf8");
   const section = sectionForVersion(changelog, version);
@@ -122,6 +132,7 @@ if (require.main === module) {
 }
 
 module.exports = {
+  assertTagMatchesVersion,
   hasBreakingMarker,
   hasRemovedEntry,
   isMajorBoundary,

--- a/test/unit/release-policy.test.js
+++ b/test/unit/release-policy.test.js
@@ -73,7 +73,7 @@ test("release tag must match the package version", () => {
 test("manual release workflow can only enter the publish job in dry-run mode", () => {
   assert.match(
     workflow,
-    /if: startsWith\(github\.ref, 'refs\/tags\/v'\) \|\| \(github\.event_name == 'workflow_dispatch' && !inputs\.full_validation && inputs\.dry_run\)/,
+    /if: \(github\.event_name != 'workflow_dispatch' && startsWith\(github\.ref, 'refs\/tags\/v'\)\) \|\| \(github\.event_name == 'workflow_dispatch' && !inputs\.full_validation && inputs\.dry_run\)/,
   );
 });
 

--- a/test/unit/release-policy.test.js
+++ b/test/unit/release-policy.test.js
@@ -1,12 +1,20 @@
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
 
 const {
+  assertTagMatchesVersion,
   hasBreakingMarker,
   hasRemovedEntry,
   isMajorBoundary,
   parseVersion,
   sectionForVersion,
 } = require("../../scripts/check-release-policy");
+
+const workflow = fs.readFileSync(
+  path.join(__dirname, "../../.github/workflows/CI.yml"),
+  "utf8",
+);
 
 function test(name, fn) {
   try {
@@ -52,4 +60,25 @@ test("major boundary means x.0.0", () => {
   assert.equal(isMajorBoundary(parseVersion("2.0.0-beta.1")), true);
   assert.equal(isMajorBoundary(parseVersion("0.16.0")), false);
   assert.equal(isMajorBoundary(parseVersion("1.2.0")), false);
+});
+
+test("release tag must match the package version", () => {
+  assert.doesNotThrow(() => assertTagMatchesVersion("v1.0.0", "1.0.0"));
+  assert.throws(
+    () => assertTagMatchesVersion("v1.0.1", "1.0.0"),
+    /Release tag v1\.0\.1 does not match package version 1\.0\.0/,
+  );
+});
+
+test("manual release workflow can only enter the publish job in dry-run mode", () => {
+  assert.match(
+    workflow,
+    /if: startsWith\(github\.ref, 'refs\/tags\/v'\) \|\| \(github\.event_name == 'workflow_dispatch' && !inputs\.full_validation && inputs\.dry_run\)/,
+  );
+});
+
+test("main package publish skips an existing version", () => {
+  const mainPublish = workflow.slice(workflow.indexOf("- name: Publish main package"));
+  assert.match(mainPublish, /npm view "\$pkg_name@\$pkg_version" version/);
+  assert.ok(mainPublish.indexOf("npm view") < mainPublish.indexOf("npm publish"));
 });


### PR DESCRIPTION
## 背景

v1.0.0リリース準備レビューで、release tagとpackage versionの不一致を検出できないこと、およびmain packageのpublish再実行が冪等でないことを確認しました。

## 変更前後

- 変更前: 任意の`v*` tagでpublish jobが進み、tagとpackage versionの一致を検証していませんでした。
- 変更前: 手動実行でrelease tagなしの実publish経路がありました。
- 変更前: platform/Wasm packageは公開済みversionをskipしますが、main packageは同じversionを再publishして失敗しました。
- 変更後: tag publish時に`v${package.json.version}`との完全一致を検証します。
- 変更後: 手動実行は明示的なdry-runだけpublish jobへ入り、実publishしません。
- 変更後: main packageも公開済みversionを検出してskipします。

## 意思決定

既存の`check-release-policy.js`と、platform/Wasm packageで採用済みの`npm view`による確認パターンを再利用しました。新規依存やrelease用scaffoldは追加していません。

## 変更内容

- release tagとpackage versionの整合性チェック
- 手動release workflowのdry-run限定
- main package publishの再実行ガード
- 上記の最小unit/workflow契約テスト

## 検証結果

- `npm run build`
- `npm test`
- `npm run release:check`
- `actionlint .github/workflows/CI.yml`
- `git diff --check`
- `npm audit --omit=dev --audit-level=high`（0件）

## 残る制約

- このPRはtag作成、npm publish、GitHub Release作成を行いません。
- `main` branch protectionはGitHub側の外部設定として別対応です。
- dev dependencyの既知high advisory 2件は既存Issue/PRの範囲で、本変更には混在させていません。
