### PR TITLE
docs: simplify README for v1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,247 +1,146 @@
 # lazy-image 🦀
 
-<img width="256" height="256" alt="image" src="https://github.com/user-attachments/assets/239496c7-ad7f-4649-b130-8ed0a65481f7" />
+<img width="192" height="192" alt="lazy-image" src="https://github.com/user-attachments/assets/239496c7-ad7f-4649-b130-8ed0a65481f7" />
 
-> **Web image optimization engine for Node.js.** Rust core, smaller JPEG outputs, bounded memory.
-
-At the same encoder quality setting in current canonical benchmarks, lazy-image produces **17-20% smaller JPEG outputs** than sharp for two PNG → JPEG cases: no-resize conversion and resize-to-800px. The resize case passes a source-reference quality floor but is not an exact perceptual-quality match. AVIF/WebP and multi-operation pipelines are workload-specific.
-
-- **Not** a drop-in replacement for sharp — use sharp if you need its full API or maximum throughput.
-- **Security-first**: Metadata is stripped by default; `keepMetadata()` preserves
-  ICC and EXIF (not XMP in this runtime). GPS is stripped unless explicitly
-  disabled. File-path inputs (`fromPath()`/`processBatch()` → `toFile()`) bypass
-  the V8 heap. Small/medium files (≤ 256 MB) are read into Rust-owned memory
-  for SIGBUS safety, and files larger than 256 MB use mmap with advisory locks.
-  `fromPath()` performs that setup synchronously; use
-  `await ImageEngine.fromPathAsync(path)` in request-serving code to move it
-  off the Node.js event loop.
-  For mmap paths, avoid modifying, truncating, or deleting source files during
-  processing; use a copy or `from(Buffer)` for mutable inputs.
-  See [docs/ZERO_COPY.md](./docs/ZERO_COPY.md).
-- Japanese: [README.ja.md](./README.ja.md). **mmap (files > 256 MB)**: do not modify or delete source files while processing; use a copy or `from(Buffer)` for mutable inputs.
-- Lazy contract: [docs/LAZY_SEMANTICS.md](./docs/LAZY_SEMANTICS.md) explains what is deferred vs eager.
-- Metadata matrix: [docs/METADATA_SUPPORT.md](./docs/METADATA_SUPPORT.md).
-- Philosophy and non-goals: [docs/PROJECT_PHILOSOPHY.md](./docs/PROJECT_PHILOSOPHY.md).
+Image optimization for Node.js, powered by Rust. lazy-image prioritizes smaller
+web images, bounded memory, and safe defaults over encoding speed or a broad
+editing API.
 
 [![npm version](https://badge.fury.io/js/@alberteinshutoin%2Flazy-image.svg)](https://www.npmjs.com/package/@alberteinshutoin/lazy-image)
-[![npm downloads](https://img.shields.io/npm/dm/@alberteinshutoin/lazy-image)](https://www.npmjs.com/package/@alberteinshutoin/lazy-image)
 [![Node.js CI](https://github.com/albert-einshutoin/lazy-image/actions/workflows/CI.yml/badge.svg)](https://github.com/albert-einshutoin/lazy-image/actions/workflows/CI.yml)
-[![codecov](https://codecov.io/gh/albert-einshutoin/lazy-image/branch/main/graph/badge.svg)](https://codecov.io/gh/albert-einshutoin/lazy-image)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Rust](https://img.shields.io/badge/rust-1.88+-orange.svg)](https://www.rust-lang.org/)
 
----
+Node.js 22+ · prebuilt for macOS arm64/x64, Linux x64 GNU/musl and arm64 GNU,
+and Windows x64 · JPEG/PNG/WebP input · JPEG/PNG/WebP/AVIF output
 
-## Quick Start (5 lines)
+[日本語](./README.ja.md) · [API](./docs/API.md) · [Examples](./examples/) · [Performance](./docs/PERFORMANCE.md)
 
-```javascript
-const { ImageEngine } = require('@alberteinshutoin/lazy-image');
-
-const bytesWritten = await ImageEngine.fromPath('input.png')
-  .resize(800)
-  .toFile('output.jpg', 'jpeg', 80);
-
-console.log(`Wrote ${bytesWritten} bytes`);
-```
-
-## Choose lazy-image if / Choose sharp if
-
-| **Choose lazy-image if** | **Choose sharp if** |
-|---|---|
-| You pay for bandwidth (CDN, S3, CloudFront) | You need maximum encoding throughput |
-| You run in serverless / memory-constrained envs | You need a broad image editing API |
-| You want AVIF with safe defaults | You need drop-in API compatibility |
-| You want smaller JPEG outputs over broader codec throughput | You need GIF, SVG, or TIFF support |
-
-**Key differentiators:**
-
-1. **JPEG file size optimization** — mozjpeg produces 17-20% smaller JPEG outputs in the canonical simple PNG → JPEG no-resize and resize benchmarks
-2. **Memory efficiency** — file-path inputs are not copied into the V8 heap; decoded pixels stay in Rust memory
-3. **Security-first** — GPS auto-strip, Image Firewall, Rust memory safety
-4. **AVIF output support** — libavif encoder with quality-tuned defaults and ICC support; benchmark AVIF workloads for size/speed
-
-**What lazy-image does NOT compete on:** raw encoding speed (sharp/libvips is faster), feature breadth (no drawing, compositing, or GIF), API compatibility with sharp.
-
-**Project philosophy:** optimize for smaller web outputs, bounded memory, and safe defaults first. Any speed claims must be codec- and workload-specific, not a blanket "faster than sharp" promise.
-
-Benchmarks and details: [docs/PERFORMANCE.md](./docs/PERFORMANCE.md). Full compatibility matrix: [docs/COMPATIBILITY.md](./docs/COMPATIBILITY.md).
-
----
-
-## Recommended Paths
-
-Start with one of these workflows:
-
-- **Web delivery optimization**: `await fromPathAsync() -> resize()/crop() -> toFile()` for event-loop-safe source loading and low V8 heap use
-- **Upload sanitization**: `await fromPathAsync() -> sanitize({ policy: 'strict' }) -> toFile()/toBuffer()` for untrusted user uploads
-- **Build-time / batch generation**: `processBatch()` or `clone()` for static sites, media pipelines, and multi-output generation
-- **Final optimization after editing**: use sharp/ImageMagick for compositing, filters, or animation, then pass the result through lazy-image for final JPEG/WebP/AVIF optimization
-
-Scenario guide: [docs/ADOPTION_GUIDE.md](./docs/ADOPTION_GUIDE.md).
-
----
-
-## Cost Savings Example (ROI)
-
-Assume:
-- average image size before optimization: **1.0 MB**
-- average JPEG-oriented reduction with lazy-image: **18%** (example only; not universal across all codecs)
-- CDN transfer rate: **$0.085/GB** (example: CloudFront pay-as-you-go, US/EU next 9TB tier)
-
-| Scenario | Transfer with sharp | Transfer with lazy-image | Monthly savings |
-|---|---:|---:|---:|
-| 1M image deliveries / month | 976.6 GB | 800.8 GB | **$14.94** |
-| 10M image deliveries / month | 9.54 TB | 7.82 TB | **$149.41** |
-| 100M image deliveries / month | 95.37 TB | 78.20 TB | **$1,494.14** |
-
-Break-even intuition:
-- Encoding overhead is paid **once per generated image**
-- Bandwidth savings are realized **every time the image is delivered**
-- If each generated image is viewed multiple times, lazy-image generally wins quickly
-
-Use the interactive calculator:
-- [docs/roi-calculator.html](./docs/roi-calculator.html)
-- Methodology and formulas: [docs/ROI_CALCULATOR.md](./docs/ROI_CALCULATOR.md)
-
----
-
-## Installation
+## Install
 
 ```bash
 npm install @alberteinshutoin/lazy-image
 ```
 
-Platform-specific binaries (~6–9 MB per platform) are installed automatically. Build from source: `npm run build`. See [docs/PERFORMANCE.md](./docs/PERFORMANCE.md#serverless) for package size comparison with sharp.
+Prebuilt native binaries are installed automatically on supported platforms.
 
-| Distribution path | Notes |
-|---|---|
-| npm optional binaries | macOS arm64/x64, Linux x64/arm64 GNU, Linux x64 musl, Windows x64 |
-| Runtime requirement | Node.js 22+ for prebuilt binaries and source builds |
-| Source build | Rust 1.88+ and the native codec toolchain documented in [CONTRIBUTING.md](./CONTRIBUTING.md) |
-
----
-
-## Architecture Overview
-
-```
-src/                        # selected high-level Rust core modules
-├── engine/
-│   ├── api/                # ImageEngine public API + NAPI-facing operations
-│   ├── pipeline/           # Operation application, color state, capabilities, optimization
-│   ├── tasks/              # NAPI async task contexts and encode/batch/write execution
-│   ├── memory/             # Cgroup detection, memory estimates, weighted semaphore
-│   ├── io/                 # File sources, mmap, ICC/EXIF extraction and embedding
-│   ├── resize.rs           # Dimension calc, fast_image_resize dispatch
-│   ├── encoder.rs          # JPEG/PNG/WebP/AVIF encoding + ICC/EXIF embedding
-│   ├── decoder.rs          # Format detection + decoding
-│   ├── firewall.rs         # Input sanitization policies
-│   ├── metadata.rs         # Metadata policy and preservation state
-│   └── validation.rs       # Input, operation, and output validation helpers
-├── ops.rs                  # Operation enum, presets, output formats
-├── error.rs                # 4-tier error taxonomy (E1xx–E9xx)
-└── codecs/avif_safe.rs     # Safe libavif FFI wrappers
-
-lib/helpers.js              # Encoding profiles, target-bytes binary search
-streaming/pipeline.js       # Disk-backed bounded-memory streaming
-```
-
-**Key design decisions:** lazy execution (ops queue until output), file-path inputs bypass the V8 heap (read-into-memory for ≤ 256 MB, mmap with advisory locks for > 256 MB), memory-bounded concurrency via weighted semaphore, panic guards on all codec entry points. See [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) for details.
-
----
-
-## Basic Usage
-
-**Resize and save (recommended: file-to-file)**
+## Quick Start
 
 ```javascript
-await ImageEngine.fromPath('photo.jpg')
-  .resize({ width: 800, fit: 'inside' }) // positional args also supported
-  .toFile('thumb.jpg', 'jpeg', 85);
+import { ImageEngine } from '@alberteinshutoin/lazy-image';
+
+const image = await ImageEngine.fromPathAsync('input.png');
+const bytesWritten = await image
+  .resize({ width: 800, fit: 'inside' })
+  .toFile('output.jpg', 'jpeg', 80);
+
+console.log(`Wrote ${bytesWritten} bytes`);
 ```
 
-**Format conversion (e.g. PNG → WebP/AVIF)**
+Use `fromPathAsync()` in servers so file setup does not block the Node.js event
+loop. CommonJS is also supported:
 
 ```javascript
-const buffer = await ImageEngine.fromPath('input.png')
-  .resize({ width: 600 })
+const { ImageEngine } = require('@alberteinshutoin/lazy-image');
+```
+
+## Common tasks
+
+## Buffer to WebP
+
+```javascript
+import { readFile } from 'node:fs/promises';
+import { ImageEngine } from '@alberteinshutoin/lazy-image';
+
+const input = await readFile('input.jpg');
+const output = await ImageEngine.from(input)
+  .resize({ width: 1200 })
   .toBuffer('webp', 80);
 ```
 
-**Metadata without decoding**
+## Sanitize an upload
 
 ```javascript
-const { inspectFile } = require('@alberteinshutoin/lazy-image');
-const meta = inspectFile('input.jpg'); // { width, height, format }
+const output = await ImageEngine.from(uploadBuffer)
+  .sanitize({ policy: 'public-upload' })
+  .resize({ width: 1600, height: 1600, fit: 'inside' })
+  .toBuffer('jpeg', 85);
 ```
 
-`lazy-image` defers full pixel decode, transforms, and encoding until `toBuffer()` / `toFile()`. Constructors still do source setup and metadata extraction; see [docs/LAZY_SEMANTICS.md](./docs/LAZY_SEMANTICS.md).
+The `public-upload` policy enforces resource limits and strips EXIF, GPS, and
+XMP while preserving only validated ICC profiles.
 
-More: batch processing, presets, metrics, streaming — [docs/API.md](./docs/API.md).
+## Inspect without decoding
 
----
+```javascript
+import { inspectFile } from '@alberteinshutoin/lazy-image';
 
-## Documentation
+const { width, height, format } = inspectFile('input.jpg');
+```
 
-| Topic | Link |
-|-------|------|
-| **Examples** | [examples/](./examples/) |
-| **TypeScript guide** | [docs/TYPESCRIPT.md](./docs/TYPESCRIPT.md) |
-| **Full API reference** | [docs/API.md](./docs/API.md) |
-| **Migration from sharp** | [docs/MIGRATION_FROM_SHARP.md](./docs/MIGRATION_FROM_SHARP.md) |
-| **Performance & when to use** | [docs/PERFORMANCE.md](./docs/PERFORMANCE.md) |
-| **Architecture & security** | [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) |
-| **Troubleshooting** | [docs/TROUBLESHOOTING.md](./docs/TROUBLESHOOTING.md) |
-| **Security policy & reporting** | [SECURITY.md](./SECURITY.md) |
-| **Roadmap & scope** | [docs/ROADMAP.md](./docs/ROADMAP.md) |
-| **Adoption guide / recommended workflows** | [docs/ADOPTION_GUIDE.md](./docs/ADOPTION_GUIDE.md) |
-| **Wasm / browser / Edge strategy** | [docs/WASM_STRATEGY.md](./docs/WASM_STRATEGY.md) |
-| **Wasm package and policy API** | [docs/WASM_PACKAGE_API.md](./docs/WASM_PACKAGE_API.md) |
-| **Wasm upload benchmark guidance** | [docs/WASM_BENCHMARKING.md](./docs/WASM_BENCHMARKING.md) |
-| **Metadata support matrix** | [docs/METADATA_SUPPORT.md](./docs/METADATA_SUPPORT.md) |
-| **ROI calculator methodology** | [docs/ROI_CALCULATOR.md](./docs/ROI_CALCULATOR.md) |
-| **Version history** | [docs/VERSION_HISTORY.md](./docs/VERSION_HISTORY.md) |
-| **Specification (spec/)** | [spec/pipeline.md](./spec/pipeline.md), [spec/resize.md](./spec/resize.md), [spec/errors.md](./spec/errors.md), [spec/limits.md](./spec/limits.md), [spec/quality.md](./spec/quality.md), [spec/metadata.md](./spec/metadata.md) |
-| **Error codes** | [docs/ERROR_CODES.md](./docs/ERROR_CODES.md) |
-| **Benchmarks (raw data)** | [docs/TRUE_BENCHMARKS.md](./docs/TRUE_BENCHMARKS.md) |
-| **Binary size comparison (AVIF on/off)** | [docs/BINARY_SIZE.md](./docs/BINARY_SIZE.md) |
-| **Benchmark snapshots log** | [docs/BENCHMARK_RESULTS.md](./docs/BENCHMARK_RESULTS.md) |
-| **Benchmark operations** | [docs/BENCHMARK_OPERATIONS.md](./docs/BENCHMARK_OPERATIONS.md) |
-| **Selective test CI and safe fallback** | [docs/SELECTIVE_TESTING.md](./docs/SELECTIVE_TESTING.md) |
+## Main API
 
----
+```text
+ImageEngine.from(buffer)
+await ImageEngine.fromPathAsync(path)
 
-## Features (summary)
+.resize({ width?, height?, fit? })
+.crop(x, y, width, height)
+.rotate(90 | 180 | 270)
+.flipH() / .flipV() / .grayscale()
+.sanitize({ policy })
 
-Smaller JPEG (mozjpeg) · WebP (libwebp) · AVIF (libavif) · ICC profiles · EXIF auto-orient · Bypass-V8-heap file I/O (read-into-memory ≤ 256 MB, mmap > 256 MB) · Disk-backed bounded-memory pipeline (`createStreamingPipeline()`, not true chunked transform streaming) · Image Firewall · GPS auto-strip · Fluent API · Rust core (NAPI-RS) · Cross-platform (macOS, Windows, Linux). Design choices and limits: [docs/ROADMAP.md](./docs/ROADMAP.md) and [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md).
+await .toFile(path, format, quality?)
+await .toBuffer(format, quality?)
+await .encode({ format, quality?, preset?, metrics? })
+```
 
----
+Operations are queued and evaluated once when an output method runs. Use
+`clone()` when producing multiple variants from one source. See the
+[full API reference](./docs/API.md) for batch processing, presets, metrics,
+streaming, metadata controls, and error codes.
+
+## When to use it
+
+Choose lazy-image when output size, predictable memory use, or upload safety is
+more important than raw throughput. Choose sharp or ImageMagick when you need
+maximum speed, drawing, compositing, animation, SVG, TIFF, or a drop-in sharp
+API. See the [benchmark methodology](./docs/PERFORMANCE.md) before comparing
+codecs or quality settings.
+
+## Safety and limits
+
+- Metadata is stripped by default. Use `keepMetadata()` only when needed.
+- File inputs up to 256 MB use Rust-owned memory; larger files may use mmap.
+  Do not modify or delete an mmap-backed source while processing it.
+- Rotation supports 90°, 180°, and 270°.
+- 16-bit images are converted to 8-bit.
+- Animated GIF/APNG, drawing, and heavy filters are out of scope.
+
+Details: [metadata](./docs/METADATA_SUPPORT.md) · [file I/O](./docs/ZERO_COPY.md) ·
+[thread model](./docs/THREAD_MODEL.md) · [errors](./docs/ERROR_CODES.md)
+
+## Browser and Edge
+
+Use the separate Wasm package for browser and V8-isolate upload preflight:
+
+```bash
+npm install @alberteinshutoin/lazy-image-wasm
+```
+
+See the [Wasm package guide](./docs/WASM_PACKAGE_API.md). Validate bundle size
+and latency in the target runtime before production use.
 
 ## Development
 
 ```bash
-npm install && npm run build
+npm install
+npm run build
 npm test
 ```
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for workflow, test commands, and contribution guidelines. Benchmark testing: [lazy-image-test](https://github.com/albert-einshutoin/lazy-image-test) Docker environment. Fuzzing: [FUZZING.md](./FUZZING.md).
-
-Pull requests use conservative change-impact analysis with an always-on smoke
-test and automatic full-suite fallback. See
-[docs/SELECTIVE_TESTING.md](./docs/SELECTIVE_TESTING.md) for local reproduction,
-rules, adapters, rollout metrics, and manual full validation.
-
----
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for build requirements and workflow.
 
 ## License
 
-MIT
-
----
-
-## Credits
-
-[mozjpeg](https://github.com/mozilla/mozjpeg) · [libwebp](https://chromium.googlesource.com/webm/libwebp) · [libavif](https://github.com/AOMediaCodec/libavif) · [fast_image_resize](https://github.com/Cykooz/fast_image_resize) · [img-parts](https://github.com/paolobarbolini/img-parts) · [napi-rs](https://napi.rs/)
-
----
-
-**Ship it.** 🚀
+MIT. Built with mozjpeg, libwebp, libavif, fast_image_resize, img-parts, and
+NAPI-RS.


### PR DESCRIPTION
## 背景

v1.0.1に向けて、READMEが性能説明、ROI例、内部構成、文書一覧を重複して掲載しており、初めて使う人が導入手順へ到達しづらい状態でした。

## 変更前後

- 247行から145行へ短縮
- インストールと最小のファイル変換例を冒頭へ移動
- Buffer変換、アップロード無害化、ヘッダー検査の代表例を追加
- 入出力形式、対応環境、採用判断、安全上の制約を簡潔に整理
- 数値性能主張、ROI表、内部ディレクトリ構成、巨大な文書表をREADMEから削除し、詳細文書へのリンクへ集約

## 意思決定

公開APIの入口を説明するREADMEに限定し、性能測定や内部設計は既存の専門文書を正本としました。ランタイム/API/依存関係の変更はありません。

## 検証

- `git diff --check`
- READMEのコードフェンス整合・相対リンク存在確認
- `npm run test:pack-contract`
- `npm run test:release-policy`
- `npm run release:check`
- `npm audit --json`（脆弱性0件）
- `node scripts/check-release-policy.js 1.0.1`

## 残る制約

v1.0.1のversion bump、CHANGELOG確定、タグ作成、npm公開はこのPRの対象外です。READMEマージ後に専用のリリースPRで実施します。
