### PR TITLE
docs: align v1.x release contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Synchronized the v1.x documentation with the published Wasm MVP and removed
+  stale references to planned or unavailable package entrypoints.
+- Clarified that deprecated output conveniences and metrics aliases remain
+  available throughout v1.x and are candidates for removal only in v2.0.0.
+
 ---
 
 ## [1.0.0] - 2026-08-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Synchronized the v1.x documentation with the published Wasm MVP and removed
   stale references to planned or unavailable package entrypoints.
-- Clarified that deprecated output conveniences and metrics aliases remain
-  available throughout v1.x and are candidates for removal only in v2.0.0.
+- Clarified that deprecated output conveniences remain available throughout
+  v1.x, and removed stale documentation for metrics aliases removed before v1.
 
 ---
 

--- a/docs/ADOPTION_GUIDE.md
+++ b/docs/ADOPTION_GUIDE.md
@@ -210,8 +210,13 @@ Same pattern as Lambda. Use `/tmp` for scratch files. For Cloud Run, set `--memo
 
 These environments run in V8 isolates and **do not support the native NAPI binary** that lazy-image ships. The published `@alberteinshutoin/lazy-image` package requires a Node.js runtime (Vercel Node Functions, Netlify Node Functions, AWS Lambda, Cloud Run, etc.).
 
-For Edge / Workers, process images in a background Node-runtime function and serve the results from a CDN. Wasm support for V8-isolate runtimes is tracked under [#645](https://github.com/albert-einshutoin/lazy-image/issues/645).
-The current product direction is documented in [WASM_STRATEGY.md](./WASM_STRATEGY.md), with benchmark expectations in [WASM_BENCHMARKING.md](./WASM_BENCHMARKING.md).
+For Edge / Workers, the published `@alberteinshutoin/lazy-image-wasm` MVP provides
+an upload-preflight path. Treat production suitability as runtime-specific and
+validate bundle cost, codec loading, and latency for the target deployment.
+Broader runtime evidence and ergonomics are tracked under
+[#645](https://github.com/albert-einshutoin/lazy-image/issues/645). The current
+product direction is documented in [WASM_STRATEGY.md](./WASM_STRATEGY.md), with
+benchmark expectations in [WASM_BENCHMARKING.md](./WASM_BENCHMARKING.md).
 
 ### Cold start optimization
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -2,8 +2,8 @@
 
 Full API reference for lazy-image. For a quick start, see [README.md](../README.md#-basic-usage).
 
-This page documents the native Node.js package. The planned browser/Edge Wasm
-API is intentionally narrower and is documented separately in
+This page documents the native Node.js package. The published browser/Edge Wasm
+MVP is intentionally narrower and is documented separately in
 [WASM_PACKAGE_API.md](./WASM_PACKAGE_API.md).
 
 ## Constructors
@@ -35,7 +35,6 @@ const bytes = await engine.resize(800).toFile('output.jpg', 'jpeg', 80);
 | `.brightness(value)` | Adjust brightness (-100 to 100) |
 | `.contrast(value)` | Adjust contrast (-100 to 100) |
 | `.normalizePixelFormat()` | Normalize pixel format to RGB/RGBA without color space conversion. |
-| `.toColorspace(space)` | ⚠️ **DEPRECATED** - Use `.normalizePixelFormat()` instead. |
 | `.preset(name)` | ⚠️ **DEPRECATED** - Applies a preset (`'thumbnail'`, `'avatar'`, `'hero'`, `'social'`) by mutating the pipeline and returning a separate `PresetResult`. Prefer `encode({ preset: name })`, `.toBufferWithPreset(name)`, or `.toFileWithPreset(path, name)` for self-contained preset output. |
 | `.sanitize({ policy? })` | Image Firewall: apply `strict`, `lenient`, or `public-upload`. The public-upload policy keeps strict resource limits, preserves only validated ICC up to 512 KiB, and always strips EXIF/GPS/XMP. See [METADATA_SUPPORT.md](./METADATA_SUPPORT.md). |
 | `.limits({ maxPixels?, maxBytes?, timeoutMs? })` | Override firewall limits. |

--- a/docs/API.md
+++ b/docs/API.md
@@ -220,18 +220,6 @@ interface ProcessingMetrics {
   iccOutcome: 'absent' | 'preserved' | 'unsafe-stripped' | 'policy-stripped' | 'unsupported';
   metadataStripped: boolean;
   policyViolations: string[];
-  /** @deprecated use decodeMs */
-  decodeTime: number;
-  /** @deprecated use opsMs */
-  processTime: number;
-  /** @deprecated use encodeMs */
-  encodeTime: number;
-  /** @deprecated use peakRss */
-  memoryPeak: number;
-  /** @deprecated use bytesIn */
-  inputSize: number;
-  /** @deprecated use bytesOut */
-  outputSize: number;
 }
 
 interface OutputWithMetrics {
@@ -309,7 +297,8 @@ interface BatchOutputWithMetrics {
 
 Metrics payloads are versioned. See [metrics-api.md](./metrics-api.md) and [metrics-schema.json](./metrics-schema.json).
 
-**Deprecation**: Legacy metric field names (`decodeTime`, `processTime`, etc.) will be removed in v2.0.0. Use `decodeMs`, `opsMs`, `peakRss`, `bytesIn`, `bytesOut`.
+Only the canonical fields above are part of the v1.x contract. Legacy metric
+aliases removed before v1 are not returned.
 
 ---
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -35,14 +35,16 @@ Key rules:
 Before starting a release:
 
 1. **`main` is green**: all required CI workflows pass on the latest commit.
-2. **No open release PR**: only one release in flight at a time.
-3. **`NPM_TOKEN` secret is valid**: check expiry in GitHub repo settings (Settings -> Secrets and variables -> Actions).
-4. **Local tooling**: `gh`, `cargo`, `npm`, `git` installed and authenticated.
-5. **Decide the next version**: follow [SEMVER_POLICY.md](SEMVER_POLICY.md).
+2. **`main` is protected**: require a pull request, successful CI/security checks,
+   and resolved review conversations before merging.
+3. **No open release PR**: only one release in flight at a time.
+4. **`NPM_TOKEN` secret is valid**: check expiry in GitHub repo settings (Settings -> Secrets and variables -> Actions).
+5. **Local tooling**: `gh`, `cargo`, `npm`, `git` installed and authenticated.
+6. **Decide the next version**: follow [SEMVER_POLICY.md](SEMVER_POLICY.md).
    - MAJOR (`x.0.0`): breaking changes
    - MINOR (`0.x.0`): backward-compatible additions
    - PATCH (`0.0.x`): bug fixes only
-6. **Check breaking-change markers**: if the target changelog section contains
+7. **Check breaking-change markers**: if the target changelog section contains
    `BREAKING` or `Removed`, the release version must be a major boundary
    (`x.0.0`). For current 0.x work, that means `1.0.0`.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -15,6 +15,7 @@ The following foundations are already in place on `main`:
 - **Benchmark and regression tooling**: benchmark docs, regression workflow, zero-copy measurement
 - **Fuzzing in CI**: nightly and PR-targeted fuzz workflows with multiple targets
 - **Release-size tuning**: release LTO, strip, and size-oriented profile tuning
+- **Wasm upload-preflight MVP**: public browser/Edge policy package with JPEG/WebP output, structured errors, and byte-budget search
 
 ## Current Priorities
 
@@ -55,8 +56,8 @@ The following foundations are already in place on `main`:
 
 ### Long-term
 
-- WebAssembly / worker-oriented packaging where the architecture fits
-- Browser upload-preflight package with byte-budget search, metadata stripping, and Web Worker guidance if the benchmark evidence supports it
+- Broader browser/Edge runtime validation and worker deployment guidance
+- Wasm upload-preflight benchmark evidence for bundle cost, latency, byte-budget behavior, and metadata stripping
 - Native Web Streams style APIs if and when true streaming execution becomes viable
 
 ---
@@ -89,6 +90,7 @@ To maintain focus and stability, the following features are explicitly **out of 
 - **ベンチマーク運用**: benchmark docs、regression workflow、zero-copy 計測
 - **CI fuzzing**: 複数ターゲットを持つ PR / nightly fuzz workflow
 - **リリースサイズ最適化**: release LTO、strip、サイズ指向の profile tuning
+- **Wasm upload-preflight MVP**: JPEG/WebP 出力、構造化エラー、byte-budget search を持つ browser/Edge 向け policy package を公開済み
 
 ---
 
@@ -131,8 +133,8 @@ To maintain focus and stability, the following features are explicitly **out of 
 
 ### 長期
 
-- 適合する形での WebAssembly / worker 向け展開
-- benchmark evidence が揃った場合の byte-budget search / metadata strip / Web Worker guidance 付き browser upload-preflight package
+- browser / Edge runtime 検証と worker deployment guidance の拡充
+- bundle cost、latency、byte-budget behavior、metadata strip に関する Wasm benchmark evidence
 - 実行モデルが整った場合の native Web Streams 風 API
 
 ---

--- a/docs/VERSIONING_PLAN.md
+++ b/docs/VERSIONING_PLAN.md
@@ -33,4 +33,14 @@
 - release branch では version/changelog 更新後に `npm run release:check` を実行し、
   breaking marker を含む non-major release を拒否する。
 
+## v1.x 互換性契約
+
+- `toBufferWithMetrics()` などの既存 output convenience API と deprecated
+  metrics aliases は v1.x では維持し、削除は v2.0.0 でのみ検討する。
+- #703（artifact compiler）、#769（実画像 benchmark evidence）、#645
+  （Wasm runtime expansion）は additive な将来作業であり、v1.0.1 の blocker
+  にはしない。
+- v1.0.1 は公開契約・ドキュメント・release governance の整合修正に限定し、
+  API removal や新しい runtime assumption を含めない。
+
 詳細な中長期方針は [ROADMAP.md](./ROADMAP.md) を参照してください。

--- a/docs/VERSIONING_PLAN.md
+++ b/docs/VERSIONING_PLAN.md
@@ -35,8 +35,9 @@
 
 ## v1.x 互換性契約
 
-- `toBufferWithMetrics()` などの既存 output convenience API と deprecated
-  metrics aliases は v1.x では維持し、削除は v2.0.0 でのみ検討する。
+- `toBufferWithMetrics()` などの既存 output convenience API は v1.x では
+  維持し、削除は v2.0.0 でのみ検討する。v1 より前に削除済みの metrics
+  aliases は v1.x の公開契約に含めない。
 - #703（artifact compiler）、#769（実画像 benchmark evidence）、#645
   （Wasm runtime expansion）は additive な将来作業であり、v1.0.1 の blocker
   にはしない。

--- a/docs/VERSION_HISTORY.md
+++ b/docs/VERSION_HISTORY.md
@@ -2,6 +2,11 @@
 
 | Version | Features |
 |---------|----------|
+| v1.0.0 | Node.js 22+ runtime floor, unified native/Wasm error contract, public-upload firewall policy, authoritative upload preflight traits, event-loop-safe `fromPathAsync()`, native target-byte file output, and the stable Wasm error-taxonomy release. |
+| v0.16.0 | Wasm upload-preflight MVP, benchmark/strategy documentation, reliability hardening, guarded release policy, and Wasm package publishing. |
+| v0.15.0 | Engine/module refactoring, package metadata cleanup, and maintained public API compatibility. |
+| v0.14.0 | TypeScript/examples/governance improvements and internal modularization. |
+| v0.13.0 | Unified `encode()` / `encodeToFile()` APIs, native target-byte search, ESM support, expanded metadata output, and serverless adoption guidance. |
 | v0.12.0 | npm package contract fixes (docs/spec included in tarball), pack verification, public TypeScript API tightening, CI permission minimization. |
 | v0.11.0 | Optional AVIF feature flag, expanded benchmark suite (AVIF/memory/cold-start + regression checks), firewall/decode hardening, error clone context fix, and API cleanup (deprecated aliases removed). |
 | v0.10.2 | Release 0.10.2 (version bump / パッケージ更新). |

--- a/docs/WASM_BENCHMARKING.md
+++ b/docs/WASM_BENCHMARKING.md
@@ -3,7 +3,7 @@
 This document defines how to evaluate the browser/Edge upload-preflight track.
 It complements the native sharp comparison benchmarks; it does not replace
 `TRUE_BENCHMARKS.md` as the source for public native performance claims.
-The planned package and policy API is defined in
+The published package and policy API is defined in
 [WASM_PACKAGE_API.md](./WASM_PACKAGE_API.md).
 The initial implementation package lives in `packages/lazy-image-wasm`; this
 benchmark remains the comparison artifact generator rather than a replacement
@@ -49,7 +49,7 @@ The report schema includes:
 - memory information where the runtime exposes useful data
 
 The native `@alberteinshutoin/lazy-image` row is a Node reference. It gives a
-quality, byte-budget, and latency baseline for the future Wasm package, but it
+quality, byte-budget, and latency baseline for the Wasm package, but it
 is not a browser runtime result.
 
 ## Competitor Baselines
@@ -74,7 +74,8 @@ bundle claims require a bundled entrypoint and `browserBundleGzipBytes`.
 
 Safe public claims:
 
-- "lazy-image is evaluating a browser/Edge upload-preflight Wasm track."
+- "lazy-image provides a browser/Edge upload-preflight Wasm MVP; production
+  suitability remains runtime- and workload-specific."
 - "The Wasm benchmark harness records browser bundle size when a runtime adapter
   provides it, plus load latency, first encode latency, byte-budget hit rate,
   quality, metadata behavior, and memory where available."

--- a/docs/WASM_PACKAGE_API.md
+++ b/docs/WASM_PACKAGE_API.md
@@ -1,18 +1,18 @@
 # Wasm Package And Policy API
 
 This document defines the package shape and shared policy contract for the
-Wasm/browser/Edge track. The initial package lives under
-`packages/lazy-image-wasm`; it is not yet a public npm release. The native Node
-package remains the production package until the Wasm package is benchmarked in
-real browser and Edge runtimes.
+Wasm/browser/Edge track. The v1.0.0 MVP is published as
+`@alberteinshutoin/lazy-image-wasm` and lives under `packages/lazy-image-wasm`.
+The native Node package remains the recommended production path until the Wasm
+package is benchmarked in real browser and Edge runtimes.
 
 ## Package Shape
 
-Planned package name:
+Package name:
 
 - `@alberteinshutoin/lazy-image-wasm`
 
-Planned entrypoints:
+Published entrypoints:
 
 | Entrypoint | Runtime | Purpose |
 |---|---|---|
@@ -57,7 +57,7 @@ core can replace that adapter without changing the public policy shape.
 
 ## Public API
 
-The first public API should be high-level and policy-oriented:
+The public API is high-level and policy-oriented:
 
 ```typescript
 import { optimizeUpload } from '@alberteinshutoin/lazy-image-wasm/browser';
@@ -249,7 +249,7 @@ If a future Wasm API needs batch behavior, it should be a browser/Edge-specific
 helper built around repeated `optimizeUpload()` calls and explicit caller-side
 concurrency.
 
-## First Release Scope
+## v1.0.0 Scope
 
 In scope:
 
@@ -273,9 +273,8 @@ Out of scope:
 - drawing, compositing, filters, animation, TIFF, PDF, SVG, RAW
 - filesystem or Node-only APIs
 
-## Acceptance For Implementation Work
+## Compatibility Guardrails
 
-Implementation-heavy Wasm issues should not start until this contract is either
-accepted as-is or updated by a dedicated design PR. After implementation begins,
-changes to the public policy shape should be treated as API design changes, not
-incidental benchmark or build-system work.
+The package is public as of v1.0.0. Changes to its policy shape, error taxonomy,
+entrypoints, or default behavior follow the same SemVer policy as the native
+package and must not be introduced as incidental benchmark or build-system work.

--- a/docs/WASM_PACKAGE_API.md
+++ b/docs/WASM_PACKAGE_API.md
@@ -40,11 +40,16 @@ fetched or embedded.
 
 ```typescript
 import { createUploadOptimizer } from '@alberteinshutoin/lazy-image-wasm/browser';
+import type { CreateUploadOptimizerOptions } from '@alberteinshutoin/lazy-image-wasm/shared';
 
-const optimizer = await createUploadOptimizer({
-  wasmUrl: new URL('./lazy_image_wasm_bg.wasm', import.meta.url),
-});
+declare const wasmModules: NonNullable<CreateUploadOptimizerOptions['wasmModules']>;
+
+const optimizer = await createUploadOptimizer({ wasmModules });
 ```
+
+Each value is a `WebAssembly.Module`, `ArrayBuffer`, or `Uint8Array` resolved by
+the target bundler or runtime. See the shipped Edge example for deployment
+binding names and isolate-level optimizer caching.
 
 The package may use `WebAssembly.instantiateStreaming()` when available, but it
 must provide a fallback for runtimes that return the wrong MIME type for Wasm

--- a/docs/metrics-api.md
+++ b/docs/metrics-api.md
@@ -22,14 +22,7 @@ lazy-image exposes structured telemetry via `ImageEngine.toBufferWithMetrics()`,
   "iccPreserved": false,
   "iccOutcome": "absent",
   "metadataStripped": true,
-  "policyViolations": ["firewall_rejected_metadata"],
-  // Legacy aliases kept for backward compatibility
-  "decodeTime": 12.4,
-  "processTime": 8.1,
-  "encodeTime": 15.3,
-  "memoryPeak": 28450000,
-  "inputSize": 152004,
-  "outputSize": 62488
+  "policyViolations": ["firewall_rejected_metadata"]
 }
 ```
 
@@ -44,7 +37,6 @@ lazy-image exposes structured telemetry via `ImageEngine.toBufferWithMetrics()`,
 - **iccPreserved / metadataStripped**: Whether ICC profile was preserved or metadata was stripped.
 - **iccOutcome**: `absent`, `preserved`, `unsafe-stripped`, `policy-stripped`, or `unsupported`; use this instead of inferring ICC presence from `iccPreserved: false`.
 - **policyViolations**: Non-fatal Image Firewall actions that altered output (e.g., forced metadata strip under strict policy).
-- **Legacy aliases** (deprecated): `decodeTime`, `processTime`, `encodeTime`, `memoryPeak`, `inputSize`, `outputSize` map 1:1 to the new fields. They will be removed in v2.0.0; migrate to `decodeMs`, `opsMs`, `encodeMs`, `peakRss`, `bytesIn`, `bytesOut`.
 
 ## Validation
 
@@ -56,4 +48,5 @@ lazy-image exposes structured telemetry via `ImageEngine.toBufferWithMetrics()`,
 
 - Additive changes only within minor versions. Breaking changes (field removal/rename or semantic shifts) require a new `version` value.
 - Downstream clients should gate on `version` and ignore unknown fields to remain forward compatible.
-- Legacy aliases are supported through v1.x with @deprecated annotations in `index.d.ts`. Removal is planned for v2.0.0.
+- The v1.x contract contains only the canonical fields above. Legacy metric
+  aliases removed before v1 are not emitted and are not accepted by the schema.

--- a/docs/metrics-schema.json
+++ b/docs/metrics-schema.json
@@ -20,13 +20,7 @@
     "iccPreserved",
     "iccOutcome",
     "metadataStripped",
-    "policyViolations",
-    "decodeTime",
-    "processTime",
-    "encodeTime",
-    "memoryPeak",
-    "inputSize",
-    "outputSize"
+    "policyViolations"
   ],
   "properties": {
     "version": {
@@ -60,36 +54,6 @@
       "type": "array",
       "description": "Non-fatal Image Firewall enforcement that altered output",
       "items": { "type": "string" }
-    },
-    "decodeTime": {
-      "type": "number",
-      "minimum": 0,
-      "description": "Legacy alias of decodeMs (ms)"
-    },
-    "processTime": {
-      "type": "number",
-      "minimum": 0,
-      "description": "Legacy alias of opsMs (ms)"
-    },
-    "encodeTime": {
-      "type": "number",
-      "minimum": 0,
-      "description": "Legacy alias of encodeMs (ms)"
-    },
-    "memoryPeak": {
-      "type": "number",
-      "minimum": 0,
-      "description": "Legacy alias of peakRss (bytes)"
-    },
-    "inputSize": {
-      "type": "number",
-      "minimum": 0,
-      "description": "Legacy alias of bytesIn (bytes)"
-    },
-    "outputSize": {
-      "type": "number",
-      "minimum": 0,
-      "description": "Legacy alias of bytesOut (bytes)"
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
## 背景

v1.0.0 リリース後の全体監査で、公開済み Wasm MVP と文書の記述、v1.x の互換性方針、release 前提条件に不整合が残っていました。v1.0.1 の patch scope を実装変更なしで明確にし、公開契約と運用状態を同期します。

## 変更前 / 変更後

- 変更前: Wasm package を未公開・計画中とする記述や、実装に存在しない `toColorspace()` の API 行が残っていた
- 変更後: 公開済み MVP、entrypoint、制約を現在形で記述し、存在しない API 行を削除
- 変更前: output convenience API の v1.x 維持方針が未定義で、削除済みmetrics aliasも文書に残っていた
- 変更後: output convenience APIはv1.xで維持し、pre-v1で削除済みのmetrics aliasを公開契約から除外
- 変更前: release 文書に branch protection の必須条件がなかった
- 変更後: PR、CI/security checks、conversation resolution を release 前提として明記

## 意思決定

- v1.0.1 は公開契約・文書・release governance の整合修正に限定する
- API removal、新しい runtime assumption、version bump、tag/publish はこの PR に含めない
- #703、#769、#645 の追加機能・benchmark evidence は v1.0.1 blocker にしない

## 変更内容

- CHANGELOG と VERSIONING_PLAN に v1.x compatibility contract を追加
- VERSION_HISTORY を v0.13.0〜v1.0.0 まで補完
- Wasm API、benchmark、adoption、roadmap 文書を公開済み状態へ同期
- native API 文書から未実装の `toColorspace()` 行を削除
- metrics API・JSON Schemaからpre-v1で削除済みのaliasを除外
- Wasm asset loading例を実在する `wasmModules` optionへ修正
- release prerequisite に main branch protection を追加

## リポジトリ設定・Issue同期

- `main` に strict required checks 5件、PR必須、conversation resolution、admin enforcement、force-push/delete 禁止を設定済み
- Issue #645 は実装済み checklist を完了し、benchmark evidence と deferred AVIF のみ未完として維持

## 検証

- `git diff --check`
- `npm run test:release-policy`
- `npm run test:pack-contract`
- `npm run release:check`
- `npm audit --json`（脆弱性0件）
- metrics JSON Schemaの構文とlegacy alias不在確認
- 変更した Markdown 9ファイルの相対リンク存在確認
- release 専門レビュー: blocker なし

## 残る制約

- Browser/Edge の性能主張には #645 の実環境 benchmark evidence が必要
- Wasm AVIF は deferred
- v1.0.1 の version bump、tag、npm publish、GitHub Release は別の明示的な release 工程
