### PR TITLE
feat: add deterministic public-upload policy compiler

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -652,6 +652,12 @@ export interface ArtifactPlan {
   } | null
 }
 
+export declare function compileArtifactPlan(
+  source: ArtifactSourceFacts,
+  policy: PublicUploadPolicy | undefined,
+  compilerFingerprint: string,
+): ArtifactPlan
+
 export interface ResolvedEncodeProfile {
   format: CanonicalOutputFormat
   quality?: number

--- a/index.d.ts
+++ b/index.d.ts
@@ -572,6 +572,85 @@ export type ResizeFit = 'inside' | 'cover' | 'fill'
 export type FirewallPolicy = 'strict' | 'lenient' | 'public-upload'
 export type IccOutcome = 'absent' | 'preserved' | 'unsafe-stripped' | 'policy-stripped' | 'unsupported'
 export type EncodeProfile = 'size-first' | 'balanced' | 'speed-first'
+export type ArtifactFormat = 'jpeg' | 'webp' | 'avif'
+
+export interface ArtifactByteBudget {
+  readonly width: number
+  readonly format: ArtifactFormat
+  readonly maxBytes: number
+}
+
+export interface PublicUploadPolicy {
+  readonly preset?: 'publicUpload'
+  readonly widths?: readonly number[]
+  readonly formats?: readonly ArtifactFormat[]
+  readonly budgets?: readonly ArtifactByteBudget[]
+  readonly placeholder?: boolean
+}
+
+export interface ArtifactSourceFacts {
+  readonly sha256: string
+  readonly bytes: number
+  readonly format: 'jpeg' | 'jpg' | 'png' | 'webp'
+  readonly width: number
+  readonly height: number
+  readonly hasAlpha: boolean
+  readonly isAnimated: boolean
+  readonly orientationKnown: true
+  readonly orientation: number | null
+}
+
+export interface ArtifactPlanSource {
+  readonly sha256: string
+  readonly bytes: number
+  readonly detectedFormat: 'jpeg' | 'png' | 'webp'
+  readonly encodedWidth: number
+  readonly encodedHeight: number
+  readonly displayWidth: number
+  readonly displayHeight: number
+  readonly hasAlpha: boolean
+  readonly isAnimated: false
+  readonly orientationKnown: true
+  readonly orientation: number | null
+  readonly orientationApplied: boolean
+}
+
+export interface ArtifactPlanPolicy {
+  readonly preset: 'publicUpload'
+  readonly widths: readonly number[]
+  readonly formats: readonly ArtifactFormat[]
+  readonly budgets: readonly ArtifactByteBudget[]
+  readonly placeholder: boolean
+}
+
+export interface ArtifactPlanItem {
+  readonly id: string
+  readonly path: string
+  readonly format: ArtifactFormat
+  readonly width: number
+  readonly quality: number
+  readonly targetBytes?: number
+}
+
+export interface ArtifactPlan {
+  readonly schemaVersion: 1
+  readonly compilerFingerprint: string
+  readonly policyFingerprint: string
+  readonly cacheKey: string
+  readonly source: ArtifactPlanSource
+  readonly policy: ArtifactPlanPolicy
+  readonly artifacts: readonly ArtifactPlanItem[]
+  readonly delivery: {
+    readonly srcsets: readonly { readonly format: ArtifactFormat; readonly value: string }[]
+  }
+  readonly placeholder: {
+    readonly id: 'placeholder'
+    readonly path: 'placeholder.webp'
+    readonly format: 'webp'
+    readonly width: 16
+    readonly quality: 20
+  } | null
+}
 
 export interface ResolvedEncodeProfile {
   format: CanonicalOutputFormat

--- a/index.js
+++ b/index.js
@@ -600,12 +600,14 @@ module.exports.version = nativeBinding.version
 // High-level helpers and streaming API (extracted to lib/helpers.js)
 const { createStreamingPipeline } = require('./streaming/pipeline')
 const helpers = require('./lib/helpers')
+const { compileArtifactPlan } = require('./lib/artifact-policy')
 const _getErrorCategory = helpers.createGetErrorCategory(nativeBinding.ErrorCategory, nativeBinding.ErrorCode)
 const _processBatchChunked = helpers.createProcessBatchChunked(nativeBinding.ImageEngine)
 module.exports.getErrorCategory = _getErrorCategory
 module.exports.processBatchChunked = _processBatchChunked
 module.exports.createStreamingPipeline = createStreamingPipeline
 module.exports.resolveEncodeProfile = helpers.resolveEncodeProfile
+module.exports.compileArtifactPlan = compileArtifactPlan
 if (nativeBinding && nativeBinding.ImageEngine) {
   helpers.attachPrototypeMethods(nativeBinding.ImageEngine)
 }

--- a/index.mjs
+++ b/index.mjs
@@ -16,6 +16,7 @@ export const {
   processBatchChunked,
   createStreamingPipeline,
   resolveEncodeProfile,
+  compileArtifactPlan,
 } = mod;
 
 // Default export for convenience

--- a/lib/artifact-policy.js
+++ b/lib/artifact-policy.js
@@ -47,6 +47,38 @@ function rejectUnknownKeys(value, allowed, name) {
   }
 }
 
+function requireOwnData(value, key, name) {
+  const descriptor = Object.getOwnPropertyDescriptor(value, key);
+  if (!descriptor || !Object.hasOwn(descriptor, 'value')) {
+    fail(`${name}.${key} must be an own data property`);
+  }
+  return descriptor.value;
+}
+
+function optionalOwnData(value, key, name) {
+  const descriptor = Object.getOwnPropertyDescriptor(value, key);
+  if (!descriptor) {
+    if (key in value) fail(`${name}.${key} must be an own data property`);
+    return undefined;
+  }
+  if (!Object.hasOwn(descriptor, 'value')) {
+    fail(`${name}.${key} must be an own data property`);
+  }
+  return descriptor.value;
+}
+
+function snapshotArray(value, name) {
+  const snapshot = [];
+  for (let index = 0; index < value.length; index += 1) {
+    const key = String(index);
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (!descriptor) fail(`${name} must not contain empty entries`);
+    if (!Object.hasOwn(descriptor, 'value')) fail(`${name} entries must be own data properties`);
+    snapshot.push(descriptor.value);
+  }
+  return snapshot;
+}
+
 function requireInteger(value, name, minimum, maximum) {
   if (!Number.isInteger(value) || value < minimum || value > maximum) {
     fail(`${name} must be an integer between ${minimum} and ${maximum}`);
@@ -58,37 +90,47 @@ function normalizeSource(source) {
   requireRecord(source, 'source');
   rejectUnknownKeys(source, SOURCE_KEYS, 'source');
 
-  if (typeof source.sha256 !== 'string' || !/^[a-f0-9]{64}$/.test(source.sha256)) {
+  const sha256 = requireOwnData(source, 'sha256', 'source');
+  const bytesValue = requireOwnData(source, 'bytes', 'source');
+  const format = requireOwnData(source, 'format', 'source');
+  const widthValue = requireOwnData(source, 'width', 'source');
+  const heightValue = requireOwnData(source, 'height', 'source');
+  const hasAlpha = requireOwnData(source, 'hasAlpha', 'source');
+  const isAnimated = requireOwnData(source, 'isAnimated', 'source');
+  const orientationKnown = requireOwnData(source, 'orientationKnown', 'source');
+  const orientationValue = requireOwnData(source, 'orientation', 'source');
+
+  if (typeof sha256 !== 'string' || !/^[a-f0-9]{64}$/.test(sha256)) {
     fail('source.sha256 must be a lowercase SHA-256 digest');
   }
-  const bytes = requireInteger(source.bytes, 'source.bytes', 1, MAX_INPUT_BYTES);
-  const width = requireInteger(source.width, 'source.width', 1, MAX_DIMENSION);
-  const height = requireInteger(source.height, 'source.height', 1, MAX_DIMENSION);
+  const bytes = requireInteger(bytesValue, 'source.bytes', 1, MAX_INPUT_BYTES);
+  const width = requireInteger(widthValue, 'source.width', 1, MAX_DIMENSION);
+  const height = requireInteger(heightValue, 'source.height', 1, MAX_DIMENSION);
   if (width * height > MAX_PIXELS) fail(`source dimensions must not exceed ${MAX_PIXELS} pixels`);
-  if (!['jpeg', 'jpg', 'png', 'webp'].includes(source.format)) {
+  if (!['jpeg', 'jpg', 'png', 'webp'].includes(format)) {
     fail('source.format must be jpeg, jpg, png, or webp');
   }
-  if (typeof source.hasAlpha !== 'boolean') fail('source.hasAlpha must be a boolean');
-  if (typeof source.isAnimated !== 'boolean') fail('source.isAnimated must be a boolean');
-  if (source.isAnimated) fail('animated input is not supported by publicUpload');
-  if (source.orientationKnown !== true) {
+  if (typeof hasAlpha !== 'boolean') fail('source.hasAlpha must be a boolean');
+  if (typeof isAnimated !== 'boolean') fail('source.isAnimated must be a boolean');
+  if (isAnimated) fail('animated input is not supported by publicUpload');
+  if (orientationKnown !== true) {
     fail('source.orientationKnown must be true before compiling an artifact plan');
   }
 
-  const orientation = source.orientation === null
+  const orientation = orientationValue === null
     ? null
-    : requireInteger(source.orientation, 'source.orientation', 1, 8);
+    : requireInteger(orientationValue, 'source.orientation', 1, 8);
   const swapsDimensions = orientation != null && orientation >= 5;
 
   return {
-    sha256: source.sha256,
+    sha256,
     bytes,
-    detectedFormat: source.format === 'jpg' ? 'jpeg' : source.format,
+    detectedFormat: format === 'jpg' ? 'jpeg' : format,
     encodedWidth: width,
     encodedHeight: height,
     displayWidth: swapsDimensions ? height : width,
     displayHeight: swapsDimensions ? width : height,
-    hasAlpha: source.hasAlpha,
+    hasAlpha,
     isAnimated: false,
     orientationKnown: true,
     orientation,
@@ -101,10 +143,8 @@ function normalizeWidths(rawWidths, sourceWidth) {
   if (rawWidths.length > MAX_RAW_WIDTHS) {
     fail(`widths must contain at most ${MAX_RAW_WIDTHS} raw entries`);
   }
-  for (let index = 0; index < rawWidths.length; index += 1) {
-    if (!Object.hasOwn(rawWidths, index)) fail('widths must not contain empty entries');
-  }
-  const widths = [...new Set(rawWidths.map((width) => requireInteger(width, 'widths entry', 16, 8192)))]
+  const widths = [...new Set(snapshotArray(rawWidths, 'widths')
+    .map((width) => requireInteger(width, 'widths entry', 16, 8192)))]
     .sort((left, right) => left - right);
   if (widths.length > MAX_WIDTHS) fail(`widths must contain at most ${MAX_WIDTHS} entries`);
   const displayWidths = widths.filter((width) => width <= sourceWidth);
@@ -118,10 +158,11 @@ function normalizeFormats(rawFormats) {
   if (rawFormats.length > MAX_RAW_FORMATS) {
     fail(`formats must contain at most ${MAX_RAW_FORMATS} raw entries`);
   }
-  for (const format of rawFormats) {
+  const formats = snapshotArray(rawFormats, 'formats');
+  for (const format of formats) {
     if (!FORMAT_ORDER.includes(format)) fail('formats entries must be jpeg, webp, or avif');
   }
-  const requested = new Set(rawFormats);
+  const requested = new Set(formats);
   if (requested.size > MAX_FORMATS) fail(`formats must contain at most ${MAX_FORMATS} entries`);
   return FORMAT_ORDER.filter((format) => requested.has(format));
 }
@@ -131,16 +172,17 @@ function normalizeBudgets(rawBudgets, artifactIds) {
   if (rawBudgets.length > MAX_ARTIFACTS) fail(`budgets must contain at most ${MAX_ARTIFACTS} entries`);
 
   const budgets = new Map();
-  for (const rawBudget of rawBudgets) {
+  for (const rawBudget of snapshotArray(rawBudgets, 'budgets')) {
     requireRecord(rawBudget, 'budget');
     rejectUnknownKeys(rawBudget, BUDGET_KEYS, 'budget');
-    const width = requireInteger(rawBudget.width, 'budget.width', 16, 8192);
-    if (!FORMAT_ORDER.includes(rawBudget.format)) fail('budget.format must be jpeg, webp, or avif');
-    const maxBytes = requireInteger(rawBudget.maxBytes, 'budget.maxBytes', 1, MAX_BUDGET_BYTES);
-    const id = `${width}/${rawBudget.format}`;
+    const width = requireInteger(requireOwnData(rawBudget, 'width', 'budget'), 'budget.width', 16, 8192);
+    const format = requireOwnData(rawBudget, 'format', 'budget');
+    if (!FORMAT_ORDER.includes(format)) fail('budget.format must be jpeg, webp, or avif');
+    const maxBytes = requireInteger(requireOwnData(rawBudget, 'maxBytes', 'budget'), 'budget.maxBytes', 1, MAX_BUDGET_BYTES);
+    const id = `${width}/${format}`;
     if (!artifactIds.has(id)) fail(`budget target does not exist in the normalized artifact plan: ${id}`);
     if (budgets.has(id)) fail(`duplicate budget target: ${id}`);
-    budgets.set(id, { width, format: rawBudget.format, maxBytes });
+    budgets.set(id, { width, format, maxBytes });
   }
   return [...artifactIds].flatMap((id) => budgets.has(id) ? [budgets.get(id)] : []);
 }
@@ -161,27 +203,32 @@ function compileArtifactPlan(sourceInput, policyInput = {}, compilerFingerprint)
   const source = normalizeSource(sourceInput);
   const policy = requireRecord(policyInput, 'policy');
   rejectUnknownKeys(policy, POLICY_KEYS, 'policy');
-  if (policy.preset !== undefined && policy.preset !== 'publicUpload') fail('policy.preset must be publicUpload');
-  if (policy.placeholder !== undefined && typeof policy.placeholder !== 'boolean') {
+  const preset = optionalOwnData(policy, 'preset', 'policy');
+  const widthsInput = optionalOwnData(policy, 'widths', 'policy');
+  const formatsInput = optionalOwnData(policy, 'formats', 'policy');
+  const budgetsInput = optionalOwnData(policy, 'budgets', 'policy');
+  const placeholder = optionalOwnData(policy, 'placeholder', 'policy');
+  if (preset !== undefined && preset !== 'publicUpload') fail('policy.preset must be publicUpload');
+  if (placeholder !== undefined && typeof placeholder !== 'boolean') {
     fail('policy.placeholder must be a boolean');
   }
   if (typeof compilerFingerprint !== 'string' || !/^[a-f0-9]{64}$/.test(compilerFingerprint)) {
     fail('compilerFingerprint must be a lowercase SHA-256 digest');
   }
 
-  const widths = normalizeWidths(policy.widths === undefined ? DEFAULT_WIDTHS : policy.widths, source.displayWidth);
-  const formats = normalizeFormats(policy.formats === undefined ? ['webp'] : policy.formats);
+  const widths = normalizeWidths(widthsInput === undefined ? DEFAULT_WIDTHS : widthsInput, source.displayWidth);
+  const formats = normalizeFormats(formatsInput === undefined ? ['webp'] : formatsInput);
   if (source.hasAlpha && formats.includes('jpeg')) fail('alpha input cannot produce jpeg artifacts');
 
   const artifactIds = new Set(formats.flatMap((format) => widths.map((width) => `${width}/${format}`)));
   if (artifactIds.size > MAX_ARTIFACTS) fail(`artifact plan must contain at most ${MAX_ARTIFACTS} entries`);
-  const budgets = normalizeBudgets(policy.budgets === undefined ? [] : policy.budgets, artifactIds);
+  const budgets = normalizeBudgets(budgetsInput === undefined ? [] : budgetsInput, artifactIds);
   const normalizedPolicy = {
     preset: 'publicUpload',
     widths,
     formats,
     budgets,
-    placeholder: policy.placeholder === undefined ? true : policy.placeholder,
+    placeholder: placeholder === undefined ? true : placeholder,
   };
   const policyFingerprint = digest(normalizedPolicy);
   const budgetsById = new Map(budgets.map((budget) => [`${budget.width}/${budget.format}`, budget.maxBytes]));

--- a/lib/artifact-policy.js
+++ b/lib/artifact-policy.js
@@ -1,0 +1,215 @@
+'use strict';
+
+const { createHash } = require('node:crypto');
+
+const MAX_INPUT_BYTES = 32 * 1024 * 1024;
+const MAX_PIXELS = 40_000_000;
+const MAX_DIMENSION = 32_768;
+const MAX_WIDTHS = 8;
+const MAX_FORMATS = 3;
+const MAX_ARTIFACTS = 24;
+const MAX_BUDGET_BYTES = 32 * 1024 * 1024;
+const FORMAT_ORDER = ['jpeg', 'webp', 'avif'];
+const DEFAULT_WIDTHS = [320, 640, 1280];
+const DEFAULT_QUALITY = { jpeg: 85, webp: 80, avif: 60 };
+const POLICY_KEYS = new Set(['preset', 'widths', 'formats', 'budgets', 'placeholder']);
+const SOURCE_KEYS = new Set([
+  'sha256', 'bytes', 'format', 'width', 'height', 'hasAlpha', 'isAnimated',
+  'orientationKnown', 'orientation',
+]);
+const BUDGET_KEYS = new Set(['width', 'format', 'maxBytes']);
+
+function fail(message) {
+  const error = new TypeError(`[E400] ${message}`);
+  error.code = 'LAZY_IMAGE_USER_ERROR';
+  error.errorCode = 'E400';
+  error.errorCategory = 'UserError';
+  error.recoveryHint = 'Provide validated source facts and a valid publicUpload policy.';
+  throw error;
+}
+
+function requireRecord(value, name) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    fail(`${name} must be an object`);
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    fail(`${name} must be a plain object`);
+  }
+  return value;
+}
+
+function rejectUnknownKeys(value, allowed, name) {
+  for (const key of Reflect.ownKeys(value)) {
+    if (typeof key !== 'string' || !allowed.has(key)) fail(`unknown ${name} key: ${String(key)}`);
+  }
+}
+
+function requireInteger(value, name, minimum, maximum) {
+  if (!Number.isInteger(value) || value < minimum || value > maximum) {
+    fail(`${name} must be an integer between ${minimum} and ${maximum}`);
+  }
+  return value;
+}
+
+function normalizeSource(source) {
+  requireRecord(source, 'source');
+  rejectUnknownKeys(source, SOURCE_KEYS, 'source');
+
+  if (typeof source.sha256 !== 'string' || !/^[a-f0-9]{64}$/.test(source.sha256)) {
+    fail('source.sha256 must be a lowercase SHA-256 digest');
+  }
+  const bytes = requireInteger(source.bytes, 'source.bytes', 1, MAX_INPUT_BYTES);
+  const width = requireInteger(source.width, 'source.width', 1, MAX_DIMENSION);
+  const height = requireInteger(source.height, 'source.height', 1, MAX_DIMENSION);
+  if (width * height > MAX_PIXELS) fail(`source dimensions must not exceed ${MAX_PIXELS} pixels`);
+  if (!['jpeg', 'jpg', 'png', 'webp'].includes(source.format)) {
+    fail('source.format must be jpeg, jpg, png, or webp');
+  }
+  if (typeof source.hasAlpha !== 'boolean') fail('source.hasAlpha must be a boolean');
+  if (typeof source.isAnimated !== 'boolean') fail('source.isAnimated must be a boolean');
+  if (source.isAnimated) fail('animated input is not supported by publicUpload');
+  if (source.orientationKnown !== true) {
+    fail('source.orientationKnown must be true before compiling an artifact plan');
+  }
+
+  const orientation = source.orientation === null
+    ? null
+    : requireInteger(source.orientation, 'source.orientation', 1, 8);
+  const swapsDimensions = orientation != null && orientation >= 5;
+
+  return {
+    sha256: source.sha256,
+    bytes,
+    detectedFormat: source.format === 'jpg' ? 'jpeg' : source.format,
+    encodedWidth: width,
+    encodedHeight: height,
+    displayWidth: swapsDimensions ? height : width,
+    displayHeight: swapsDimensions ? width : height,
+    hasAlpha: source.hasAlpha,
+    isAnimated: false,
+    orientationKnown: true,
+    orientation,
+    orientationApplied: orientation != null && orientation !== 1,
+  };
+}
+
+function normalizeWidths(rawWidths, sourceWidth) {
+  if (!Array.isArray(rawWidths) || rawWidths.length === 0) fail('widths must be a non-empty array');
+  if (rawWidths.length > MAX_WIDTHS) fail(`widths must contain at most ${MAX_WIDTHS} entries`);
+  for (let index = 0; index < rawWidths.length; index += 1) {
+    if (!Object.hasOwn(rawWidths, index)) fail('widths must not contain empty entries');
+  }
+  const widths = [...new Set(rawWidths.map((width) => requireInteger(width, 'widths entry', 16, 8192)))]
+    .sort((left, right) => left - right)
+    .filter((width) => width <= sourceWidth);
+  if (widths.length > 0) return widths;
+  if (sourceWidth < 16) fail('source display width must be at least 16 pixels');
+  return [sourceWidth];
+}
+
+function normalizeFormats(rawFormats) {
+  if (!Array.isArray(rawFormats) || rawFormats.length === 0) fail('formats must be a non-empty array');
+  if (rawFormats.length > MAX_FORMATS) fail(`formats must contain at most ${MAX_FORMATS} entries`);
+  for (const format of rawFormats) {
+    if (!FORMAT_ORDER.includes(format)) fail('formats entries must be jpeg, webp, or avif');
+  }
+  const requested = new Set(rawFormats);
+  return FORMAT_ORDER.filter((format) => requested.has(format));
+}
+
+function normalizeBudgets(rawBudgets, artifactIds) {
+  if (!Array.isArray(rawBudgets)) fail('budgets must be an array');
+  if (rawBudgets.length > MAX_ARTIFACTS) fail(`budgets must contain at most ${MAX_ARTIFACTS} entries`);
+
+  const budgets = new Map();
+  for (const rawBudget of rawBudgets) {
+    requireRecord(rawBudget, 'budget');
+    rejectUnknownKeys(rawBudget, BUDGET_KEYS, 'budget');
+    const width = requireInteger(rawBudget.width, 'budget.width', 16, 8192);
+    if (!FORMAT_ORDER.includes(rawBudget.format)) fail('budget.format must be jpeg, webp, or avif');
+    const maxBytes = requireInteger(rawBudget.maxBytes, 'budget.maxBytes', 1, MAX_BUDGET_BYTES);
+    const id = `${width}/${rawBudget.format}`;
+    if (!artifactIds.has(id)) fail(`budget target does not exist in the normalized artifact plan: ${id}`);
+    if (budgets.has(id)) fail(`duplicate budget target: ${id}`);
+    budgets.set(id, { width, format: rawBudget.format, maxBytes });
+  }
+  return [...artifactIds].flatMap((id) => budgets.has(id) ? [budgets.get(id)] : []);
+}
+
+function digest(value) {
+  return createHash('sha256').update(JSON.stringify(value)).digest('hex');
+}
+
+function deepFreeze(value) {
+  Object.freeze(value);
+  for (const nested of Object.values(value)) {
+    if (nested && typeof nested === 'object' && !Object.isFrozen(nested)) deepFreeze(nested);
+  }
+  return value;
+}
+
+function compileArtifactPlan(sourceInput, policyInput = {}, compilerFingerprint) {
+  const source = normalizeSource(sourceInput);
+  const policy = requireRecord(policyInput, 'policy');
+  rejectUnknownKeys(policy, POLICY_KEYS, 'policy');
+  if (policy.preset != null && policy.preset !== 'publicUpload') fail('policy.preset must be publicUpload');
+  if (policy.placeholder != null && typeof policy.placeholder !== 'boolean') {
+    fail('policy.placeholder must be a boolean');
+  }
+  if (typeof compilerFingerprint !== 'string' || !/^[a-f0-9]{64}$/.test(compilerFingerprint)) {
+    fail('compilerFingerprint must be a lowercase SHA-256 digest');
+  }
+
+  const widths = normalizeWidths(policy.widths ?? DEFAULT_WIDTHS, source.displayWidth);
+  const formats = normalizeFormats(policy.formats ?? ['webp']);
+  if (source.hasAlpha && formats.includes('jpeg')) fail('alpha input cannot produce jpeg artifacts');
+
+  const artifactIds = new Set(formats.flatMap((format) => widths.map((width) => `${width}/${format}`)));
+  if (artifactIds.size > MAX_ARTIFACTS) fail(`artifact plan must contain at most ${MAX_ARTIFACTS} entries`);
+  const budgets = normalizeBudgets(policy.budgets ?? [], artifactIds);
+  const normalizedPolicy = {
+    preset: 'publicUpload',
+    widths,
+    formats,
+    budgets,
+    placeholder: policy.placeholder ?? true,
+  };
+  const policyFingerprint = digest(normalizedPolicy);
+  const budgetsById = new Map(budgets.map((budget) => [`${budget.width}/${budget.format}`, budget.maxBytes]));
+  const artifacts = formats.flatMap((format) => widths.map((width) => {
+    const id = `${width}/${format}`;
+    const targetBytes = budgetsById.get(id);
+    return {
+      id,
+      path: `image-${width}.${format === 'jpeg' ? 'jpg' : format}`,
+      format,
+      width,
+      quality: DEFAULT_QUALITY[format],
+      ...(targetBytes == null ? {} : { targetBytes }),
+    };
+  }));
+  const srcsets = formats.map((format) => ({
+    format,
+    value: artifacts
+      .filter((artifact) => artifact.format === format)
+      .map((artifact) => `${artifact.path} ${artifact.width}w`)
+      .join(', '),
+  }));
+
+  return deepFreeze({
+    schemaVersion: 1,
+    compilerFingerprint,
+    policyFingerprint,
+    cacheKey: digest({ schemaVersion: 1, compilerFingerprint, sourceSha256: source.sha256, policyFingerprint }),
+    source,
+    policy: normalizedPolicy,
+    artifacts,
+    delivery: { srcsets },
+    placeholder: normalizedPolicy.placeholder
+      ? { id: 'placeholder', path: 'placeholder.webp', format: 'webp', width: 16, quality: 20 }
+      : null,
+  });
+}
+
+module.exports = { compileArtifactPlan };

--- a/lib/artifact-policy.js
+++ b/lib/artifact-policy.js
@@ -8,6 +8,8 @@ const MAX_DIMENSION = 32_768;
 const MAX_WIDTHS = 8;
 const MAX_FORMATS = 3;
 const MAX_ARTIFACTS = 24;
+const MAX_RAW_WIDTHS = 64;
+const MAX_RAW_FORMATS = 12;
 const MAX_BUDGET_BYTES = 32 * 1024 * 1024;
 const FORMAT_ORDER = ['jpeg', 'webp', 'avif'];
 const DEFAULT_WIDTHS = [320, 640, 1280];
@@ -96,25 +98,31 @@ function normalizeSource(source) {
 
 function normalizeWidths(rawWidths, sourceWidth) {
   if (!Array.isArray(rawWidths) || rawWidths.length === 0) fail('widths must be a non-empty array');
-  if (rawWidths.length > MAX_WIDTHS) fail(`widths must contain at most ${MAX_WIDTHS} entries`);
+  if (rawWidths.length > MAX_RAW_WIDTHS) {
+    fail(`widths must contain at most ${MAX_RAW_WIDTHS} raw entries`);
+  }
   for (let index = 0; index < rawWidths.length; index += 1) {
     if (!Object.hasOwn(rawWidths, index)) fail('widths must not contain empty entries');
   }
   const widths = [...new Set(rawWidths.map((width) => requireInteger(width, 'widths entry', 16, 8192)))]
-    .sort((left, right) => left - right)
-    .filter((width) => width <= sourceWidth);
-  if (widths.length > 0) return widths;
+    .sort((left, right) => left - right);
+  if (widths.length > MAX_WIDTHS) fail(`widths must contain at most ${MAX_WIDTHS} entries`);
+  const displayWidths = widths.filter((width) => width <= sourceWidth);
+  if (displayWidths.length > 0) return displayWidths;
   if (sourceWidth < 16) fail('source display width must be at least 16 pixels');
   return [sourceWidth];
 }
 
 function normalizeFormats(rawFormats) {
   if (!Array.isArray(rawFormats) || rawFormats.length === 0) fail('formats must be a non-empty array');
-  if (rawFormats.length > MAX_FORMATS) fail(`formats must contain at most ${MAX_FORMATS} entries`);
+  if (rawFormats.length > MAX_RAW_FORMATS) {
+    fail(`formats must contain at most ${MAX_RAW_FORMATS} raw entries`);
+  }
   for (const format of rawFormats) {
     if (!FORMAT_ORDER.includes(format)) fail('formats entries must be jpeg, webp, or avif');
   }
   const requested = new Set(rawFormats);
+  if (requested.size > MAX_FORMATS) fail(`formats must contain at most ${MAX_FORMATS} entries`);
   return FORMAT_ORDER.filter((format) => requested.has(format));
 }
 
@@ -153,27 +161,27 @@ function compileArtifactPlan(sourceInput, policyInput = {}, compilerFingerprint)
   const source = normalizeSource(sourceInput);
   const policy = requireRecord(policyInput, 'policy');
   rejectUnknownKeys(policy, POLICY_KEYS, 'policy');
-  if (policy.preset != null && policy.preset !== 'publicUpload') fail('policy.preset must be publicUpload');
-  if (policy.placeholder != null && typeof policy.placeholder !== 'boolean') {
+  if (policy.preset !== undefined && policy.preset !== 'publicUpload') fail('policy.preset must be publicUpload');
+  if (policy.placeholder !== undefined && typeof policy.placeholder !== 'boolean') {
     fail('policy.placeholder must be a boolean');
   }
   if (typeof compilerFingerprint !== 'string' || !/^[a-f0-9]{64}$/.test(compilerFingerprint)) {
     fail('compilerFingerprint must be a lowercase SHA-256 digest');
   }
 
-  const widths = normalizeWidths(policy.widths ?? DEFAULT_WIDTHS, source.displayWidth);
-  const formats = normalizeFormats(policy.formats ?? ['webp']);
+  const widths = normalizeWidths(policy.widths === undefined ? DEFAULT_WIDTHS : policy.widths, source.displayWidth);
+  const formats = normalizeFormats(policy.formats === undefined ? ['webp'] : policy.formats);
   if (source.hasAlpha && formats.includes('jpeg')) fail('alpha input cannot produce jpeg artifacts');
 
   const artifactIds = new Set(formats.flatMap((format) => widths.map((width) => `${width}/${format}`)));
   if (artifactIds.size > MAX_ARTIFACTS) fail(`artifact plan must contain at most ${MAX_ARTIFACTS} entries`);
-  const budgets = normalizeBudgets(policy.budgets ?? [], artifactIds);
+  const budgets = normalizeBudgets(policy.budgets === undefined ? [] : policy.budgets, artifactIds);
   const normalizedPolicy = {
     preset: 'publicUpload',
     widths,
     formats,
     budgets,
-    placeholder: policy.placeholder ?? true,
+    placeholder: policy.placeholder === undefined ? true : policy.placeholder,
   };
   const policyFingerprint = digest(normalizedPolicy);
   const budgetsById = new Map(budgets.map((budget) => [`${budget.width}/${budget.format}`, budget.maxBytes]));

--- a/scripts/postbuild-fixup.js
+++ b/scripts/postbuild-fixup.js
@@ -25,6 +25,85 @@ export type ResizeFit = 'inside' | 'cover' | 'fill'
 export type FirewallPolicy = 'strict' | 'lenient' | 'public-upload'
 export type IccOutcome = 'absent' | 'preserved' | 'unsafe-stripped' | 'policy-stripped' | 'unsupported'
 export type EncodeProfile = 'size-first' | 'balanced' | 'speed-first'
+export type ArtifactFormat = 'jpeg' | 'webp' | 'avif'
+
+export interface ArtifactByteBudget {
+  readonly width: number
+  readonly format: ArtifactFormat
+  readonly maxBytes: number
+}
+
+export interface PublicUploadPolicy {
+  readonly preset?: 'publicUpload'
+  readonly widths?: readonly number[]
+  readonly formats?: readonly ArtifactFormat[]
+  readonly budgets?: readonly ArtifactByteBudget[]
+  readonly placeholder?: boolean
+}
+
+export interface ArtifactSourceFacts {
+  readonly sha256: string
+  readonly bytes: number
+  readonly format: 'jpeg' | 'jpg' | 'png' | 'webp'
+  readonly width: number
+  readonly height: number
+  readonly hasAlpha: boolean
+  readonly isAnimated: boolean
+  readonly orientationKnown: true
+  readonly orientation: number | null
+}
+
+export interface ArtifactPlanSource {
+  readonly sha256: string
+  readonly bytes: number
+  readonly detectedFormat: 'jpeg' | 'png' | 'webp'
+  readonly encodedWidth: number
+  readonly encodedHeight: number
+  readonly displayWidth: number
+  readonly displayHeight: number
+  readonly hasAlpha: boolean
+  readonly isAnimated: false
+  readonly orientationKnown: true
+  readonly orientation: number | null
+  readonly orientationApplied: boolean
+}
+
+export interface ArtifactPlanPolicy {
+  readonly preset: 'publicUpload'
+  readonly widths: readonly number[]
+  readonly formats: readonly ArtifactFormat[]
+  readonly budgets: readonly ArtifactByteBudget[]
+  readonly placeholder: boolean
+}
+
+export interface ArtifactPlanItem {
+  readonly id: string
+  readonly path: string
+  readonly format: ArtifactFormat
+  readonly width: number
+  readonly quality: number
+  readonly targetBytes?: number
+}
+
+export interface ArtifactPlan {
+  readonly schemaVersion: 1
+  readonly compilerFingerprint: string
+  readonly policyFingerprint: string
+  readonly cacheKey: string
+  readonly source: ArtifactPlanSource
+  readonly policy: ArtifactPlanPolicy
+  readonly artifacts: readonly ArtifactPlanItem[]
+  readonly delivery: {
+    readonly srcsets: readonly { readonly format: ArtifactFormat; readonly value: string }[]
+  }
+  readonly placeholder: {
+    readonly id: 'placeholder'
+    readonly path: 'placeholder.webp'
+    readonly format: 'webp'
+    readonly width: 16
+    readonly quality: 20
+  } | null
+}
 
 export interface ResolvedEncodeProfile {
   format: CanonicalOutputFormat

--- a/scripts/postbuild-fixup.js
+++ b/scripts/postbuild-fixup.js
@@ -105,6 +105,12 @@ export interface ArtifactPlan {
   } | null
 }
 
+export declare function compileArtifactPlan(
+  source: ArtifactSourceFacts,
+  policy: PublicUploadPolicy | undefined,
+  compilerFingerprint: string,
+): ArtifactPlan
+
 export interface ResolvedEncodeProfile {
   format: CanonicalOutputFormat
   quality?: number
@@ -310,12 +316,14 @@ function patchIndexJs() {
 // High-level helpers and streaming API (extracted to lib/helpers.js)
 const { createStreamingPipeline } = require('./streaming/pipeline')
 const helpers = require('./lib/helpers')
+const { compileArtifactPlan } = require('./lib/artifact-policy')
 const _getErrorCategory = helpers.createGetErrorCategory(nativeBinding.ErrorCategory, nativeBinding.ErrorCode)
 const _processBatchChunked = helpers.createProcessBatchChunked(nativeBinding.ImageEngine)
 module.exports.getErrorCategory = _getErrorCategory
 module.exports.processBatchChunked = _processBatchChunked
 module.exports.createStreamingPipeline = createStreamingPipeline
 module.exports.resolveEncodeProfile = helpers.resolveEncodeProfile
+module.exports.compileArtifactPlan = compileArtifactPlan
 if (nativeBinding && nativeBinding.ImageEngine) {
   helpers.attachPrototypeMethods(nativeBinding.ImageEngine)
 }

--- a/test/integration/artifact-policy.test.js
+++ b/test/integration/artifact-policy.test.js
@@ -1,0 +1,142 @@
+const assert = require('node:assert/strict');
+const { compileArtifactPlan } = require('../../lib/artifact-policy');
+
+const SOURCE = Object.freeze({
+  sha256: 'a'.repeat(64),
+  bytes: 1024,
+  format: 'jpeg',
+  width: 2000,
+  height: 1200,
+  hasAlpha: false,
+  isAnimated: false,
+  orientationKnown: true,
+  orientation: null,
+});
+const COMPILER_FINGERPRINT = 'b'.repeat(64);
+
+function assertPolicyError(run, message) {
+  assert.throws(run, (error) => {
+    assert.equal(error.code, 'LAZY_IMAGE_USER_ERROR');
+    assert.equal(error.errorCode, 'E400');
+    assert.equal(error.errorCategory, 'UserError');
+    assert.equal(typeof error.recoveryHint, 'string');
+    assert.match(error.message, message);
+    return true;
+  });
+}
+
+const plan = compileArtifactPlan(SOURCE, {}, COMPILER_FINGERPRINT);
+assert.deepEqual(plan.policy, {
+  preset: 'publicUpload',
+  widths: [320, 640, 1280],
+  formats: ['webp'],
+  budgets: [],
+  placeholder: true,
+});
+assert.deepEqual(plan.artifacts.map(({ id }) => id), ['320/webp', '640/webp', '1280/webp']);
+assert.equal(plan.delivery.srcsets[0].value, 'image-320.webp 320w, image-640.webp 640w, image-1280.webp 1280w');
+assert.equal(plan.placeholder.path, 'placeholder.webp');
+assert(Object.isFrozen(plan));
+assert(Object.isFrozen(plan.policy.widths));
+
+const input = {
+  preset: 'publicUpload',
+  widths: [1280, 320, 320, 768],
+  formats: ['avif', 'jpeg', 'webp'],
+  budgets: [{ width: 768, format: 'webp', maxBytes: 50_000 }],
+  placeholder: false,
+};
+const originalInput = structuredClone(input);
+const canonical = compileArtifactPlan(SOURCE, input, COMPILER_FINGERPRINT);
+assert.deepEqual(input, originalInput);
+assert.deepEqual(canonical.policy.widths, [320, 768, 1280]);
+assert.deepEqual(canonical.policy.formats, ['jpeg', 'webp', 'avif']);
+assert.deepEqual(canonical.artifacts.map(({ id }) => id), [
+  '320/jpeg', '768/jpeg', '1280/jpeg',
+  '320/webp', '768/webp', '1280/webp',
+  '320/avif', '768/avif', '1280/avif',
+]);
+assert.equal(canonical.artifacts.find(({ id }) => id === '768/webp').targetBytes, 50_000);
+assert.equal(canonical.placeholder, null);
+
+const withoutEnlargement = compileArtifactPlan(
+  { ...SOURCE, width: 500, height: 300 },
+  { widths: [1000] },
+  COMPILER_FINGERPRINT,
+);
+assert.deepEqual(withoutEnlargement.policy.widths, [500]);
+
+const rotated = compileArtifactPlan(
+  { ...SOURCE, width: 1200, height: 800, orientation: 6 },
+  { widths: [900] },
+  COMPILER_FINGERPRINT,
+);
+assert.equal(rotated.source.displayWidth, 800);
+assert.equal(rotated.source.displayHeight, 1200);
+assert.deepEqual(rotated.policy.widths, [800]);
+assert.equal(compileArtifactPlan({ ...SOURCE, format: 'jpg' }, {}, COMPILER_FINGERPRINT).source.detectedFormat, 'jpeg');
+
+const same = compileArtifactPlan(SOURCE, {}, COMPILER_FINGERPRINT);
+assert.deepEqual(same, plan);
+assert.notEqual(
+  compileArtifactPlan(SOURCE, { placeholder: false }, COMPILER_FINGERPRINT).cacheKey,
+  plan.cacheKey,
+);
+assert.notEqual(compileArtifactPlan(SOURCE, {}, 'c'.repeat(64)).cacheKey, plan.cacheKey);
+assert(!JSON.stringify(plan).includes(process.cwd()));
+
+const invalidCases = [
+  [{ widths: [15] }, /widths/],
+  [{ widths: Array.from({ length: 9 }, (_, index) => index + 16) }, /at most 8/],
+  [{ formats: ['png'] }, /formats/],
+  [{ unknown: true }, /unknown policy key/],
+  [{ budgets: [{ width: 999, format: 'webp', maxBytes: 1 }] }, /budget target/],
+  [{ budgets: [
+    { width: 320, format: 'webp', maxBytes: 1 },
+    { width: 320, format: 'webp', maxBytes: 2 },
+  ] }, /duplicate budget/],
+  [{ budgets: [{ width: 320, format: 'webp', maxBytes: 32 * 1024 * 1024 + 1 }] }, /maxBytes/],
+];
+for (const [policy, message] of invalidCases) {
+  assertPolicyError(() => compileArtifactPlan(SOURCE, policy, COMPILER_FINGERPRINT), message);
+}
+
+assertPolicyError(
+  () => compileArtifactPlan({ ...SOURCE, hasAlpha: true }, { formats: ['jpeg'] }, COMPILER_FINGERPRINT),
+  /alpha.*jpeg/i,
+);
+assertPolicyError(
+  () => compileArtifactPlan({ ...SOURCE, isAnimated: true }, {}, COMPILER_FINGERPRINT),
+  /animated/i,
+);
+assertPolicyError(
+  () => compileArtifactPlan({ ...SOURCE, hasAlpha: undefined }, {}, COMPILER_FINGERPRINT),
+  /hasAlpha/,
+);
+for (const [source, message] of [
+  [{ ...SOURCE, isAnimated: undefined }, /isAnimated/],
+  [{ ...SOURCE, orientationKnown: false }, /orientationKnown/],
+  [{ ...SOURCE, orientation: undefined }, /source.orientation/],
+  [{ ...SOURCE, sha256: 'invalid' }, /sha256/],
+  [{ ...SOURCE, sha256: { toString: () => 'a'.repeat(64), toJSON: () => 'leak' } }, /sha256/],
+  [{ ...SOURCE, bytes: 32 * 1024 * 1024 + 1 }, /source.bytes/],
+  [{ ...SOURCE, format: 'avif' }, /source.format/],
+  [{ ...SOURCE, width: 10_000, height: 10_000 }, /pixels/],
+  [{ ...SOURCE, path: '/private/input.jpg' }, /unknown source key/],
+]) {
+  assertPolicyError(() => compileArtifactPlan(source, {}, COMPILER_FINGERPRINT), message);
+}
+assertPolicyError(
+  () => compileArtifactPlan(SOURCE, {}, 'not-a-fingerprint'),
+  /compilerFingerprint/,
+);
+assertPolicyError(
+  () => compileArtifactPlan(SOURCE, { widths: [, 32] }, COMPILER_FINGERPRINT),
+  /widths/,
+);
+assertPolicyError(
+  () => compileArtifactPlan(SOURCE, {}, { toString: () => 'b'.repeat(64), toJSON: () => 'leak' }),
+  /compilerFingerprint/,
+);
+
+console.log('artifact policy contract passed');

--- a/test/integration/artifact-policy.test.js
+++ b/test/integration/artifact-policy.test.js
@@ -1,5 +1,8 @@
 const assert = require('node:assert/strict');
 const { compileArtifactPlan } = require('../../lib/artifact-policy');
+const packageApi = require('../../index');
+
+assert.equal(packageApi.compileArtifactPlan, compileArtifactPlan);
 
 const SOURCE = Object.freeze({
   sha256: 'a'.repeat(64),
@@ -203,3 +206,12 @@ assertPolicyError(
 );
 
 console.log('artifact policy contract passed');
+
+import('../../index.mjs')
+  .then(({ compileArtifactPlan: esmCompileArtifactPlan }) => {
+    assert.equal(esmCompileArtifactPlan, compileArtifactPlan);
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });

--- a/test/integration/artifact-policy.test.js
+++ b/test/integration/artifact-policy.test.js
@@ -59,6 +59,19 @@ assert.deepEqual(canonical.artifacts.map(({ id }) => id), [
 assert.equal(canonical.artifacts.find(({ id }) => id === '768/webp').targetBytes, 50_000);
 assert.equal(canonical.placeholder, null);
 
+const duplicateWidths = compileArtifactPlan(
+  SOURCE,
+  { widths: Array(9).fill(320) },
+  COMPILER_FINGERPRINT,
+);
+assert.deepEqual(duplicateWidths.policy.widths, [320]);
+const duplicateFormats = compileArtifactPlan(
+  SOURCE,
+  { formats: ['avif', 'jpeg', 'jpeg', 'webp'] },
+  COMPILER_FINGERPRINT,
+);
+assert.deepEqual(duplicateFormats.policy.formats, ['jpeg', 'webp', 'avif']);
+
 const withoutEnlargement = compileArtifactPlan(
   { ...SOURCE, width: 500, height: 300 },
   { widths: [1000] },
@@ -134,6 +147,23 @@ assertPolicyError(
   () => compileArtifactPlan(SOURCE, { widths: [, 32] }, COMPILER_FINGERPRINT),
   /widths/,
 );
+assertPolicyError(
+  () => compileArtifactPlan(SOURCE, { widths: Array(65).fill(320) }, COMPILER_FINGERPRINT),
+  /at most 64 raw entries/,
+);
+assertPolicyError(
+  () => compileArtifactPlan(SOURCE, { formats: Array(13).fill('webp') }, COMPILER_FINGERPRINT),
+  /at most 12 raw entries/,
+);
+for (const [policy, message] of [
+  [{ preset: null }, /policy\.preset/],
+  [{ widths: null }, /widths/],
+  [{ formats: null }, /formats/],
+  [{ budgets: null }, /budgets/],
+  [{ placeholder: null }, /placeholder/],
+]) {
+  assertPolicyError(() => compileArtifactPlan(SOURCE, policy, COMPILER_FINGERPRINT), message);
+}
 assertPolicyError(
   () => compileArtifactPlan(SOURCE, {}, { toString: () => 'b'.repeat(64), toJSON: () => 'leak' }),
   /compilerFingerprint/,

--- a/test/integration/artifact-policy.test.js
+++ b/test/integration/artifact-policy.test.js
@@ -169,4 +169,37 @@ assertPolicyError(
   /compilerFingerprint/,
 );
 
+const inheritedSource = { ...SOURCE };
+delete inheritedSource.hasAlpha;
+Object.defineProperty(Object.prototype, 'hasAlpha', { value: false, configurable: true });
+try {
+  assertPolicyError(() => compileArtifactPlan(inheritedSource, {}, COMPILER_FINGERPRINT), /own data property/);
+} finally {
+  delete Object.prototype.hasAlpha;
+}
+const accessorSource = { ...SOURCE };
+Object.defineProperty(accessorSource, 'format', { get: () => 'jpeg' });
+assertPolicyError(() => compileArtifactPlan(accessorSource, {}, COMPILER_FINGERPRINT), /own data property/);
+const accessorPolicy = {};
+Object.defineProperty(accessorPolicy, 'widths', { get: () => [320] });
+assertPolicyError(() => compileArtifactPlan(SOURCE, accessorPolicy, COMPILER_FINGERPRINT), /own data property/);
+Object.defineProperty(Object.prototype, 'widths', { value: [320], configurable: true });
+try {
+  assertPolicyError(() => compileArtifactPlan(SOURCE, {}, COMPILER_FINGERPRINT), /own data property/);
+} finally {
+  delete Object.prototype.widths;
+}
+const accessorFormats = [];
+Object.defineProperty(accessorFormats, '0', { get: () => 'webp' });
+assertPolicyError(
+  () => compileArtifactPlan(SOURCE, { formats: accessorFormats }, COMPILER_FINGERPRINT),
+  /own data properties/,
+);
+const accessorBudget = {};
+Object.defineProperty(accessorBudget, 'width', { get: () => 320 });
+assertPolicyError(
+  () => compileArtifactPlan(SOURCE, { budgets: [accessorBudget] }, COMPILER_FINGERPRINT),
+  /own data property/,
+);
+
 console.log('artifact policy contract passed');

--- a/test/type-safety/typescript-typecheck.test.ts
+++ b/test/type-safety/typescript-typecheck.test.ts
@@ -4,10 +4,13 @@
  */
 import * as path from 'path';
 import {
+    ArtifactPlan,
+    ArtifactSourceFacts,
     BatchProgressEvent,
     ImageEngine,
     ImageMetadata,
     OutputFormat,
+    PublicUploadPolicy,
     PresetName,
     PresetResult,
     ResizeFit,
@@ -17,6 +20,26 @@ import { createStreamingPipeline } from '../../streaming/pipeline';
 
 async function testTypeSafety() {
     const imagePath = path.resolve(__dirname, '../fixtures/test_input.jpg');
+
+    const artifactSource: ArtifactSourceFacts = {
+        sha256: 'a'.repeat(64),
+        bytes: 1024,
+        format: 'jpeg',
+        width: 1280,
+        height: 720,
+        hasAlpha: false,
+        isAnimated: false,
+        orientationKnown: true,
+        orientation: null,
+    };
+    const publicUploadPolicy: PublicUploadPolicy = {
+        preset: 'publicUpload',
+        widths: [320, 640],
+        formats: ['webp'],
+        placeholder: true,
+    };
+    const artifactPlan = null as ArtifactPlan | null;
+    console.log(`Artifact policy: ${artifactSource.format} ${publicUploadPolicy.widths?.length} ${artifactPlan}`);
     
     // Type-safe OutputFormat usage
     const validFormats: OutputFormat[] = ['jpeg', 'jpg', 'png', 'webp', 'avif'];

--- a/test/type-safety/typescript-typecheck.test.ts
+++ b/test/type-safety/typescript-typecheck.test.ts
@@ -7,6 +7,7 @@ import {
     ArtifactPlan,
     ArtifactSourceFacts,
     BatchProgressEvent,
+    compileArtifactPlan,
     ImageEngine,
     ImageMetadata,
     OutputFormat,
@@ -39,7 +40,12 @@ async function testTypeSafety() {
         placeholder: true,
     };
     const artifactPlan = null as ArtifactPlan | null;
-    console.log(`Artifact policy: ${artifactSource.format} ${publicUploadPolicy.widths?.length} ${artifactPlan}`);
+    const compiledArtifactPlan: ArtifactPlan = compileArtifactPlan(
+        artifactSource,
+        publicUploadPolicy,
+        'b'.repeat(64),
+    );
+    console.log(`Artifact policy: ${artifactSource.format} ${publicUploadPolicy.widths?.length} ${artifactPlan} ${compiledArtifactPlan.cacheKey}`);
     
     // Type-safe OutputFormat usage
     const validFormats: OutputFormat[] = ['jpeg', 'jpg', 'png', 'webp', 'avif'];


### PR DESCRIPTION
## Description

未信頼画像を公開用artifactへ変換する前段として、検証済みsource factsとpublic-upload policyから、決定的かつ不変なartifact planを生成するpure compilerを追加します。

変更前はpublic-uploadの方向性と個別encode APIは存在しましたが、responsive出力、byte budget、cache identityを一つのcanonical planへ正規化する境界がありませんでした。変更後は同じ入力とcompiler fingerprintから常に同じplan、policy fingerprint、cache keyを生成できます。

## Related Issue

Closes #814

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🧪 Tests (adding or updating tests)

## Decisions

- compilerはfilesystem、decode/encode、staging、publishを行わないpure moduleに限定
- Node.js標準ライブラリのみを使用し、新規依存を追加しない
- unknown field、不正なbudget、animated input、alphaからJPEG、未確定EXIF orientationをfail-closedで拒否
- validation errorを既存契約に合わせてE400 / UserError / recoveryHintへ集約
- widths、formats、budgetsをcanonical順へ正規化し、plan全体をdeep freeze

## Changes Made

- `lib/artifact-policy.js`にpolicy normalizationとdeterministic plan生成を追加
- responsive srcset、placeholder、artifact byte budget、fingerprint/cache keyをplanへ収録
- `ArtifactSourceFacts`、`PublicUploadPolicy`、`ArtifactPlan`等の生成TypeScript型を追加
- primitive fingerprint、疎配列、EXIF向き未確定を含むtrust-boundary契約テストを追加

## Testing

```bash
node test/integration/artifact-policy.test.js
npm run build
npm run test:types
npm run check:generated-artifacts
npm test
git diff --check
```

- JavaScript、Rust 291 unit testsほか、Wasm packageを含む`npm test`成功
- TypeScript専門レビュー: ALLOW
- セキュリティ専門レビュー: ALLOW
- Codex Companion Stop Review Gate: 指摘なし

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where non-obvious rationale is needed
- [x] Generated TypeScript declarations are synchronized
- [x] My changes generate no new warnings
- [x] I have added tests that prove the feature contract
- [x] New and existing tests pass locally with my changes
- [x] No dependent unmerged change is required

## Performance Impact

- [x] No runtime image-processing performance impact

compilerはpureなin-memory planningのみで、画像decode/encode経路には接続していません。

## Remaining Scope

transactional executor、filesystem staging、manifest書き込み、publish切替、CLI/Wasm公開は本PRに含めません。#703の後続Issueとして分離します。