### PR TITLE
feat: add transactional artifact executor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Transactional native `compileImage()` for deterministic public-upload
+  artifacts, optional placeholder data URLs, verified hashes, and atomic
+  directory publication. Existing output directories are never overwritten.
+
 ---
 
 ## [1.0.1] - 2026-08-27

--- a/README.ja.md
+++ b/README.ja.md
@@ -46,6 +46,22 @@ console.log(`Wrote ${bytesWritten} bytes`);
 - 静的サイト生成バッチ: `processBatch()` / `clone()`
 - 編集後の最終最適化: sharp/ImageMagick の後段に lazy-image を通す
 
+未信頼のローカル画像から公開用成果物一式を安全に作る場合は、
+transactional compilerを使います。全artifact、placeholder、manifestを
+private stagingで検証してから一度だけ公開ディレクトリへcommitします。
+
+```javascript
+const { compileImage } = require('@alberteinshutoin/lazy-image');
+
+const manifest = await compileImage({
+  inputPath: '/srv/uploads/image.bin',
+  outputDir: '/srv/public/images/v1',
+  policy: { widths: [320, 640], formats: ['webp'], placeholder: true },
+});
+```
+
+既存の出力ディレクトリは上書きせず、artifact全体をNode.jsのBufferへ戻しません。
+
 ## Cost Savings Example (ROI)
 
 README（英語版）と同じ想定計算を参照します。月間配信量とエンコーディング回数次第で節約は拡大します。

--- a/README.md
+++ b/README.md
@@ -69,6 +69,23 @@ const output = await ImageEngine.from(uploadBuffer)
 The `public-upload` policy enforces resource limits and strips EXIF, GPS, and
 XMP while preserving only validated ICC profiles.
 
+For a complete, fail-closed artifact set, use the transactional compiler. It
+creates library-owned responsive filenames and `manifest.json` in private
+staging, then publishes the directory only after verification:
+
+```javascript
+const { compileImage } = require('@alberteinshutoin/lazy-image');
+
+const manifest = await compileImage({
+  inputPath: '/srv/uploads/image.bin',
+  outputDir: '/srv/public/images/v1',
+  policy: { widths: [320, 640], formats: ['webp'], placeholder: true },
+});
+```
+
+Existing output directories are rejected and full artifact bytes are never
+returned as Node.js buffers.
+
 ## Inspect without decoding
 
 ```javascript

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,398 @@
+use std::{env, fs, path::PathBuf, process::Command};
+
+const SHA256_K: [u32; 64] = [
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+];
+
+fn sha256(bytes: &[u8]) -> [u8; 32] {
+    let mut message = bytes.to_vec();
+    let bit_len = (message.len() as u64) * 8;
+    message.push(0x80);
+    while (message.len() + 8) % 64 != 0 {
+        message.push(0);
+    }
+    message.extend_from_slice(&bit_len.to_be_bytes());
+
+    let mut state = [
+        0x6a09e667u32,
+        0xbb67ae85,
+        0x3c6ef372,
+        0xa54ff53a,
+        0x510e527f,
+        0x9b05688c,
+        0x1f83d9ab,
+        0x5be0cd19,
+    ];
+    for chunk in message.chunks_exact(64) {
+        let mut schedule = [0u32; 64];
+        for (index, word) in schedule[..16].iter_mut().enumerate() {
+            *word = u32::from_be_bytes([
+                chunk[index * 4],
+                chunk[index * 4 + 1],
+                chunk[index * 4 + 2],
+                chunk[index * 4 + 3],
+            ]);
+        }
+        for index in 16..64 {
+            let s0 = schedule[index - 15].rotate_right(7)
+                ^ schedule[index - 15].rotate_right(18)
+                ^ (schedule[index - 15] >> 3);
+            let s1 = schedule[index - 2].rotate_right(17)
+                ^ schedule[index - 2].rotate_right(19)
+                ^ (schedule[index - 2] >> 10);
+            schedule[index] = schedule[index - 16]
+                .wrapping_add(s0)
+                .wrapping_add(schedule[index - 7])
+                .wrapping_add(s1);
+        }
+
+        let mut working = state;
+        for (index, constant) in SHA256_K.iter().enumerate() {
+            let s1 = working[4].rotate_right(6)
+                ^ working[4].rotate_right(11)
+                ^ working[4].rotate_right(25);
+            let choice = (working[4] & working[5]) ^ ((!working[4]) & working[6]);
+            let temp1 = working[7]
+                .wrapping_add(s1)
+                .wrapping_add(choice)
+                .wrapping_add(*constant)
+                .wrapping_add(schedule[index]);
+            let s0 = working[0].rotate_right(2)
+                ^ working[0].rotate_right(13)
+                ^ working[0].rotate_right(22);
+            let majority =
+                (working[0] & working[1]) ^ (working[0] & working[2]) ^ (working[1] & working[2]);
+            let temp2 = s0.wrapping_add(majority);
+            working = [
+                temp1.wrapping_add(temp2),
+                working[0],
+                working[1],
+                working[2],
+                working[3].wrapping_add(temp1),
+                working[4],
+                working[5],
+                working[6],
+            ];
+        }
+        for index in 0..8 {
+            state[index] = state[index].wrapping_add(working[index]);
+        }
+    }
+
+    let mut digest = [0u8; 32];
+    for (index, word) in state.iter().enumerate() {
+        digest[index * 4..index * 4 + 4].copy_from_slice(&word.to_be_bytes());
+    }
+    digest
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+const EXPLICIT_ENV_KEYS: &[&str] = &[
+    "AR",
+    "CC",
+    "CFLAGS",
+    "CPPFLAGS",
+    "CXX",
+    "CXXFLAGS",
+    "LIBAVIF_CFLAGS",
+    "LIBAVIF_LIBS",
+    "MOZJPEG_CFLAGS",
+    "MOZJPEG_LIBS",
+    "RUSTFLAGS",
+    "CARGO_ENCODED_RUSTFLAGS",
+    "TARGET_AR",
+    "TARGET_CC",
+    "TARGET_CFLAGS",
+    "TARGET_CXX",
+    "TARGET_CXXFLAGS",
+    "WEBP_CFLAGS",
+    "WEBP_LIBS",
+    "PKG_CONFIG_PATH",
+    "PKG_CONFIG_LIBDIR",
+    "RUSTC_WRAPPER",
+    "RUSTC_WORKSPACE_WRAPPER",
+];
+
+const TARGET_TOOLCHAIN_ENV_KEYS: &[&str] = &[
+    "AR",
+    "CC",
+    "CFLAGS",
+    "CPPFLAGS",
+    "CXX",
+    "CXXFLAGS",
+    "PKG_CONFIG_PATH",
+    "PKG_CONFIG_LIBDIR",
+];
+
+const KNOWN_FEATURES: &[&str] = &["NAPI", "JEMALLOC", "AVIF", "FUZZING", "STRESS", "COW_DEBUG"];
+
+const KNOWN_CFG_KEYS: &[&str] = &[
+    "CARGO_CFG_DEBUG_ASSERTIONS",
+    "CARGO_CFG_OVERFLOW_CHECKS",
+    "CARGO_CFG_PANIC",
+    "CARGO_CFG_PROC_MACRO",
+    "CARGO_CFG_TARGET_ABI",
+    "CARGO_CFG_TARGET_ARCH",
+    "CARGO_CFG_TARGET_ENDIAN",
+    "CARGO_CFG_TARGET_ENV",
+    "CARGO_CFG_TARGET_FAMILY",
+    "CARGO_CFG_TARGET_FEATURE",
+    "CARGO_CFG_TARGET_HAS_ATOMIC",
+    "CARGO_CFG_TARGET_OS",
+    "CARGO_CFG_TARGET_POINTER_WIDTH",
+    "CARGO_CFG_UNIX",
+    "CARGO_CFG_WINDOWS",
+];
+
+const PROFILE_FIELDS: &[&str] = &[
+    "CODEGEN_UNITS",
+    "DEBUG",
+    "DEBUG_ASSERTIONS",
+    "INCREMENTAL",
+    "LTO",
+    "OPT_LEVEL",
+    "OVERFLOW_CHECKS",
+    "PANIC",
+    "RPATH",
+    "STRIP",
+];
+
+const TARGET_PROFILE_FIELDS: &[&str] = &[
+    "AR",
+    "CC",
+    "CFLAGS",
+    "CRATE_TYPE",
+    "CXX",
+    "CXXFLAGS",
+    "LINKER",
+    "RUSTFLAGS",
+    "RUNNER",
+];
+
+const KNOWN_DEP_KEYS: &[&str] = &[
+    "DEP_AOM_INCLUDE",
+    "DEP_AOM_PKGCONFIG",
+    "DEP_DAV1D_INCLUDE",
+    "DEP_DAV1D_PKGCONFIG",
+    "DEP_DAV1D_STATICLIB",
+    "DEP_JPEG_ABI",
+    "DEP_JPEG_INCLUDE",
+];
+
+fn output_environment_key(key: &str, target: &str) -> bool {
+    if key.starts_with("CARGO_FEATURE_")
+        || key.starts_with("CARGO_CFG_")
+        || key.starts_with("CARGO_PROFILE_")
+        || key.starts_with("CARGO_TARGET_")
+        || key.starts_with("DEP_")
+        || EXPLICIT_ENV_KEYS.contains(&key)
+    {
+        return true;
+    }
+    let normalized_target = target.replace('-', "_");
+    let variants = [target, normalized_target.as_str()];
+    let toolchain_names = [
+        "AR",
+        "CC",
+        "CFLAGS",
+        "CPPFLAGS",
+        "CXX",
+        "CXXFLAGS",
+        "PKG_CONFIG_PATH",
+        "PKG_CONFIG_LIBDIR",
+    ];
+    variants.iter().any(|variant| {
+        toolchain_names
+            .iter()
+            .any(|name| key == format!("{name}_{variant}") || key == format!("{variant}_{name}"))
+    })
+}
+
+fn selected_environment(target: &str) -> Vec<(String, String)> {
+    let mut values = env::vars()
+        .filter(|(key, _)| output_environment_key(key, target))
+        .collect::<Vec<_>>();
+    values.sort_unstable_by(|left, right| left.0.cmp(&right.0));
+    values
+}
+
+fn monitored_environment_keys(target: &str, profile: &str) -> Vec<String> {
+    let mut keys = EXPLICIT_ENV_KEYS
+        .iter()
+        .map(|key| (*key).to_string())
+        .chain(
+            KNOWN_FEATURES
+                .iter()
+                .map(|feature| format!("CARGO_FEATURE_{feature}")),
+        )
+        .chain(KNOWN_CFG_KEYS.iter().map(|key| (*key).to_string()))
+        .chain(KNOWN_DEP_KEYS.iter().map(|key| (*key).to_string()))
+        .collect::<Vec<_>>();
+
+    let profile_name = profile.to_ascii_uppercase().replace('-', "_");
+    keys.extend(
+        PROFILE_FIELDS
+            .iter()
+            .map(|field| format!("CARGO_PROFILE_{profile_name}_{field}")),
+    );
+
+    let normalized_target = target.replace('-', "_");
+    for variant in [target, normalized_target.as_str()] {
+        keys.extend(
+            TARGET_PROFILE_FIELDS
+                .iter()
+                .map(|field| format!("CARGO_TARGET_{}_{}", variant.to_ascii_uppercase(), field)),
+        );
+        keys.extend(
+            TARGET_TOOLCHAIN_ENV_KEYS
+                .iter()
+                .flat_map(|name| [format!("{name}_{variant}"), format!("{variant}_{name}")]),
+        );
+    }
+
+    // Prefix-based Cargo metadata is intentionally retained in the digest. Add
+    // the keys visible in this invocation and the static keys above to cover
+    // unset-to-set changes on the next incremental build.
+    keys.extend(
+        env::vars()
+            .filter(|(key, _)| output_environment_key(key, target))
+            .map(|(key, _)| key),
+    );
+    keys.sort_unstable();
+    keys.dedup();
+    keys
+}
+
+fn compiler_config_digest(
+    cargo_toml: &[u8],
+    cargo_lock: &[u8],
+    target: &str,
+    profile: &str,
+    rustc_identity: &[u8],
+    environment: &[(String, String)],
+) -> String {
+    let mut identity = Vec::new();
+    for (label, bytes) in [
+        ("cargo.toml", cargo_toml),
+        ("cargo.lock", cargo_lock),
+        ("target", target.as_bytes()),
+        ("profile", profile.as_bytes()),
+        ("rustc", rustc_identity),
+    ] {
+        identity.extend_from_slice(label.as_bytes());
+        identity.push(0);
+        identity.extend_from_slice(bytes);
+        identity.push(0);
+    }
+    for (key, value) in environment {
+        identity.extend_from_slice(key.as_bytes());
+        identity.push(0);
+        identity.extend_from_slice(value.as_bytes());
+        identity.push(0);
+    }
+    hex(&sha256(&identity))
+}
+
+fn main() {
+    let manifest_dir = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").expect("manifest dir"));
+    let cargo_toml = fs::read(manifest_dir.join("Cargo.toml")).expect("Cargo.toml");
+    let cargo_lock = fs::read(manifest_dir.join("Cargo.lock")).expect("Cargo.lock");
+    let target = env::var("TARGET").expect("target");
+    let profile = env::var("PROFILE").expect("profile");
+    let rustc = env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
+    let rustc_output = Command::new(rustc)
+        .arg("-vV")
+        .output()
+        .expect("rustc -vV must execute");
+    assert!(rustc_output.status.success(), "rustc -vV failed");
+    assert!(
+        !rustc_output.stdout.is_empty(),
+        "rustc -vV returned no identity"
+    );
+    let rustc_identity = rustc_output.stdout;
+    let environment = selected_environment(&target);
+    for key in monitored_environment_keys(&target, &profile) {
+        println!("cargo:rerun-if-env-changed={key}");
+    }
+
+    println!("cargo:rerun-if-changed=Cargo.toml");
+    println!("cargo:rerun-if-changed=Cargo.lock");
+    println!("cargo:rerun-if-env-changed=TARGET");
+    println!("cargo:rerun-if-env-changed=PROFILE");
+    println!(
+        "cargo:rustc-env=LAZY_IMAGE_COMPILER_CONFIG={}",
+        compiler_config_digest(
+            &cargo_toml,
+            &cargo_lock,
+            &target,
+            &profile,
+            &rustc_identity,
+            &environment,
+        )
+    );
+    println!("cargo:rustc-env=LAZY_IMAGE_COMPILER_TARGET={target}");
+    println!("cargo:rustc-env=LAZY_IMAGE_COMPILER_PROFILE={profile}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        compiler_config_digest, hex, monitored_environment_keys, output_environment_key, sha256,
+    };
+
+    #[test]
+    fn sha256_matches_standard_vector() {
+        assert_eq!(
+            hex(&sha256(b"")),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        );
+    }
+
+    #[test]
+    fn compiler_digest_includes_feature_configuration() {
+        let base = vec![("CARGO_FEATURE_AVIF".to_string(), "1".to_string())];
+        let mut changed = base.clone();
+        changed.push(("CARGO_FEATURE_STRESS".to_string(), "1".to_string()));
+        assert_ne!(
+            compiler_config_digest(b"manifest", b"lock", "target", "release", b"rustc", &base),
+            compiler_config_digest(
+                b"manifest",
+                b"lock",
+                "target",
+                "release",
+                b"rustc",
+                &changed
+            ),
+        );
+    }
+
+    #[test]
+    fn target_qualified_toolchain_keys_are_identity_inputs() {
+        assert!(output_environment_key(
+            "CC_aarch64_apple_darwin",
+            "aarch64-apple-darwin"
+        ));
+        assert!(output_environment_key(
+            "aarch64-apple-darwin_CFLAGS",
+            "aarch64-apple-darwin"
+        ));
+    }
+
+    #[test]
+    fn monitoring_includes_unset_toolchain_and_profile_keys() {
+        let keys = monitored_environment_keys("aarch64-apple-darwin", "release");
+        assert!(keys.contains(&"CC_aarch64_apple_darwin".to_string()));
+        assert!(keys.contains(&"aarch64-apple-darwin_CFLAGS".to_string()));
+        assert!(keys.contains(&"CARGO_PROFILE_RELEASE_LTO".to_string()));
+    }
+}

--- a/docs/ADOPTION_GUIDE.md
+++ b/docs/ADOPTION_GUIDE.md
@@ -40,6 +40,22 @@ Runnable companion: [`examples/upload-sanitize-server.mjs`](../examples/upload-s
 shows a dependency-free raw upload endpoint with header inspection, Image
 Firewall limits, and error-category to HTTP status mapping.
 
+For the complete public artifact transaction, use `compileImage()` instead of
+manually wiring several output calls:
+
+```javascript
+const manifest = await compileImage({
+  inputPath: '/srv/uploads/upload.bin',
+  outputDir: '/srv/public/images/v1',
+  policy: { widths: [320, 640], formats: ['webp'], placeholder: true },
+});
+```
+
+It rejects an existing output directory, writes only library-owned names,
+verifies the generated files and privacy metadata, and publishes only after a
+single directory rename. The output parent must be trusted and remain on the
+same filesystem during the call.
+
 ### 3. Build-time static asset optimization
 
 Use batch processing or cloning when the same source needs multiple outputs.

--- a/docs/API.md
+++ b/docs/API.md
@@ -70,6 +70,32 @@ const bytes = await ImageEngine.fromPath('photo.jpg').toFileWithPreset('thumb.we
 | `processBatchChunked(inputs, outDir, { format, quality?, fastMode?, concurrency?, chunkSize?, onProgress?, signal? })` | Top-level batch helper that splits inputs into native `processBatch()` chunks. Reports progress after each chunk and checks `AbortSignal` before starting the next chunk. |
 | `.clone()` | Clone the engine for multi-output (e.g. same pipeline to JPEG + WebP + AVIF). |
 
+### Transactional public-upload compilation
+
+`compileImage()` is the high-level native Node.js entrypoint for one untrusted
+local image. It consumes the deterministic `compileArtifactPlan()` contract,
+writes plan-owned artifacts and an optional 16px WebP placeholder into a
+private sibling staging directory, verifies hashes/metadata, and publishes by
+one directory rename. Existing output directories are rejected; failures and
+abort signals remove the unpublished staging set.
+
+```javascript
+const { compileImage } = require('@alberteinshutoin/lazy-image');
+
+const manifest = await compileImage({
+  inputPath: '/srv/uploads/upload.bin',
+  outputDir: '/srv/public/images/version-1',
+  policy: { widths: [320, 640], formats: ['webp'], placeholder: true },
+});
+```
+
+The input is content-sniffed (the filename is not trusted), artifact filenames
+are library-owned, and full artifact bytes never cross into a V8 `Buffer`.
+`manifest.json` is deterministic for the same source, policy, and compiler
+identity. The output parent must be trusted and on the same filesystem as the
+staging directory; portable Node.js has no cross-platform no-replace directory
+rename primitive, so another process must not replace that parent concurrently.
+
 ## Utilities
 
 | Method | Description |
@@ -79,6 +105,7 @@ const bytes = await ImageEngine.fromPath('photo.jpg').toFileWithPreset('thumb.we
 | `.dimensions()` | Get `{ width, height }` (requires decode) |
 | `.hasIccProfile()` | Returns ICC profile size in bytes, or null if none |
 | `resolveEncodeProfile(format, profile, quality?)` | Resolve profile into concrete `{ format, quality, fastMode }` options. |
+| `compilerIdentity()` | Return the stable native codec/build identity used by artifact fingerprints. |
 | `createStreamingPipeline({ format, quality, ops, onMetrics? })` | Disk-backed bounded-memory pipeline. Not a true chunk-by-chunk transform stream. Optional `onMetrics` callback receives `ProcessingMetrics` after file output completes. |
 
 ### Upload preflight contract
@@ -240,6 +267,7 @@ interface TargetBytesOptions {
   maxQuality?: number;
   fastMode?: boolean;
   qualityFloorPolicy?: 'best-effort' | 'strict';
+  strict?: boolean;
 }
 
 interface BufferTargetBytesResult {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -73,6 +73,22 @@ On Windows, memory-mapped files **cannot be deleted** while mapped. Keep the `Im
 
 ## Security
 
+### Transactional public-upload compilation
+
+The native-only `compileImage()` API keeps the public artifact set private
+until every plan item, placeholder, hash, dimension, byte budget, and metadata
+invariant has passed. It uses a random sibling staging directory, executes the
+immutable `compileArtifactPlan()` sequentially through `ImageEngine.clone()`,
+writes `manifest.json` last, then renames the directory into place. Existing
+files, directories, and symlinks are never overwritten. Abort or any failure
+before the rename removes the current staging directory; the returned manifest
+is assembled before the rename so no filesystem work follows a successful
+commit.
+
+The output parent is an application-owned trust boundary. Node.js does not
+offer a portable no-replace directory rename, so the application must prevent
+another process from replacing that parent during compilation.
+
 For vulnerability reporting and supported versions, see [SECURITY.md](../SECURITY.md).
 
 ### Rust memory safety

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -382,6 +382,14 @@ An I/O error occurred while writing the output file.
 - Verify write permissions for output directory
 - Ensure output path is valid
 
+`compileImage()` reports the same native `E300`/`E301` codes through an
+`ArtifactCompilationError` with a `phase` (`preflight`, `planning`,
+`processing`, `verification`, `commit`, or `cleanup`) and, when applicable, an
+`artifactId`. A strict target-byte miss remains `E300`; staging, manifest, and
+directory-commit failures remain `E301`. Aborts use the standard `AbortError`
+and never publish a final directory. The public message omits private paths;
+the original native error is available as `cause`.
+
 ---
 
 ### Configuration Errors (E4xx)

--- a/docs/METADATA_SUPPORT.md
+++ b/docs/METADATA_SUPPORT.md
@@ -26,6 +26,11 @@ EXIF (including GPS), XMP, comments, and unknown ancillary metadata out of the
 re-encoded output. Calling `keepMetadata()` before or after cannot weaken this
 policy; `.limits()` may only tighten its fixed resource limits.
 
+`compileImage()` applies the same privacy-safe policy to every delivery
+artifact, records the existing `IccOutcome` value in the manifest, and uses a
+separate strip-all metadata policy for the 16px placeholder. The placeholder
+is the only artifact read into a bounded Node.js buffer (to build its data URL).
+
 ## Feature Matrix
 
 | Metadata type | Default | Opt-in API | Current status |

--- a/docs/THREAD_MODEL.md
+++ b/docs/THREAD_MODEL.md
@@ -34,6 +34,7 @@ lazy-image uses two thread pools:
 | `toBufferWithMetrics()` | libuv | Single image with metrics |
 | `toFile()` | libuv | Single image to file |
 | `processBatch()` | **rayon** | Parallel batch processing |
+| `compileImage()` | libuv + Rust async tasks | Plan-order sequential artifacts; concurrency is fixed at 1 in v1 |
 
 ## Concurrency Control
 
@@ -77,6 +78,11 @@ const results = await engine.processBatch(files, outDir, {
 - `1-1024`: Use specified number of workers (manual control)
 
 ## Memory Considerations
+
+`compileImage()` hashes source and delivery files with bounded streaming reads.
+Each artifact remains file-to-file; only the small placeholder is read into a
+bounded Node.js buffer for its data URL. Target-byte search may perform several
+native encodes, and AVIF can dominate total execution time.
 
 ### Per-Image Memory
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -275,6 +275,9 @@ export interface BatchResultWithMetrics {
   metrics?: ProcessingMetrics
 }
 
+/** Return the stable native codec/build identity used by artifact fingerprints. */
+export declare function compilerIdentity(): string
+
 export interface Dimensions {
   width: number
   height: number
@@ -658,6 +661,93 @@ export declare function compileArtifactPlan(
   compilerFingerprint: string,
 ): ArtifactPlan
 
+export interface CompileImageOptions {
+  readonly inputPath: string
+  readonly outputDir: string
+  readonly policy: PublicUploadPolicy
+  readonly signal?: AbortSignal
+}
+
+export interface ImageArtifactManifest {
+  readonly schemaVersion: 1
+  readonly compiler: {
+    readonly name: '@alberteinshutoin/lazy-image'
+    readonly version: string
+    readonly platform: string
+    readonly arch: string
+    readonly fingerprint: string
+  }
+  readonly policy: {
+    readonly preset: 'publicUpload'
+    readonly fingerprint: string
+    readonly widths: readonly number[]
+    readonly formats: readonly ArtifactFormat[]
+    readonly placeholder: boolean
+  }
+  readonly source: {
+    readonly sha256: string
+    readonly bytes: number
+    readonly detectedFormat: 'jpeg' | 'png' | 'webp'
+    readonly encodedWidth: number
+    readonly encodedHeight: number
+    readonly displayWidth: number
+    readonly displayHeight: number
+    readonly hasAlpha: boolean
+    readonly orientation: number | null
+    readonly orientationApplied: boolean
+  }
+  readonly metadata: {
+    readonly mode: 'privacySafe'
+    readonly exif: 'stripped'
+    readonly gps: 'stripped'
+    readonly xmp: 'stripped'
+    readonly comments: 'stripped'
+    readonly unknownAncillary: 'stripped'
+    readonly artifactIccPolicy: 'preserve-if-safe'
+    readonly placeholderIccPolicy: 'strip'
+  }
+  readonly artifacts: readonly {
+    readonly id: string
+    readonly path: string
+    readonly format: ArtifactFormat
+    readonly width: number
+    readonly height: number
+    readonly bytes: number
+    readonly quality: number
+    readonly targetBytes?: number
+    readonly iccOutcome: IccOutcome
+    readonly sha256: string
+  }[]
+  readonly delivery: {
+    readonly srcsets: readonly { readonly format: ArtifactFormat; readonly value: string }[]
+  }
+  readonly placeholder?: {
+    readonly path: 'placeholder.webp'
+    readonly dataUrl: string
+    readonly format: 'webp'
+    readonly width: number
+    readonly height: number
+    readonly bytes: number
+    readonly iccOutcome: 'stripped-for-placeholder'
+    readonly sha256: string
+  }
+  readonly cacheKey: string
+}
+
+export interface ArtifactCompilationError extends Error {
+  readonly phase: 'preflight' | 'planning' | 'processing' | 'verification' | 'commit' | 'cleanup'
+  readonly artifactId?: string
+  readonly errorCode?: string
+  readonly category?: ErrorCategory
+  readonly errorCategory?: ErrorCategory
+  readonly code?: string
+  readonly recoveryHint?: string
+  readonly cause?: unknown
+  readonly cleanupError?: unknown
+}
+
+export declare function compileImage(options: CompileImageOptions): Promise<ImageArtifactManifest>
+
 export interface ResolvedEncodeProfile {
   format: CanonicalOutputFormat
   quality?: number
@@ -748,6 +838,8 @@ export interface TargetBytesOptions {
   fastMode?: boolean
   /** Behaviour when budget cannot be met: 'best-effort' (default) or 'strict' */
   qualityFloorPolicy?: 'best-effort' | 'strict'
+  /** Fail when the target cannot be met (alias for qualityFloorPolicy: 'strict') */
+  strict?: boolean
 }
 
 export interface BufferTargetBytesResult {

--- a/index.js
+++ b/index.js
@@ -588,6 +588,7 @@ if (!nativeBinding) {
 
 module.exports = nativeBinding
 module.exports.ImageEngine = nativeBinding.ImageEngine
+module.exports.compilerIdentity = nativeBinding.compilerIdentity
 module.exports.ErrorCategory = nativeBinding.ErrorCategory
 module.exports.ErrorCode = nativeBinding.ErrorCode
 module.exports.inspect = nativeBinding.inspect
@@ -601,6 +602,7 @@ module.exports.version = nativeBinding.version
 const { createStreamingPipeline } = require('./streaming/pipeline')
 const helpers = require('./lib/helpers')
 const { compileArtifactPlan } = require('./lib/artifact-policy')
+const { compileImage } = require('./lib/artifact-compiler')
 const _getErrorCategory = helpers.createGetErrorCategory(nativeBinding.ErrorCategory, nativeBinding.ErrorCode)
 const _processBatchChunked = helpers.createProcessBatchChunked(nativeBinding.ImageEngine)
 module.exports.getErrorCategory = _getErrorCategory
@@ -608,6 +610,7 @@ module.exports.processBatchChunked = _processBatchChunked
 module.exports.createStreamingPipeline = createStreamingPipeline
 module.exports.resolveEncodeProfile = helpers.resolveEncodeProfile
 module.exports.compileArtifactPlan = compileArtifactPlan
+module.exports.compileImage = compileImage
 if (nativeBinding && nativeBinding.ImageEngine) {
   helpers.attachPrototypeMethods(nativeBinding.ImageEngine)
 }

--- a/index.mjs
+++ b/index.mjs
@@ -12,11 +12,13 @@ export const {
   supportedInputFormats,
   supportedOutputFormats,
   version,
+  compilerIdentity,
   getErrorCategory,
   processBatchChunked,
   createStreamingPipeline,
   resolveEncodeProfile,
   compileArtifactPlan,
+  compileImage,
 } = mod;
 
 // Default export for convenience

--- a/lib/artifact-compiler.js
+++ b/lib/artifact-compiler.js
@@ -1375,6 +1375,7 @@ async function compileImage(options) {
         throwIfAborted(signal, 'commit');
         await removeStagingMarker(staging, signal);
         markerRemoved = true;
+        throwIfAborted(signal, 'commit');
         await fsp.rename(staging, commitPaths.finalPath);
         committed = true;
       } catch (error) {

--- a/lib/artifact-compiler.js
+++ b/lib/artifact-compiler.js
@@ -1,0 +1,1426 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const fsp = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+const zlib = require('node:zlib');
+
+const { compileArtifactPlan } = require('./artifact-policy');
+
+const MAX_INPUT_BYTES = 32 * 1024 * 1024;
+const MAX_PIXELS = 40_000_000;
+const PLACEHOLDER_MAX_BYTES = 1024 * 1024;
+const MAX_METADATA_BUFFER = 1024 * 1024;
+const MAX_ICC_BYTES = 512 * 1024;
+const STAGING_MARKER = '.lazy-image-staging';
+const PACKAGE_NAME = '@alberteinshutoin/lazy-image';
+const PACKAGE_VERSION = require('../package.json').version;
+const ICC_OUTCOMES = new Set(['absent', 'preserved', 'unsafe-stripped', 'policy-stripped', 'unsupported']);
+
+const ERROR_CATEGORY = {
+  UserError: 0,
+  CodecError: 1,
+  ResourceLimit: 2,
+  InternalBug: 3,
+};
+
+const OPTION_KEYS = new Set(['inputPath', 'outputDir', 'policy', 'signal']);
+
+class ArtifactCompilationError extends Error {
+  constructor(message, details = {}) {
+    super(message);
+    this.name = 'ArtifactCompilationError';
+    this.phase = details.phase;
+    if (details.artifactId !== undefined) this.artifactId = details.artifactId;
+    if (details.errorCode !== undefined) this.errorCode = details.errorCode;
+    if (details.category !== undefined) {
+      this.category = details.category;
+      this.errorCategory = details.category;
+    }
+    if (details.recoveryHint !== undefined) this.recoveryHint = details.recoveryHint;
+    if (details.cause !== undefined) this.cause = details.cause;
+    this.code = details.code || categoryCode(details.category);
+  }
+}
+
+function categoryCode(category) {
+  switch (category) {
+    case ERROR_CATEGORY.UserError: return 'LAZY_IMAGE_USER_ERROR';
+    case ERROR_CATEGORY.CodecError: return 'LAZY_IMAGE_CODEC_ERROR';
+    case ERROR_CATEGORY.ResourceLimit: return 'LAZY_IMAGE_RESOURCE_LIMIT';
+    case ERROR_CATEGORY.InternalBug: return 'LAZY_IMAGE_INTERNAL_BUG';
+    default: return undefined;
+  }
+}
+
+function abortError(phase, cause) {
+  const error = new Error('Image artifact compilation aborted');
+  error.name = 'AbortError';
+  error.code = 'ABORT_ERR';
+  error.phase = phase;
+  if (cause !== undefined) error.cause = cause;
+  return error;
+}
+
+function isAbortError(error) {
+  return Boolean(error && (error.name === 'AbortError' || error.code === 'ABORT_ERR'));
+}
+
+function throwIfAborted(signal, phase) {
+  if (signal && signal.aborted) throw abortError(phase);
+}
+
+function ownData(value, key, name, required = true) {
+  const descriptor = Object.getOwnPropertyDescriptor(value, key);
+  if (!descriptor) {
+    if (required) throw inputError(`${name}.${key} is required`);
+    return undefined;
+  }
+  if (!Object.hasOwn(descriptor, 'value')) {
+    throw inputError(`${name}.${key} must be an own data property`);
+  }
+  return descriptor.value;
+}
+
+function inputError(message) {
+  return structuredError(message, 'E400', ERROR_CATEGORY.UserError, 'Provide inputPath, outputDir, and a valid publicUpload policy.');
+}
+
+function structuredError(message, errorCode, category, recoveryHint, cause) {
+  const error = new Error(message);
+  error.errorCode = errorCode;
+  error.category = category;
+  error.errorCategory = category;
+  error.code = categoryCode(category);
+  error.recoveryHint = recoveryHint;
+  if (cause !== undefined) error.cause = cause;
+  return error;
+}
+
+function validateOptions(options) {
+  if (options === null || typeof options !== 'object' || Array.isArray(options)) {
+    throw inputError('compileImage options must be an object');
+  }
+  const prototype = Object.getPrototypeOf(options);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw inputError('compileImage options must be a plain object');
+  }
+  for (const key of Reflect.ownKeys(options)) {
+    if (typeof key !== 'string' || !OPTION_KEYS.has(key)) {
+      throw inputError(`unknown compileImage option: ${String(key)}`);
+    }
+  }
+
+  const inputPath = ownData(options, 'inputPath', 'options');
+  const outputDir = ownData(options, 'outputDir', 'options');
+  const policy = ownData(options, 'policy', 'options');
+  const signal = ownData(options, 'signal', 'options', false);
+
+  for (const [value, name] of [[inputPath, 'inputPath'], [outputDir, 'outputDir']]) {
+    if (typeof value !== 'string' || value.length === 0 || value.includes('\0')) {
+      throw inputError(`options.${name} must be a non-empty path string`);
+    }
+  }
+  if (policy === null || typeof policy !== 'object' || Array.isArray(policy)) {
+    throw inputError('options.policy must be a publicUpload policy object');
+  }
+  if (signal !== undefined && (signal === null || typeof signal !== 'object' || typeof signal.aborted !== 'boolean'
+    || typeof signal.addEventListener !== 'function' || typeof signal.removeEventListener !== 'function')) {
+    throw inputError('options.signal must be an AbortSignal');
+  }
+  return { inputPath, outputDir, policy, signal };
+}
+
+function wrapError(error, phase, artifactId, fallback = {}) {
+  if (error instanceof ArtifactCompilationError) return error;
+  if (isAbortError(error)) return error;
+  const errorCode = error && error.errorCode !== undefined ? error.errorCode : fallback.errorCode;
+  const category = normalizeCategory(error && error.category !== undefined
+    ? error.category
+    : (error && error.errorCategory !== undefined ? error.errorCategory : fallback.category));
+  const recoveryHint = error && error.recoveryHint ? error.recoveryHint : fallback.recoveryHint;
+  const wrapped = new ArtifactCompilationError(
+    `Image artifact compilation failed during ${phase}${artifactId ? ` (${artifactId})` : ''}`,
+    {
+      phase,
+      artifactId,
+      errorCode,
+      category,
+      recoveryHint,
+      cause: error,
+      code: error && error.code ? error.code : categoryCode(category),
+    },
+  );
+  return wrapped;
+}
+
+function normalizeCategory(category) {
+  if (typeof category === 'number') return category;
+  if (typeof category === 'string' && Object.hasOwn(ERROR_CATEGORY, category)) {
+    return ERROR_CATEGORY[category];
+  }
+  return category;
+}
+
+function statIdentity(stat) {
+  return {
+    dev: stat.dev,
+    ino: stat.ino,
+    size: stat.size,
+    mtimeMs: stat.mtimeMs,
+    ctimeMs: stat.ctimeMs,
+  };
+}
+
+function sameIdentity(left, right) {
+  return left.dev === right.dev
+    && left.ino === right.ino
+    && left.size === right.size
+    && left.mtimeMs === right.mtimeMs
+    && left.ctimeMs === right.ctimeMs;
+}
+
+async function lstatRegular(filePath, fallback) {
+  let stat;
+  try {
+    stat = await fsp.lstat(filePath);
+  } catch (error) {
+    const code = error && error.code === 'ENOENT' ? 'E100' : fallback.errorCode;
+    const category = code === 'E100' ? ERROR_CATEGORY.UserError : fallback.category;
+    throw structuredError(
+      code === 'E100' ? 'Input file was not found' : 'File access failed',
+      code,
+      category,
+      code === 'E100' ? 'Verify the input path and ensure the file exists.' : fallback.recoveryHint,
+      error,
+    );
+  }
+  if (stat.isSymbolicLink()) {
+    throw structuredError('Symbolic-link paths are not accepted', fallback.errorCode, fallback.category, fallback.recoveryHint);
+  }
+  if (!stat.isFile()) {
+    throw structuredError('The path must refer to a regular file', fallback.errorCode, fallback.category, fallback.recoveryHint);
+  }
+  return stat;
+}
+
+async function hashHandle(handle, signal, maxBytes, phase = 'verification') {
+  throwIfAborted(signal, phase);
+  const hash = crypto.createHash('sha256');
+  const buffer = Buffer.allocUnsafe(64 * 1024);
+  let bytes = 0;
+  let position = 0;
+  while (true) {
+    throwIfAborted(signal, phase);
+    const { bytesRead } = await handle.read(buffer, 0, buffer.length, position);
+    if (bytesRead === 0) break;
+    bytes += bytesRead;
+    if (maxBytes !== undefined && bytes > maxBytes) {
+      throw structuredError('Input exceeds the public-upload byte limit', 'E121', ERROR_CATEGORY.ResourceLimit, 'Use an input no larger than 32 MiB.');
+    }
+    hash.update(buffer.subarray(0, bytesRead));
+    position += bytesRead;
+  }
+  return { bytes, sha256: hash.digest('hex') };
+}
+
+async function hashRegularFile(filePath, signal, phase = 'verification') {
+  throwIfAborted(signal, phase);
+  const before = await fsp.lstat(filePath);
+  if (!before.isFile() || before.isSymbolicLink()) throw new Error('file is not a regular file');
+  let handle;
+  try {
+    handle = await fsp.open(filePath, fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW || 0));
+    const opened = await handle.stat();
+    if (!opened.isFile() || !sameIdentity(statIdentity(before), statIdentity(opened))) throw new Error('file changed before hashing');
+    const digest = await hashHandle(handle, signal, undefined, phase);
+    const after = await handle.stat();
+    if (!sameIdentity(statIdentity(before), statIdentity(after))) throw new Error('file changed during hashing');
+    return digest;
+  } finally {
+    if (handle) await handle.close().catch(() => {});
+  }
+}
+
+async function writeHandle(handle, data) {
+  let offset = 0;
+  while (offset < data.length) {
+    const { bytesWritten } = await handle.write(data, offset, data.length - offset);
+    if (bytesWritten === 0) throw new Error('snapshot write made no progress');
+    offset += bytesWritten;
+  }
+}
+
+async function createSourceSnapshot(inputPath, signal) {
+  throwIfAborted(signal, 'preflight');
+  const pathStat = await lstatRegular(inputPath, {
+    errorCode: 'E101',
+    category: ERROR_CATEGORY.ResourceLimit,
+    recoveryHint: 'Verify input permissions and availability.',
+  });
+  if (pathStat.size > MAX_INPUT_BYTES) {
+    throw structuredError('Input exceeds the public-upload byte limit', 'E121', ERROR_CATEGORY.ResourceLimit, 'Use an input no larger than 32 MiB.');
+  }
+
+  let sourceHandle;
+  let snapshotDir;
+  let snapshotHandle;
+  try {
+    const flags = fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW || 0);
+    sourceHandle = await fsp.open(inputPath, flags);
+    const openedStat = await sourceHandle.stat();
+    if (!openedStat.isFile() || !sameIdentity(statIdentity(pathStat), statIdentity(openedStat))) {
+      throw structuredError('Input changed while it was being opened', 'E101', ERROR_CATEGORY.ResourceLimit, 'Keep the input unchanged and retry.');
+    }
+
+    snapshotDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'lazy-image-source-'));
+    await fsp.chmod(snapshotDir, 0o700);
+    const snapshotPath = path.join(snapshotDir, 'source.bin');
+    snapshotHandle = await fsp.open(snapshotPath, 'wx', 0o600);
+    const hash = crypto.createHash('sha256');
+    const buffer = Buffer.allocUnsafe(64 * 1024);
+    let bytes = 0;
+    let position = 0;
+    while (true) {
+      throwIfAborted(signal, 'preflight');
+      const { bytesRead } = await sourceHandle.read(buffer, 0, buffer.length, position);
+      if (bytesRead === 0) break;
+      bytes += bytesRead;
+      if (bytes > MAX_INPUT_BYTES) {
+        throw structuredError('Input exceeds the public-upload byte limit', 'E121', ERROR_CATEGORY.ResourceLimit, 'Use an input no larger than 32 MiB.');
+      }
+      const chunk = buffer.subarray(0, bytesRead);
+      hash.update(chunk);
+      await writeHandle(snapshotHandle, chunk);
+      position += bytesRead;
+    }
+    const finalSourceStat = await sourceHandle.stat();
+    if (!sameIdentity(statIdentity(pathStat), statIdentity(finalSourceStat))) {
+      throw structuredError('Input changed while it was being snapshotted', 'E101', ERROR_CATEGORY.ResourceLimit, 'Keep the input unchanged and retry.');
+    }
+    await snapshotHandle.close();
+    snapshotHandle = undefined;
+    return {
+      path: snapshotPath,
+      dir: snapshotDir,
+      handle: sourceHandle,
+      identity: statIdentity(pathStat),
+      bytes,
+      sha256: hash.digest('hex'),
+    };
+  } catch (error) {
+    if (snapshotHandle) await snapshotHandle.close().catch(() => {});
+    if (sourceHandle) await sourceHandle.close().catch(() => {});
+    if (snapshotDir) await fsp.rm(snapshotDir, { recursive: true, force: true }).catch(() => {});
+    if (signal && signal.aborted) throw abortError('preflight', error);
+    if (error && error.errorCode) throw error;
+    throw structuredError('Input snapshot could not be created', 'E101', ERROR_CATEGORY.ResourceLimit, 'Verify input permissions and availability.', error);
+  }
+}
+
+async function cleanupSourceSnapshot(snapshot) {
+  if (!snapshot) return;
+  let cleanupError;
+  if (snapshot.handle) {
+    try {
+      await snapshot.handle.close();
+    } catch (error) {
+      cleanupError = error;
+    }
+  }
+  try {
+    await fsp.rm(snapshot.dir, { recursive: true, force: true });
+  } catch (error) {
+    cleanupError = cleanupError || error;
+  }
+  if (cleanupError) {
+    throw structuredError('Private input snapshot could not be removed', 'E301', ERROR_CATEGORY.ResourceLimit, 'Verify temporary-directory permissions and retry.', cleanupError);
+  }
+}
+
+function normalizeInputFormat(format) {
+  if (format === 'jpg') return 'jpeg';
+  if (format === 'jpeg' || format === 'png' || format === 'webp') return format;
+  throw structuredError('Input format is unsupported or could not be determined', 'E111', ERROR_CATEGORY.CodecError, 'Use a static JPEG, PNG, or WebP image.');
+}
+
+function sourceFacts(metadata, digest) {
+  if (!metadata || typeof metadata !== 'object') {
+    throw structuredError('Input metadata could not be determined', 'E130', ERROR_CATEGORY.CodecError, 'Provide a decodable static image.');
+  }
+  if (!Number.isInteger(metadata.width) || !Number.isInteger(metadata.height)
+    || metadata.width < 1 || metadata.height < 1
+    || typeof metadata.hasAlpha !== 'boolean'
+    || typeof metadata.isAnimated !== 'boolean') {
+    throw structuredError('Input metadata is incomplete', 'E130', ERROR_CATEGORY.CodecError, 'Provide a decodable static image.');
+  }
+  const orientation = metadata.orientation === undefined ? null : metadata.orientation;
+  if (orientation !== null && (!Number.isInteger(orientation) || orientation < 1 || orientation > 8)) {
+    throw structuredError('Input orientation is invalid', 'E130', ERROR_CATEGORY.CodecError, 'Provide a decodable image with valid orientation metadata.');
+  }
+  return {
+    sha256: digest.sha256,
+    bytes: digest.bytes,
+    format: normalizeInputFormat(metadata.format),
+    width: metadata.width,
+    height: metadata.height,
+    hasAlpha: metadata.hasAlpha,
+    isAnimated: metadata.isAnimated,
+    orientationKnown: true,
+    orientation,
+  };
+}
+
+function compilerFingerprint(nativeVersion, nativeIdentity = {}) {
+  const identity = {
+    schemaVersion: 1,
+    package: PACKAGE_NAME,
+    packageVersion: PACKAGE_VERSION,
+    nativeVersion,
+    nativeIdentity,
+    platform: process.platform,
+    arch: process.arch,
+  };
+  return crypto.createHash('sha256').update(JSON.stringify(identity)).digest('hex');
+}
+
+async function resolveCommitPaths(outputDir) {
+  let resolved;
+  try {
+    resolved = path.resolve(outputDir);
+  } catch (error) {
+    throw structuredError('Output directory path is invalid', 'E400', ERROR_CATEGORY.UserError, 'Provide a valid output directory path.', error);
+  }
+  const name = path.basename(resolved);
+  if (!name || name === '.' || name === path.sep) {
+    throw structuredError('Output directory must name a child directory', 'E400', ERROR_CATEGORY.UserError, 'Provide a versioned output directory path.');
+  }
+
+  let parent;
+  try {
+    parent = await fsp.realpath(path.dirname(resolved));
+  } catch (error) {
+    throw structuredError('Output parent directory is unavailable', 'E301', ERROR_CATEGORY.ResourceLimit, 'Create a trusted output parent and retry.', error);
+  }
+  const finalPath = path.join(parent, name);
+  await ensureFinalAbsent(finalPath);
+  return { parent, finalPath, name };
+}
+
+async function ensureFinalAbsent(finalPath) {
+  try {
+    await fsp.lstat(finalPath);
+  } catch (error) {
+    if (error && error.code === 'ENOENT') return;
+    throw structuredError('Output path could not be checked', 'E301', ERROR_CATEGORY.ResourceLimit, 'Use an available output directory and retry.', error);
+  }
+  throw structuredError('Output directory already exists', 'E301', ERROR_CATEGORY.ResourceLimit, 'Publish to a new output directory; overwrite is not supported.');
+}
+
+function stagingPath(staging, relativePath) {
+  if (typeof relativePath !== 'string' || relativePath.length === 0
+    || path.posix.isAbsolute(relativePath)
+    || relativePath.includes('\\')
+    || path.posix.normalize(relativePath) !== relativePath) {
+    throw structuredError('Compiler produced an unsafe relative output path', 'E900', ERROR_CATEGORY.InternalBug, 'Report the compiler path invariant failure.');
+  }
+  const resolved = path.resolve(staging, relativePath);
+  const relative = path.relative(staging, resolved);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw structuredError('Compiler produced an output path outside staging', 'E900', ERROR_CATEGORY.InternalBug, 'Report the compiler path invariant failure.');
+  }
+  return resolved;
+}
+
+async function createStaging(parent, name) {
+  const staging = await fsp.mkdtemp(path.join(parent, `.${name}.lazy-image-staging-`));
+  try {
+    await fsp.chmod(staging, 0o700);
+    await fsp.writeFile(path.join(staging, STAGING_MARKER), 'lazy-image staging v1\n', { flag: 'wx', mode: 0o600 });
+  } catch (error) {
+    await fsp.rm(staging, { recursive: true, force: true }).catch(() => {});
+    throw structuredError('Private staging directory could not be prepared', 'E301', ERROR_CATEGORY.ResourceLimit, 'Verify output directory permissions and retry.', error);
+  }
+  return staging;
+}
+
+async function verifyStagingAllowlist(staging, plan) {
+  const expected = new Set([STAGING_MARKER, 'manifest.json']);
+  for (const artifact of plan.artifacts) expected.add(artifact.path);
+  if (plan.placeholder) expected.add(plan.placeholder.path);
+  let entries;
+  try {
+    entries = await fsp.readdir(staging);
+  } catch (error) {
+    throw structuredError('Private staging contents could not be listed', 'E900', ERROR_CATEGORY.InternalBug, 'Report the staging verification failure.', error);
+  }
+  if (entries.length !== expected.size || entries.some((entry) => !expected.has(entry))) {
+    throw structuredError('Private staging contains unexpected files', 'E900', ERROR_CATEGORY.InternalBug, 'Report the staging verification failure.');
+  }
+  for (const entry of entries) {
+    const entryPath = stagingPath(staging, entry);
+    const stat = await fsp.lstat(entryPath);
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+      throw structuredError('Private staging contains a non-regular file', 'E900', ERROR_CATEGORY.InternalBug, 'Report the staging verification failure.');
+    }
+  }
+  const marker = await fsp.readFile(stagingPath(staging, STAGING_MARKER), 'utf8');
+  if (marker !== 'lazy-image staging v1\n') {
+    throw structuredError('Private staging marker is invalid', 'E900', ERROR_CATEGORY.InternalBug, 'Report the staging verification failure.');
+  }
+}
+
+async function cleanupStaging(staging, plan, markerRemoved = false) {
+  const stat = await fsp.lstat(staging);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error('staging path is no longer the owned directory');
+  }
+  const entries = await fsp.readdir(staging);
+  if (entries.includes(STAGING_MARKER)) {
+    const markerStat = await fsp.lstat(stagingPath(staging, STAGING_MARKER));
+    if (!markerStat.isFile() || markerStat.isSymbolicLink()) throw new Error('staging marker is not a regular file');
+    const marker = await fsp.readFile(stagingPath(staging, STAGING_MARKER), 'utf8');
+    if (marker !== 'lazy-image staging v1\n') throw new Error('staging marker is invalid');
+  } else if (!markerRemoved) {
+    throw new Error('staging marker is missing');
+  }
+  const allowed = new Set([STAGING_MARKER, 'manifest.json']);
+  if (plan) {
+    for (const artifact of plan.artifacts) allowed.add(artifact.path);
+    if (plan.placeholder) allowed.add(plan.placeholder.path);
+  }
+  for (const entry of entries) {
+    if (!allowed.has(entry) && !/^\.manifest-[0-9a-f-]+\.tmp$/.test(entry)) {
+      throw new Error('staging contains an unexpected entry');
+    }
+    const entryStat = await fsp.lstat(stagingPath(staging, entry));
+    if (!entryStat.isFile() || entryStat.isSymbolicLink()) throw new Error('staging contains a non-regular entry');
+  }
+  await fsp.rm(staging, { recursive: true, force: true });
+}
+
+async function removeStagingMarker(staging, signal) {
+  const markerPath = stagingPath(staging, STAGING_MARKER);
+  const markerStat = await fsp.lstat(markerPath);
+  if (!markerStat.isFile() || markerStat.isSymbolicLink()) throw new Error('staging marker is not a regular file');
+  const marker = await fsp.readFile(markerPath, 'utf8');
+  if (marker !== 'lazy-image staging v1\n') throw new Error('staging marker is invalid');
+  throwIfAborted(signal, 'commit');
+  await fsp.unlink(markerPath);
+}
+
+function outputFormat(format) {
+  return format === 'jpg' ? 'jpeg' : format;
+}
+
+function privacyFailure() {
+  return structuredError('Output metadata privacy invariant failed', 'E900', ERROR_CATEGORY.InternalBug, 'Report the output metadata verification failure.');
+}
+
+class ContainerReader {
+  constructor(handle, size, signal, phase) {
+    this.handle = handle;
+    this.size = size;
+    this.signal = signal;
+    this.phase = phase;
+    this.position = 0;
+    this.scratch = Buffer.allocUnsafe(64 * 1024);
+  }
+
+  async read(length) {
+    if (!Number.isSafeInteger(length) || length < 0 || length > MAX_METADATA_BUFFER) {
+      throw new Error('metadata field exceeds the bounded parser buffer');
+    }
+    const output = Buffer.allocUnsafe(length);
+    let offset = 0;
+    while (offset < length) {
+      throwIfAborted(this.signal, this.phase);
+      const { bytesRead } = await this.handle.read(output, offset, length - offset, this.position);
+      if (bytesRead === 0) throw new Error('unexpected end of image container');
+      offset += bytesRead;
+      this.position += bytesRead;
+    }
+    return output;
+  }
+
+  async skip(length) {
+    if (!Number.isSafeInteger(length) || length < 0 || this.position + length > this.size) {
+      throw new Error('image container length is invalid');
+    }
+    let remaining = length;
+    while (remaining > 0) {
+      throwIfAborted(this.signal, this.phase);
+      const amount = Math.min(remaining, this.scratch.length);
+      const { bytesRead } = await this.handle.read(this.scratch, 0, amount, this.position);
+      if (bytesRead === 0) throw new Error('unexpected end of image container');
+      remaining -= bytesRead;
+      this.position += bytesRead;
+    }
+  }
+
+  async byte() {
+    return (await this.read(1))[0];
+  }
+
+  async u16be() {
+    return (await this.read(2)).readUInt16BE(0);
+  }
+
+  async u32be() {
+    return (await this.read(4)).readUInt32BE(0);
+  }
+
+  async u32le() {
+    return (await this.read(4)).readUInt32LE(0);
+  }
+}
+
+async function readContainer(filePath, signal, phase, parser) {
+  throwIfAborted(signal, phase);
+  let before;
+  try {
+    before = await fsp.lstat(filePath);
+  } catch (error) {
+    throw structuredError('File could not be read for verification', 'E900', ERROR_CATEGORY.InternalBug, 'Report the output verification failure.', error);
+  }
+  if (!before.isFile() || before.isSymbolicLink()) {
+    throw structuredError('File is not a regular file for verification', 'E900', ERROR_CATEGORY.InternalBug, 'Report the output verification failure.');
+  }
+  let handle;
+  try {
+    handle = await fsp.open(filePath, fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW || 0));
+    const opened = await handle.stat();
+    if (!opened.isFile() || !sameIdentity(statIdentity(before), statIdentity(opened))) {
+      throw structuredError('File changed before verification', 'E900', ERROR_CATEGORY.InternalBug, 'Report the output verification failure.');
+    }
+    const result = await parser(new ContainerReader(handle, before.size, signal, phase), before.size);
+    if (!result || result.complete !== true) {
+      throw structuredError('Image container could not be completely verified', 'E900', ERROR_CATEGORY.InternalBug, 'Report the output verification failure.');
+    }
+    const after = await handle.stat();
+    if (!sameIdentity(statIdentity(before), statIdentity(after))) {
+      throw structuredError('File changed during verification', 'E900', ERROR_CATEGORY.InternalBug, 'Report the output verification failure.');
+    }
+    return result;
+  } catch (error) {
+    if (signal && signal.aborted) throw abortError(phase, error);
+    if (error && error.errorCode) throw error;
+    throw structuredError('Image container could not be verified', 'E900', ERROR_CATEGORY.InternalBug, 'Report the output verification failure.', error);
+  } finally {
+    if (handle) await handle.close().catch(() => {});
+  }
+}
+
+const JPEG_ICC_PREFIX = Buffer.from('ICC_PROFILE\0');
+const EXIF_PREFIX = Buffer.from('Exif\0\0');
+const JFIF_CANONICAL = Buffer.from('4a46494600010100000100010000', 'hex');
+
+function canonicalJfifPayload(payload) {
+  return payload.equals(JFIF_CANONICAL);
+}
+
+function printableIccField(field) {
+  return [...field].every((byte) => byte === 0 || (byte >= 32 && byte <= 126));
+}
+
+function validIccProfile(profile) {
+  if (!Buffer.isBuffer(profile) || profile.length < 132 || profile.length % 4 !== 0) return false;
+  if (profile.readUInt32BE(0) !== profile.length) return false;
+  if (!printableIccField(profile.subarray(4, 8))) return false;
+  if (!['mntr', 'scnr', 'prtr'].includes(profile.toString('ascii', 12, 16))) return false;
+  if (!['RGB ', 'GRAY'].includes(profile.toString('ascii', 16, 20))) return false;
+  if (!['XYZ ', 'Lab '].includes(profile.toString('ascii', 20, 24))) return false;
+  if (profile.toString('ascii', 36, 40) !== 'acsp') return false;
+  if (profile.subarray(100, 128).some((byte) => byte !== 0)) return false;
+  if (![2, 4, 5].includes(profile[8])) return false;
+
+  const tagCount = profile.readUInt32BE(128);
+  if (tagCount > 4096) return false;
+  const tableEnd = 132 + tagCount * 12;
+  if (tableEnd > profile.length) return false;
+  const signatures = new Set();
+  const ranges = [];
+  for (let offset = 132; offset < tableEnd; offset += 12) {
+    const signature = profile.subarray(offset, offset + 4).toString('ascii');
+    if (!printableIccField(profile.subarray(offset, offset + 4)) || signatures.has(signature)) return false;
+    signatures.add(signature);
+    const dataOffset = profile.readUInt32BE(offset + 4);
+    const dataSize = profile.readUInt32BE(offset + 8);
+    const dataEnd = dataOffset + dataSize;
+    if (dataOffset < tableEnd || dataOffset % 4 !== 0 || dataSize < 8 || dataEnd > profile.length) return false;
+    if (profile.subarray(dataOffset + 4, dataOffset + 8).some((byte) => byte !== 0)) return false;
+    ranges.push([dataOffset, dataEnd]);
+  }
+  ranges.sort((left, right) => left[0] - right[0]);
+  for (let index = 1; index < ranges.length; index += 1) {
+    const previous = ranges[index - 1];
+    const current = ranges[index];
+    const sharedRange = previous[0] === current[0] && previous[1] === current[1];
+    if (!sharedRange && previous[1] > current[0]) return false;
+  }
+  return true;
+}
+
+function recordIccProfile(state, profile, rejectPrivacy) {
+  if (!Buffer.isBuffer(profile) || profile.length > MAX_ICC_BYTES || !validIccProfile(profile)) {
+    if (rejectPrivacy) throw privacyFailure();
+    state.iccOutcome = 'unsupported';
+    return;
+  }
+  if (state.iccOutcome === 'preserved') {
+    if (rejectPrivacy) throw privacyFailure();
+    state.iccOutcome = 'unsupported';
+    return;
+  }
+  state.iccOutcome = 'preserved';
+}
+
+function finalizeJpegIcc(state, rejectPrivacy) {
+  const partCount = state.iccParts.reduce((count, part) => count + (part ? 1 : 0), 0);
+  if (partCount === 0) return state.iccOutcome || 'absent';
+  if (state.iccCount === null || partCount !== state.iccCount) {
+    if (rejectPrivacy) throw privacyFailure();
+    state.iccOutcome = 'unsupported';
+    return state.iccOutcome;
+  }
+  const ordered = [];
+  for (let sequence = 1; sequence <= state.iccCount; sequence += 1) {
+    const part = state.iccParts[sequence];
+    if (!part) {
+      if (rejectPrivacy) throw privacyFailure();
+      state.iccOutcome = 'unsupported';
+      return state.iccOutcome;
+    }
+    ordered.push(part);
+  }
+  const profile = Buffer.concat(ordered);
+  recordIccProfile(state, profile, rejectPrivacy);
+  return state.iccOutcome;
+}
+
+async function readJpegMarker(reader) {
+  if (reader.position >= reader.size || await reader.byte() !== 0xff) return null;
+  let marker = await reader.byte();
+  while (marker === 0xff) {
+    if (reader.position >= reader.size) return null;
+    marker = await reader.byte();
+  }
+  return marker;
+}
+
+// JPEG entropy data uses FF00 stuffing and restart markers; return the next
+// real marker after consuming the complete scan, without buffering the image.
+async function consumeJpegScan(reader) {
+  while (reader.position < reader.size) {
+    if (await reader.byte() !== 0xff) continue;
+    if (reader.position >= reader.size) return null;
+    let marker = await reader.byte();
+    while (marker === 0xff) {
+      if (reader.position >= reader.size) return null;
+      marker = await reader.byte();
+    }
+    if (marker === 0x00 || (marker >= 0xd0 && marker <= 0xd7)) continue;
+    return marker;
+  }
+  return null;
+}
+
+async function parseJpegContainer(reader, rejectPrivacy) {
+  const soi = await reader.read(2);
+  if (soi[0] !== 0xff || soi[1] !== 0xd8) return { complete: false };
+  let hasExif = false;
+  const state = { iccParts: [], iccCount: null, iccOutcome: 'absent' };
+  let pendingMarker;
+  while (reader.position < reader.size || pendingMarker !== undefined) {
+    const marker = pendingMarker === undefined ? await readJpegMarker(reader) : pendingMarker;
+    pendingMarker = undefined;
+    if (marker === null) return { complete: false };
+    if (marker === 0xd9) {
+      if (reader.position !== reader.size) return { complete: false };
+      return { complete: true, hasExif, iccOutcome: finalizeJpegIcc(state, rejectPrivacy) };
+    }
+    if (marker === 0xda) {
+      if (reader.position + 2 > reader.size) return { complete: false };
+      const scanLength = await reader.u16be();
+      if (scanLength < 2 || scanLength - 2 > reader.size - reader.position) return { complete: false };
+      await reader.skip(scanLength - 2);
+      const nextMarker = await consumeJpegScan(reader);
+      if (nextMarker === null) return { complete: false };
+      pendingMarker = nextMarker;
+      continue;
+    }
+    if (marker === 0x01 || (marker >= 0xd0 && marker <= 0xd7)) continue;
+    if (marker === 0xd8) return { complete: false };
+    if (reader.position + 2 > reader.size) return { complete: false };
+    const length = await reader.u16be();
+    if (length < 2 || length - 2 > reader.size - reader.position) return { complete: false };
+    const payloadLength = length - 2;
+    if (marker === 0xfe || (marker >= 0xe0 && marker <= 0xef)) {
+      const payload = await reader.read(payloadLength);
+      const isExif = marker === 0xe1 && payload.subarray(0, EXIF_PREFIX.length).equals(EXIF_PREFIX);
+      const isIcc = marker === 0xe2 && payload.subarray(0, JPEG_ICC_PREFIX.length).equals(JPEG_ICC_PREFIX);
+      const isJfif = marker === 0xe0 && canonicalJfifPayload(payload);
+      hasExif ||= isExif;
+      if (isIcc) {
+        if (payload.length < 14) {
+          if (rejectPrivacy) throw privacyFailure();
+          state.iccOutcome = 'unsupported';
+        } else {
+          const sequence = payload[12];
+          const count = payload[13];
+          if (sequence === 0 || count === 0 || sequence > count || (state.iccCount !== null && state.iccCount !== count)
+            || state.iccParts[sequence]) {
+            if (rejectPrivacy) throw privacyFailure();
+            state.iccOutcome = 'unsupported';
+          } else {
+            state.iccCount = count;
+            state.iccParts[sequence] = payload.subarray(14);
+            if (state.iccParts.reduce((total, part) => total + (part ? part.length : 0), 0) > MAX_ICC_BYTES) {
+              throw privacyFailure();
+            }
+          }
+        }
+      }
+      if (rejectPrivacy && (marker === 0xfe || (marker >= 0xe0 && marker <= 0xef
+        && !isIcc && !isJfif))) {
+        throw privacyFailure();
+      }
+    } else {
+      await reader.skip(payloadLength);
+    }
+  }
+  return { complete: false };
+}
+
+const PNG_SIGNATURE = Buffer.from('\x89PNG\r\n\x1a\n', 'binary');
+const PNG_ALLOWED = new Set(['IHDR', 'PLTE', 'IDAT', 'IEND', 'iCCP', 'sRGB', 'gAMA', 'cHRM', 'tRNS']);
+
+async function parsePngContainer(reader, rejectPrivacy) {
+  if (!(await reader.read(8)).equals(PNG_SIGNATURE)) return { complete: false };
+  let hasExif = false;
+  const state = { iccOutcome: 'absent' };
+  while (reader.position < reader.size) {
+    const length = await reader.u32be();
+    const type = (await reader.read(4)).toString('ascii');
+    if (length > reader.size - reader.position - 4) return { complete: false };
+    if (type === 'eXIf') hasExif = true;
+    if (rejectPrivacy && !PNG_ALLOWED.has(type)) throw privacyFailure();
+    if (type === 'iCCP') {
+      if (length > MAX_ICC_BYTES + MAX_METADATA_BUFFER) throw privacyFailure();
+      const payload = await reader.read(length);
+      const nameEnd = payload.indexOf(0);
+      if (nameEnd < 0 || nameEnd + 2 > payload.length || payload[nameEnd + 1] !== 0) {
+        if (rejectPrivacy) throw privacyFailure();
+        state.iccOutcome = 'unsupported';
+      } else {
+        try {
+          const profile = zlib.inflateSync(payload.subarray(nameEnd + 2), { maxOutputLength: MAX_ICC_BYTES });
+          recordIccProfile(state, profile, rejectPrivacy);
+        } catch (error) {
+          if (rejectPrivacy) throw privacyFailure();
+          state.iccOutcome = 'unsupported';
+        }
+      }
+    } else {
+      await reader.skip(length);
+    }
+    await reader.skip(4);
+    if (type === 'IEND') {
+      if (length !== 0) return { complete: false };
+      return { complete: reader.position === reader.size, hasExif, iccOutcome: state.iccOutcome };
+    }
+  }
+  return { complete: false };
+}
+
+async function parseWebpContainer(reader, rejectPrivacy) {
+  if ((await reader.read(4)).toString('ascii') !== 'RIFF') return { complete: false };
+  const riffSize = await reader.u32le();
+  if ((await reader.read(4)).toString('ascii') !== 'WEBP' || riffSize + 8 !== reader.size) return { complete: false };
+  const allowed = new Set(['VP8 ', 'VP8L', 'VP8X', 'ALPH', 'ICCP']);
+  let hasExif = false;
+  const state = { iccOutcome: 'absent' };
+  while (reader.position < reader.size) {
+    const type = (await reader.read(4)).toString('ascii');
+    const length = await reader.u32le();
+    if (length > reader.size - reader.position) return { complete: false };
+    if (type === 'EXIF') hasExif = true;
+    if (rejectPrivacy && (!allowed.has(type) || type === 'EXIF' || type === 'XMP ')) {
+      throw privacyFailure();
+    }
+    if (type === 'VP8X' && length > 0) {
+      const flags = await reader.byte();
+      if ((flags & 0x02) !== 0) throw privacyFailure();
+      await reader.skip(length - 1);
+    } else if (type === 'ICCP') {
+      if (length > MAX_ICC_BYTES) throw privacyFailure();
+      const profile = await reader.read(length);
+      recordIccProfile(state, profile, rejectPrivacy);
+    } else {
+      await reader.skip(length);
+    }
+    if ((length & 1) !== 0) await reader.skip(1);
+  }
+  return { complete: reader.position === reader.size, hasExif, iccOutcome: state.iccOutcome };
+}
+
+const AVIF_ALLOWED = {
+  top: new Set(['ftyp', 'meta', 'mdat']),
+  meta: new Set(['hdlr', 'pitm', 'iloc', 'iinf', 'iprp']),
+  iinf: new Set(['infe']),
+  iprp: new Set(['ipco', 'ipma']),
+  ipco: new Set(['ispe', 'pixi', 'av1C', 'colr']),
+};
+const AVIF_FORBIDDEN = new Set(['Exif', 'xml ', 'XMP ', 'mime', 'uuid']);
+const AVIF_ITEM_FORBIDDEN = [Buffer.from('Exif'), Buffer.from('mime'), Buffer.from('xml '), Buffer.from('XMP ')];
+const AVIF_FTYP_PAYLOAD = Buffer.from('6176696600000000617669666d6966316d6961664d413142', 'hex');
+const AVIF_HANDLER = Buffer.from('0000000000000000706963740000000000000000000000006c69626176696600', 'hex');
+const AVIF_ITEM = Buffer.from('020000000001000061763031436f6c6f7200', 'hex');
+const AVIF_IPMA_BASE_ASSOCIATIONS = Buffer.from([1, 2, 0x83, 4]);
+
+async function readAvifBox(reader, fileSize) {
+  const start = reader.position;
+  if (start + 8 > fileSize) return null;
+  const size32 = await reader.u32be();
+  const type = (await reader.read(4)).toString('ascii');
+  let headerSize = 8;
+  let boxSize = size32;
+  if (size32 === 1) {
+    const high = await reader.u32be();
+    const low = await reader.u32be();
+    if (high !== 0) return null;
+    boxSize = low;
+    headerSize = 16;
+  } else if (size32 === 0) {
+    boxSize = fileSize - start;
+  }
+  if (boxSize < headerSize || boxSize > fileSize - start) return null;
+  return { start, type, headerSize, size: boxSize, end: start + boxSize, payload: boxSize - headerSize };
+}
+
+async function parseAvifBoxesStream(reader, fileSize, end, state, rejectPrivacy, context = 'top', depth = 0) {
+  if (depth > 12) return false;
+  while (reader.position < end) {
+    const box = await readAvifBox(reader, fileSize);
+    if (!box || box.end > end) return false;
+    if (!AVIF_ALLOWED[context] || !AVIF_ALLOWED[context].has(box.type) || AVIF_FORBIDDEN.has(box.type)) {
+      throw privacyFailure();
+    }
+    if (box.type === 'ftyp') {
+      if (box.payload !== AVIF_FTYP_PAYLOAD.length) throw privacyFailure();
+      const data = await reader.read(box.payload);
+      if (!data.equals(AVIF_FTYP_PAYLOAD)) throw privacyFailure();
+      state.ftyp = true;
+    } else if (box.type === 'hdlr') {
+      const data = await reader.read(box.payload);
+      if (!data.equals(AVIF_HANDLER)) throw privacyFailure();
+    } else if (box.type === 'pitm') {
+      const data = await reader.read(box.payload);
+      if (data.length !== 6 || data.readUInt32BE(0) !== 0 || data.readUInt16BE(4) !== 1) throw privacyFailure();
+    } else if (box.type === 'iloc') {
+      const data = await reader.read(box.payload);
+      if (data.length !== 22 || data.readUInt32BE(0) !== 0 || data[4] !== 0x44 || data[5] !== 0
+        || data.readUInt16BE(6) !== 1 || data.readUInt16BE(8) !== 1 || data.readUInt16BE(10) !== 0
+        || data.readUInt16BE(12) !== 1) throw privacyFailure();
+      state.extent = { offset: data.readUInt32BE(14), length: data.readUInt32BE(18) };
+      if (state.extent.offset < 1 || state.extent.length < 1) throw privacyFailure();
+    } else if (box.type === 'ispe') {
+      if (box.payload !== 12) return false;
+      const data = await reader.read(12);
+      if (data.readUInt32BE(0) !== 0) throw privacyFailure();
+      state.width = data.readUInt32BE(4);
+      state.height = data.readUInt32BE(8);
+    } else if (box.type === 'pixi') {
+      const data = await reader.read(box.payload);
+      if (data.length !== 8 || data.readUInt32BE(0) !== 0 || data[4] !== 3 || data[5] !== 8
+        || data[6] !== 8 || data[7] !== 8) throw privacyFailure();
+    } else if (box.type === 'av1C') {
+      const data = await reader.read(box.payload);
+      if (!data.equals(Buffer.from([0x81, 0x1f, 0x0c, 0x00]))) throw privacyFailure();
+    } else if (box.type === 'colr') {
+      if (box.payload < 4) return false;
+      const colourType = (await reader.read(4)).toString('ascii');
+      if (colourType === 'prof') {
+        if (box.payload - 4 > MAX_ICC_BYTES) throw privacyFailure();
+        recordIccProfile(state, await reader.read(box.payload - 4), rejectPrivacy);
+      } else if (colourType === 'nclx') {
+        const data = await reader.read(box.payload - 4);
+        if (!data.equals(Buffer.from([0x00, 0x01, 0x00, 0x0d, 0x00, 0x01, 0x80]))) throw privacyFailure();
+      } else {
+        throw privacyFailure();
+      }
+    } else if (box.type === 'infe') {
+      const data = await reader.read(box.payload);
+      if (!data.equals(AVIF_ITEM) || AVIF_ITEM_FORBIDDEN.some((marker) => data.includes(marker))) throw privacyFailure();
+    } else if (box.type === 'ipma') {
+      const data = await reader.read(box.payload);
+      const associations = state.iccOutcome === 'preserved'
+        ? Buffer.concat([AVIF_IPMA_BASE_ASSOCIATIONS, Buffer.from([5])])
+        : AVIF_IPMA_BASE_ASSOCIATIONS;
+      if (data.length !== 11 + associations.length || data.readUInt32BE(0) !== 0 || data.readUInt32BE(4) !== 1
+        || data.readUInt16BE(8) !== 1 || data[10] !== associations.length
+        || !data.subarray(11).equals(associations)) throw privacyFailure();
+    } else if (box.type === 'mdat') {
+      if (state.mdat) throw privacyFailure();
+      state.mdat = { offset: reader.position, length: box.payload };
+      await reader.skip(box.payload);
+    } else if (box.type === 'meta' || box.type === 'iinf' || box.type === 'iprp' || box.type === 'ipco') {
+      if (box.type === 'meta') {
+        const fullbox = await reader.read(Math.min(4, box.payload));
+        if (fullbox.length !== 4 || fullbox.readUInt32BE(0) !== 0) return false;
+      } else if (box.type === 'iinf') {
+        if (box.payload < 6) return false;
+        const fullbox = await reader.read(4);
+        if (fullbox.readUInt32BE(0) !== 0 || (await reader.u16be()) !== 1) return false;
+      }
+      const childContext = box.type;
+      if (!await parseAvifBoxesStream(reader, fileSize, box.end, state, rejectPrivacy, childContext, depth + 1)) return false;
+    }
+    if (reader.position !== box.end) return false;
+  }
+  return reader.position === end;
+}
+
+async function parseAvifContainer(reader, rejectPrivacy) {
+  const state = { iccOutcome: 'absent' };
+  const complete = await parseAvifBoxesStream(reader, reader.size, reader.size, state, rejectPrivacy);
+  const extentMatchesData = state.extent && state.mdat
+    && state.extent.offset === state.mdat.offset
+    && state.extent.length === state.mdat.length;
+  return { complete: complete && Boolean(state.ftyp && extentMatchesData), ...state, isAnimated: false };
+}
+
+async function inspectAvifFile(filePath, signal) {
+  const result = await readContainer(filePath, signal, 'verification', (reader) => parseAvifContainer(reader, true));
+  if (!result.ftyp || !Number.isInteger(result.width) || !Number.isInteger(result.height)
+    || result.width < 1 || result.height < 1) {
+    throw structuredError('AVIF output could not be structurally verified', 'E900', ERROR_CATEGORY.InternalBug, 'Report the output verification failure.');
+  }
+  return { format: 'avif', width: result.width, height: result.height, isAnimated: result.isAnimated, iccOutcome: result.iccOutcome };
+}
+
+async function verifyPrivacy(filePath, format, signal) {
+  const result = await readContainer(filePath, signal, 'verification', (reader) => {
+    if (format === 'jpeg') return parseJpegContainer(reader, true);
+    if (format === 'png') return parsePngContainer(reader, true);
+    if (format === 'webp') return parseWebpContainer(reader, true);
+    return parseAvifContainer(reader, true);
+  });
+  return result.iccOutcome || 'absent';
+}
+
+async function rejectUnknownOrientation(filePath, metadata, signal) {
+  if (metadata.orientation !== undefined) return;
+  let result;
+  try {
+    result = await readContainer(filePath, signal, 'preflight', (reader) => {
+      if (metadata.format === 'jpeg') return parseJpegContainer(reader, false);
+      if (metadata.format === 'png') return parsePngContainer(reader, false);
+      if (metadata.format === 'webp') return parseWebpContainer(reader, false);
+      return { complete: false };
+    });
+  } catch (error) {
+    if (isAbortError(error)) throw error;
+    throw structuredError('Input orientation could not be determined', 'E130', ERROR_CATEGORY.CodecError, 'Remove or normalize EXIF orientation before compiling the upload.', error);
+  }
+  if (result.hasExif) {
+    throw structuredError('Input EXIF orientation could not be determined within the safe inspection contract', 'E130', ERROR_CATEGORY.CodecError, 'Remove or normalize EXIF orientation before compiling the upload.');
+  }
+}
+
+function verifyIccOutcome(metrics) {
+  if (!metrics || typeof metrics.iccOutcome !== 'string' || !ICC_OUTCOMES.has(metrics.iccOutcome)) {
+    throw structuredError('Output ICC outcome is unavailable', 'E900', ERROR_CATEGORY.InternalBug, 'Report the output metrics invariant failure.');
+  }
+  return metrics.iccOutcome;
+}
+
+async function verifyArtifact({ artifact, outputPath, result, api, signal }) {
+  throwIfAborted(signal, 'verification');
+  let before;
+  try {
+    before = await fsp.lstat(outputPath);
+  } catch (error) {
+    throw structuredError('Generated artifact is missing', 'E900', ERROR_CATEGORY.InternalBug, 'Report the output verification failure.', error);
+  }
+  if (!before.isFile() || before.isSymbolicLink()) {
+    throw structuredError('Generated artifact is not a regular file', 'E900', ERROR_CATEGORY.InternalBug, 'Report the output verification failure.');
+  }
+
+  let metadata;
+  try {
+    metadata = artifact.format === 'avif'
+      ? await inspectAvifFile(outputPath, signal)
+      : api.inspectFile(outputPath);
+  } catch (error) {
+    throw error;
+  }
+  if (outputFormat(metadata.format) !== artifact.format || metadata.isAnimated === true || metadata.width !== artifact.width) {
+    throw structuredError('Generated artifact does not match the execution plan', 'E900', ERROR_CATEGORY.InternalBug, 'Report the output verification failure.');
+  }
+  if (!Number.isInteger(metadata.height) || metadata.height < 1) {
+    throw structuredError('Generated artifact dimensions are invalid', 'E900', ERROR_CATEGORY.InternalBug, 'Report the output verification failure.');
+  }
+
+  const bytes = before.size;
+  if (!Number.isInteger(bytes) || bytes < 1 || result.bytesWritten !== bytes) {
+    throw structuredError('Generated artifact byte count is inconsistent', 'E900', ERROR_CATEGORY.InternalBug, 'Report the output verification failure.');
+  }
+  if (result.metrics && result.metrics.bytesOut !== undefined && result.metrics.bytesOut !== bytes) {
+    throw structuredError('Encoder and filesystem byte counts differ', 'E900', ERROR_CATEGORY.InternalBug, 'Report the output verification failure.');
+  }
+  if (result.metrics && result.metrics.formatOut && outputFormat(result.metrics.formatOut) !== artifact.format) {
+    throw structuredError('Encoder format differs from the execution plan', 'E900', ERROR_CATEGORY.InternalBug, 'Report the output verification failure.');
+  }
+  if (artifact.targetBytes !== undefined && (result.budgetMet !== true || bytes > artifact.targetBytes)) {
+    throw structuredError('Strict byte budget was not met', 'E300', ERROR_CATEGORY.CodecError, 'Use a larger targetBytes budget or another output format.');
+  }
+
+  const iccOutcome = verifyIccOutcome(result.metrics);
+  const observedIccOutcome = await verifyPrivacy(outputPath, artifact.format, signal);
+  if ((iccOutcome === 'preserved') !== (observedIccOutcome === 'preserved')) {
+    throw structuredError('Output ICC outcome does not match its container', 'E900', ERROR_CATEGORY.InternalBug, 'Report the output metadata verification failure.');
+  }
+  const digest = await hashRegularFile(outputPath, signal, 'verification');
+  const after = await fsp.lstat(outputPath);
+  if (!after.isFile() || !sameIdentity(statIdentity(before), statIdentity(after))) {
+    throw structuredError('Generated artifact changed during verification', 'E900', ERROR_CATEGORY.InternalBug, 'Report the output verification failure.');
+  }
+  return {
+    id: artifact.id,
+    path: artifact.path,
+    format: artifact.format,
+    width: artifact.width,
+    height: metadata.height,
+    bytes,
+    quality: artifact.targetBytes === undefined ? artifact.quality : result.quality,
+    ...(artifact.targetBytes === undefined ? {} : { targetBytes: artifact.targetBytes }),
+    iccOutcome,
+    sha256: digest.sha256,
+  };
+}
+
+async function readBoundedDataUrl(filePath, expectedSha256, signal) {
+  throwIfAborted(signal, 'verification');
+  const stat = await fsp.lstat(filePath);
+  if (!stat.isFile() || stat.isSymbolicLink() || stat.size > PLACEHOLDER_MAX_BYTES) {
+    throw structuredError('Placeholder exceeds the bounded read limit', 'E900', ERROR_CATEGORY.InternalBug, 'Report the placeholder verification failure.');
+  }
+  let handle;
+  try {
+    handle = await fsp.open(filePath, fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW || 0));
+    const opened = await handle.stat();
+    if (!opened.isFile() || !sameIdentity(statIdentity(stat), statIdentity(opened))) {
+      throw structuredError('Placeholder changed before bounded read', 'E900', ERROR_CATEGORY.InternalBug, 'Report the placeholder verification failure.');
+    }
+    const data = Buffer.allocUnsafe(stat.size);
+    let offset = 0;
+    while (offset < data.length) {
+      throwIfAborted(signal, 'verification');
+      const { bytesRead } = await handle.read(data, offset, data.length - offset, offset);
+      if (bytesRead === 0) break;
+      offset += bytesRead;
+    }
+    if (offset !== data.length) {
+      throw structuredError('Placeholder changed during bounded read', 'E900', ERROR_CATEGORY.InternalBug, 'Report the placeholder verification failure.');
+    }
+    const after = await handle.stat();
+    if (!sameIdentity(statIdentity(stat), statIdentity(after))) {
+      throw structuredError('Placeholder changed during bounded read', 'E900', ERROR_CATEGORY.InternalBug, 'Report the placeholder verification failure.');
+    }
+    const digest = crypto.createHash('sha256').update(data).digest('hex');
+    if (digest !== expectedSha256) {
+      throw structuredError('Placeholder hash changed during bounded read', 'E900', ERROR_CATEGORY.InternalBug, 'Report the placeholder verification failure.');
+    }
+    return `data:image/webp;base64,${data.toString('base64')}`;
+  } finally {
+    if (handle) await handle.close().catch(() => {});
+  }
+}
+
+async function verifySourceUnchanged(snapshot, signal) {
+  throwIfAborted(signal, 'verification');
+  const stat = await snapshot.handle.stat();
+  if (!stat.isFile() || !sameIdentity(snapshot.identity, statIdentity(stat))) {
+    throw structuredError('Input changed during compilation', 'E101', ERROR_CATEGORY.ResourceLimit, 'Keep the input unchanged and retry.');
+  }
+  const digest = await hashHandle(snapshot.handle, signal, MAX_INPUT_BYTES, 'verification');
+  const after = await snapshot.handle.stat();
+  if (!sameIdentity(snapshot.identity, statIdentity(after))) {
+    throw structuredError('Input changed during compilation', 'E101', ERROR_CATEGORY.ResourceLimit, 'Keep the input unchanged and retry.');
+  }
+  if (digest.sha256 !== snapshot.sha256 || digest.bytes !== snapshot.bytes) {
+    throw structuredError('Input content changed during compilation', 'E101', ERROR_CATEGORY.ResourceLimit, 'Keep the input unchanged and retry.');
+  }
+}
+
+function manifestFor(plan, compiler, artifactResults, placeholder) {
+  return {
+    schemaVersion: 1,
+    compiler: {
+      name: PACKAGE_NAME,
+      version: compiler.version,
+      platform: process.platform,
+      arch: process.arch,
+      fingerprint: compiler.fingerprint,
+    },
+    policy: {
+      preset: 'publicUpload',
+      fingerprint: plan.policyFingerprint,
+      widths: [...plan.policy.widths],
+      formats: [...plan.policy.formats],
+      placeholder: plan.policy.placeholder,
+    },
+    source: {
+      sha256: plan.source.sha256,
+      bytes: plan.source.bytes,
+      detectedFormat: plan.source.detectedFormat,
+      encodedWidth: plan.source.encodedWidth,
+      encodedHeight: plan.source.encodedHeight,
+      displayWidth: plan.source.displayWidth,
+      displayHeight: plan.source.displayHeight,
+      hasAlpha: plan.source.hasAlpha,
+      orientation: plan.source.orientation,
+      orientationApplied: plan.source.orientationApplied,
+    },
+    metadata: {
+      mode: 'privacySafe',
+      exif: 'stripped',
+      gps: 'stripped',
+      xmp: 'stripped',
+      comments: 'stripped',
+      unknownAncillary: 'stripped',
+      artifactIccPolicy: 'preserve-if-safe',
+      placeholderIccPolicy: 'strip',
+    },
+    artifacts: artifactResults,
+    delivery: {
+      srcsets: plan.delivery.srcsets.map(({ format, value }) => ({ format, value })),
+    },
+    ...(placeholder ? { placeholder } : {}),
+    cacheKey: plan.cacheKey,
+  };
+}
+
+async function compileImage(options) {
+  let input;
+  try {
+    input = validateOptions(options);
+  } catch (error) {
+    throw wrapError(error, 'preflight', undefined, { errorCode: 'E400', category: ERROR_CATEGORY.UserError });
+  }
+
+  const { inputPath, outputDir, policy, signal } = input;
+  let resolvedInput;
+  try {
+    resolvedInput = path.resolve(inputPath);
+  } catch (error) {
+    throw wrapError(error, 'preflight', undefined, { errorCode: 'E400', category: ERROR_CATEGORY.UserError });
+  }
+
+  let sourceSnapshot;
+  let digest;
+  let facts;
+  let api;
+  let compiler;
+  let plan;
+  let commitPaths;
+  let failure;
+  try {
+    throwIfAborted(signal, 'preflight');
+    sourceSnapshot = await createSourceSnapshot(resolvedInput, signal);
+    digest = { bytes: sourceSnapshot.bytes, sha256: sourceSnapshot.sha256 };
+
+    // Load the package lazily to avoid an index.js circular dependency during startup.
+    api = require('../index');
+    const metadata = api.inspectFile(sourceSnapshot.path);
+    await rejectUnknownOrientation(sourceSnapshot.path, metadata, signal);
+    facts = sourceFacts(metadata, digest);
+    const nativeVersion = api.version();
+    if (typeof nativeVersion !== 'string' || nativeVersion.length === 0) {
+      throw structuredError('Native compiler version is unavailable', 'E900', ERROR_CATEGORY.InternalBug, 'Report the compiler identity failure.');
+    }
+    let supportedFormats;
+    try {
+      supportedFormats = api.supportedOutputFormats();
+    } catch (error) {
+      throw structuredError('Native compiler capabilities are unavailable', 'E900', ERROR_CATEGORY.InternalBug, 'Report the compiler identity failure.', error);
+    }
+    if (!Array.isArray(supportedFormats) || supportedFormats.some((format) => typeof format !== 'string')) {
+      throw structuredError('Native compiler capabilities are invalid', 'E900', ERROR_CATEGORY.InternalBug, 'Report the compiler identity failure.');
+    }
+    const nativeBuildIdentity = typeof api.compilerIdentity === 'function' ? api.compilerIdentity() : undefined;
+    if (typeof nativeBuildIdentity !== 'string' || nativeBuildIdentity.length === 0) {
+      throw structuredError('Native compiler build identity is unavailable', 'E900', ERROR_CATEGORY.InternalBug, 'Report the compiler identity failure.');
+    }
+    const nativeIdentity = {
+      build: nativeBuildIdentity,
+      nodeAbi: process.versions.modules,
+      outputFormats: [...new Set(supportedFormats.map((format) => String(format).toLowerCase()))].sort(),
+    };
+    compiler = { version: nativeVersion, fingerprint: compilerFingerprint(nativeVersion, nativeIdentity) };
+    // Keep the existing public-upload firewall as the only native processing boundary.
+    const baseEngine = api.ImageEngine.fromPath(sourceSnapshot.path).sanitize({ policy: 'public-upload' });
+    try {
+      plan = compileArtifactPlan(facts, policy, compiler.fingerprint);
+    } catch (error) {
+      throw wrapError(error, 'planning', undefined, { errorCode: 'E400', category: ERROR_CATEGORY.UserError });
+    }
+    try {
+      commitPaths = await resolveCommitPaths(outputDir);
+    } catch (error) {
+      throw wrapError(error, 'commit', undefined, { errorCode: 'E301', category: ERROR_CATEGORY.ResourceLimit });
+    }
+
+    let staging;
+    try {
+      staging = await createStaging(commitPaths.parent, commitPaths.name);
+    } catch (error) {
+      throw wrapError(error, 'commit', undefined, { errorCode: 'E301', category: ERROR_CATEGORY.ResourceLimit });
+    }
+
+    let committed = false;
+    let markerRemoved = false;
+    let primaryError;
+    try {
+      const results = [];
+      for (const artifact of plan.artifacts) {
+        throwIfAborted(signal, 'processing');
+        const outputPath = stagingPath(staging, artifact.path);
+        let result;
+        try {
+          const engine = baseEngine.clone().resize({ width: artifact.width, fit: 'inside' });
+          if (artifact.targetBytes === undefined) {
+            result = await engine.toFileWithMetrics(outputPath, artifact.format, artifact.quality, false);
+          } else {
+            result = await engine.toFileTargetBytes(outputPath, artifact.format, {
+              targetBytes: artifact.targetBytes,
+              strict: true,
+              qualityFloorPolicy: 'strict',
+            });
+          }
+        } catch (error) {
+          if (signal && signal.aborted) throw abortError('processing', error);
+          throw wrapError(error, 'processing', artifact.id);
+        }
+        try {
+          results.push(await verifyArtifact({ artifact, outputPath, result, api, signal }));
+        } catch (error) {
+          if (signal && signal.aborted) throw abortError('verification', error);
+          throw wrapError(error, 'verification', artifact.id);
+        }
+      }
+
+      let placeholder;
+      if (plan.placeholder) {
+        throwIfAborted(signal, 'processing');
+        const placeholderPath = stagingPath(staging, plan.placeholder.path);
+        let result;
+        try {
+          // The placeholder intentionally uses an explicit strip-all metadata policy;
+          // public-upload artifacts retain safe ICC profiles.
+          const placeholderEngine = api.ImageEngine.fromPath(sourceSnapshot.path)
+            .keepMetadata({ icc: false, exif: false, xmp: false, stripGps: true })
+            .limits({ maxPixels: MAX_PIXELS, maxBytes: MAX_INPUT_BYTES, timeoutMs: 5_000 })
+            .resize({ width: plan.placeholder.width, fit: 'inside' });
+          result = await placeholderEngine.toFileWithMetrics(placeholderPath, 'webp', plan.placeholder.quality, false);
+        } catch (error) {
+          if (signal && signal.aborted) throw abortError('processing', error);
+          throw wrapError(error, 'processing', plan.placeholder.id);
+        }
+        let verified;
+        try {
+          verified = await verifyArtifact({ artifact: plan.placeholder, outputPath: placeholderPath, result, api, signal });
+          const dataUrl = await readBoundedDataUrl(placeholderPath, verified.sha256, signal);
+          placeholder = {
+            path: plan.placeholder.path,
+            dataUrl,
+            format: 'webp',
+            width: verified.width,
+            height: verified.height,
+            bytes: verified.bytes,
+            iccOutcome: 'stripped-for-placeholder',
+            sha256: verified.sha256,
+          };
+        } catch (error) {
+          if (signal && signal.aborted) throw abortError('verification', error);
+          throw wrapError(error, 'verification', plan.placeholder.id);
+        }
+      }
+
+      await verifySourceUnchanged(sourceSnapshot, signal);
+      try {
+        await cleanupSourceSnapshot(sourceSnapshot);
+      } catch (error) {
+        throw wrapError(error, 'cleanup', undefined, { errorCode: 'E301', category: ERROR_CATEGORY.ResourceLimit });
+      }
+      sourceSnapshot = undefined;
+
+      const manifest = manifestFor(plan, compiler, results, placeholder);
+      const manifestPath = stagingPath(staging, 'manifest.json');
+      const manifestTempPath = stagingPath(staging, `.manifest-${crypto.randomUUID()}.tmp`);
+      const manifestBytes = JSON.stringify(manifest);
+      try {
+        await fsp.writeFile(manifestTempPath, manifestBytes, { flag: 'wx', mode: 0o600 });
+        await fsp.rename(manifestTempPath, manifestPath);
+      } catch (error) {
+        throw wrapError(error, 'commit', undefined, { errorCode: 'E301', category: ERROR_CATEGORY.ResourceLimit });
+      }
+
+      try {
+        await verifyStagingAllowlist(staging, plan);
+        await ensureFinalAbsent(commitPaths.finalPath);
+        throwIfAborted(signal, 'commit');
+        await removeStagingMarker(staging, signal);
+        markerRemoved = true;
+        await fsp.rename(staging, commitPaths.finalPath);
+        committed = true;
+      } catch (error) {
+        throw wrapError(error, 'commit', undefined, { errorCode: 'E301', category: ERROR_CATEGORY.ResourceLimit });
+      }
+      return manifest;
+    } catch (error) {
+      primaryError = error;
+      throw error;
+    } finally {
+      if (!committed) {
+        try {
+          await cleanupStaging(staging, plan, markerRemoved);
+        } catch (cleanupError) {
+          if (primaryError) {
+            primaryError.cleanupError = cleanupError;
+          } else {
+            throw wrapError(cleanupError, 'cleanup', undefined, { errorCode: 'E301', category: ERROR_CATEGORY.ResourceLimit });
+          }
+        }
+      }
+    }
+  } catch (error) {
+    let finalError;
+    if (signal && signal.aborted) {
+      finalError = isAbortError(error) ? error : abortError(error.phase || 'preflight', error);
+    } else if (error instanceof ArtifactCompilationError) {
+      finalError = error;
+    } else {
+      finalError = wrapError(error, error.phase || 'preflight');
+    }
+    failure = finalError;
+    throw finalError;
+  } finally {
+    if (sourceSnapshot) {
+      try {
+        await cleanupSourceSnapshot(sourceSnapshot);
+      } catch (cleanupError) {
+        if (failure) {
+          failure.cleanupError = cleanupError;
+        } else {
+          throw wrapError(cleanupError, 'cleanup', undefined, { errorCode: 'E301', category: ERROR_CATEGORY.ResourceLimit });
+        }
+      }
+    }
+  }
+}
+
+module.exports = { ArtifactCompilationError, compileImage, compilerFingerprint };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -88,7 +88,19 @@ function normalizeTargetBytesOptions(format, options = {}) {
     throw new Error('minQuality must be less than or equal to maxQuality');
   }
 
-  const policy = options.qualityFloorPolicy == null ? 'best-effort' : String(options.qualityFloorPolicy);
+  if (options.strict !== undefined && typeof options.strict !== 'boolean') {
+    const error = new TypeError('strict must be a boolean when provided');
+    error.code = 'LAZY_IMAGE_USER_ERROR';
+    error.errorCode = 'E400';
+    error.errorCategory = 'UserError';
+    error.category = 0;
+    error.recoveryHint = 'Set strict to true or false.';
+    throw error;
+  }
+
+  const policy = options.strict === true
+    ? 'strict'
+    : (options.qualityFloorPolicy == null ? 'best-effort' : String(options.qualityFloorPolicy));
   if (!['best-effort', 'strict'].includes(policy)) {
     throw new Error(`Unsupported qualityFloorPolicy: ${options.qualityFloorPolicy}`);
   }

--- a/scripts/postbuild-fixup.js
+++ b/scripts/postbuild-fixup.js
@@ -111,6 +111,93 @@ export declare function compileArtifactPlan(
   compilerFingerprint: string,
 ): ArtifactPlan
 
+export interface CompileImageOptions {
+  readonly inputPath: string
+  readonly outputDir: string
+  readonly policy: PublicUploadPolicy
+  readonly signal?: AbortSignal
+}
+
+export interface ImageArtifactManifest {
+  readonly schemaVersion: 1
+  readonly compiler: {
+    readonly name: '@alberteinshutoin/lazy-image'
+    readonly version: string
+    readonly platform: string
+    readonly arch: string
+    readonly fingerprint: string
+  }
+  readonly policy: {
+    readonly preset: 'publicUpload'
+    readonly fingerprint: string
+    readonly widths: readonly number[]
+    readonly formats: readonly ArtifactFormat[]
+    readonly placeholder: boolean
+  }
+  readonly source: {
+    readonly sha256: string
+    readonly bytes: number
+    readonly detectedFormat: 'jpeg' | 'png' | 'webp'
+    readonly encodedWidth: number
+    readonly encodedHeight: number
+    readonly displayWidth: number
+    readonly displayHeight: number
+    readonly hasAlpha: boolean
+    readonly orientation: number | null
+    readonly orientationApplied: boolean
+  }
+  readonly metadata: {
+    readonly mode: 'privacySafe'
+    readonly exif: 'stripped'
+    readonly gps: 'stripped'
+    readonly xmp: 'stripped'
+    readonly comments: 'stripped'
+    readonly unknownAncillary: 'stripped'
+    readonly artifactIccPolicy: 'preserve-if-safe'
+    readonly placeholderIccPolicy: 'strip'
+  }
+  readonly artifacts: readonly {
+    readonly id: string
+    readonly path: string
+    readonly format: ArtifactFormat
+    readonly width: number
+    readonly height: number
+    readonly bytes: number
+    readonly quality: number
+    readonly targetBytes?: number
+    readonly iccOutcome: IccOutcome
+    readonly sha256: string
+  }[]
+  readonly delivery: {
+    readonly srcsets: readonly { readonly format: ArtifactFormat; readonly value: string }[]
+  }
+  readonly placeholder?: {
+    readonly path: 'placeholder.webp'
+    readonly dataUrl: string
+    readonly format: 'webp'
+    readonly width: number
+    readonly height: number
+    readonly bytes: number
+    readonly iccOutcome: 'stripped-for-placeholder'
+    readonly sha256: string
+  }
+  readonly cacheKey: string
+}
+
+export interface ArtifactCompilationError extends Error {
+  readonly phase: 'preflight' | 'planning' | 'processing' | 'verification' | 'commit' | 'cleanup'
+  readonly artifactId?: string
+  readonly errorCode?: string
+  readonly category?: ErrorCategory
+  readonly errorCategory?: ErrorCategory
+  readonly code?: string
+  readonly recoveryHint?: string
+  readonly cause?: unknown
+  readonly cleanupError?: unknown
+}
+
+export declare function compileImage(options: CompileImageOptions): Promise<ImageArtifactManifest>
+
 export interface ResolvedEncodeProfile {
   format: CanonicalOutputFormat
   quality?: number
@@ -201,6 +288,8 @@ export interface TargetBytesOptions {
   fastMode?: boolean
   /** Behaviour when budget cannot be met: 'best-effort' (default) or 'strict' */
   qualityFloorPolicy?: 'best-effort' | 'strict'
+  /** Fail when the target cannot be met (alias for qualityFloorPolicy: 'strict') */
+  strict?: boolean
 }
 
 export interface BufferTargetBytesResult {
@@ -317,6 +406,7 @@ function patchIndexJs() {
 const { createStreamingPipeline } = require('./streaming/pipeline')
 const helpers = require('./lib/helpers')
 const { compileArtifactPlan } = require('./lib/artifact-policy')
+const { compileImage } = require('./lib/artifact-compiler')
 const _getErrorCategory = helpers.createGetErrorCategory(nativeBinding.ErrorCategory, nativeBinding.ErrorCode)
 const _processBatchChunked = helpers.createProcessBatchChunked(nativeBinding.ImageEngine)
 module.exports.getErrorCategory = _getErrorCategory
@@ -324,6 +414,7 @@ module.exports.processBatchChunked = _processBatchChunked
 module.exports.createStreamingPipeline = createStreamingPipeline
 module.exports.resolveEncodeProfile = helpers.resolveEncodeProfile
 module.exports.compileArtifactPlan = compileArtifactPlan
+module.exports.compileImage = compileImage
 if (nativeBinding && nativeBinding.ImageEngine) {
   helpers.attachPrototypeMethods(nativeBinding.ImageEngine)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,6 +127,24 @@ pub fn version() -> String {
 }
 
 #[cfg(feature = "napi")]
+/// Return the stable native codec/build identity used by artifact fingerprints.
+#[napi(js_name = "compilerIdentity")]
+pub fn compiler_identity() -> String {
+    let avif = if cfg!(feature = "avif") {
+        "avif"
+    } else {
+        "no-avif"
+    };
+    format!(
+        "lazy-image-native:{};config={};target={};profile={};feature={avif}",
+        env!("CARGO_PKG_VERSION"),
+        env!("LAZY_IMAGE_COMPILER_CONFIG"),
+        env!("LAZY_IMAGE_COMPILER_TARGET"),
+        env!("LAZY_IMAGE_COMPILER_PROFILE"),
+    )
+}
+
+#[cfg(feature = "napi")]
 const BASE_FORMATS: &[&str] = &["jpeg", "jpg", "png", "webp"];
 
 #[cfg(feature = "napi")]

--- a/test/integration/artifact-compiler.test.js
+++ b/test/integration/artifact-compiler.test.js
@@ -204,6 +204,34 @@ async function main() {
     assert.equal(await fsp.stat(outputDir).catch(() => null), null);
   });
 
+  await withTempParent(async (parent) => {
+    const outputDir = path.join(parent, 'abort-before-rename');
+    const controller = new AbortController();
+    const originalUnlink = fsp.unlink;
+    fsp.unlink = async function abortAfterMarkerRemoval(filePath) {
+      const result = await originalUnlink.call(this, filePath);
+      if (path.basename(filePath) === '.lazy-image-staging') controller.abort();
+      return result;
+    };
+    try {
+      await assertRejected(
+        () => compileImage({
+          inputPath: INPUT,
+          outputDir,
+          policy: { widths: [16], formats: ['webp'], placeholder: false },
+          signal: controller.signal,
+        }),
+        (error) => {
+          assert.equal(error.name, 'AbortError');
+          assert.equal(error.phase, 'commit');
+        },
+      );
+    } finally {
+      fsp.unlink = originalUnlink;
+    }
+    assert.equal(await fsp.stat(outputDir).catch(() => null), null);
+  });
+
   for (const format of ['png', 'webp']) {
     await withTempParent(async (parent) => {
       const inputPath = path.join(parent, `unknown-orientation.${format}`);

--- a/test/integration/artifact-compiler.test.js
+++ b/test/integration/artifact-compiler.test.js
@@ -1,0 +1,558 @@
+const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const fsp = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+
+const { ImageEngine, compileImage } = require('../../index');
+const { compilerFingerprint } = require('../../lib/artifact-compiler');
+const { resolveFixture } = require('../helpers/paths');
+
+const INPUT = resolveFixture('test_100KB_1057x1057.jpg');
+
+async function withTempParent(run) {
+  const parent = await fsp.mkdtemp(path.join(os.tmpdir(), 'lazy-image-compiler-'));
+  try {
+    return await run(parent);
+  } finally {
+    await fsp.rm(parent, { recursive: true, force: true });
+  }
+}
+
+async function hashFile(filePath) {
+  const hash = crypto.createHash('sha256');
+  for await (const chunk of fs.createReadStream(filePath)) hash.update(chunk);
+  return hash.digest('hex');
+}
+
+async function assertRejected(run, check) {
+  await assert.rejects(run, (error) => {
+    check(error);
+    return true;
+  });
+}
+
+async function writeUnknownOrientationFixture(format, outputPath) {
+  const data = await ImageEngine.fromPath(resolveFixture('test_with_exif.jpg'))
+    .keepMetadata({ icc: false, exif: true, stripGps: false })
+    .toBuffer(format, 80, false);
+  const orientationTag = Buffer.from([0x12, 0x01, 0x03, 0x00]);
+  const tagOffset = data.indexOf(orientationTag);
+  assert.notEqual(tagOffset, -1, `${format} fixture should contain EXIF orientation`);
+  data[tagOffset + 8] = 9;
+  data[tagOffset + 9] = 0;
+  await fsp.writeFile(outputPath, data);
+}
+
+function makeIccProfile(shared) {
+  const profile = Buffer.alloc(shared ? 164 : 132);
+  profile.writeUInt32BE(profile.length, 0);
+  profile.write('ADBE', 4, 'ascii');
+  profile[8] = 2;
+  profile.write('mntr', 12, 'ascii');
+  profile.write('RGB ', 16, 'ascii');
+  profile.write('XYZ ', 20, 'ascii');
+  profile.write('acsp', 36, 'ascii');
+  if (shared) {
+    profile.writeUInt32BE(2, 128);
+    profile.write('rXYZ', 132, 'ascii');
+    profile.writeUInt32BE(156, 136);
+    profile.writeUInt32BE(8, 140);
+    profile.write('gXYZ', 144, 'ascii');
+    profile.writeUInt32BE(156, 148);
+    profile.writeUInt32BE(8, 152);
+    profile.write('curv', 156, 'ascii');
+  }
+  return profile;
+}
+
+async function writeIccFixture(outputPath, { shared, split }) {
+  const base = await ImageEngine.fromPath(INPUT).toBuffer('jpeg', 80, false);
+  const profile = makeIccProfile(shared);
+  const parts = split ? [profile.subarray(0, 80), profile.subarray(80)] : [profile];
+  const segments = parts.map((part, index) => {
+    const payload = Buffer.concat([
+      Buffer.from('ICC_PROFILE\0', 'ascii'),
+      Buffer.from([index + 1, parts.length]),
+      part,
+    ]);
+    const segment = Buffer.concat([Buffer.from([0xff, 0xe2, 0, 0]), payload]);
+    segment.writeUInt16BE(segment.length - 2, 2);
+    return segment;
+  });
+  const sos = base.indexOf(Buffer.from([0xff, 0xda]));
+  await fsp.writeFile(outputPath, Buffer.concat([base.subarray(0, sos), ...segments, base.subarray(sos)]));
+}
+
+async function main() {
+  const esm = await import('../../index.mjs');
+  assert.equal(typeof esm.compileImage, 'function');
+  assert.notEqual(
+    compilerFingerprint('1.0.1', { build: 'codec-a' }),
+    compilerFingerprint('1.0.1', { build: 'codec-b' }),
+    'compiler build identity must participate in the cache fingerprint',
+  );
+
+  await withTempParent(async (parent) => {
+    const outputDir = path.join(parent, 'published');
+    const manifest = await compileImage({
+      inputPath: INPUT,
+      outputDir,
+      policy: { widths: [320], formats: ['webp'], placeholder: true },
+    });
+
+    assert.equal(manifest.schemaVersion, 1);
+    assert.deepEqual(manifest.policy.widths, [320]);
+    assert.deepEqual(manifest.policy.formats, ['webp']);
+    assert.equal(manifest.artifacts.length, 1);
+    assert.deepEqual(Object.keys(manifest.artifacts[0]), [
+      'id', 'path', 'format', 'width', 'height', 'bytes', 'quality', 'iccOutcome', 'sha256',
+    ]);
+    assert.equal(manifest.artifacts[0].path, 'image-320.webp');
+    assert.equal(manifest.placeholder.path, 'placeholder.webp');
+    assert.match(manifest.placeholder.dataUrl, /^data:image\/webp;base64,/);
+    assert.ok(!JSON.stringify(manifest).includes(INPUT));
+    assert.ok(!JSON.stringify(manifest).includes(path.basename(INPUT)));
+
+    const manifestBytes = await fsp.readFile(path.join(outputDir, 'manifest.json'), 'utf8');
+    assert.deepEqual(JSON.parse(manifestBytes), manifest);
+    assert.equal(manifest.artifacts[0].bytes, (await fsp.stat(path.join(outputDir, manifest.artifacts[0].path))).size);
+    assert.equal(manifest.artifacts[0].sha256, await hashFile(path.join(outputDir, manifest.artifacts[0].path)));
+    assert.deepEqual((await fsp.readdir(outputDir)).filter((name) => !name.startsWith('.')).sort(), [
+      'image-320.webp', 'manifest.json', 'placeholder.webp',
+    ]);
+  });
+
+  await withTempParent(async (parent) => {
+    const outputDir = path.join(parent, 'already-there');
+    await fsp.mkdir(outputDir);
+    await assertRejected(
+      () => compileImage({ inputPath: INPUT, outputDir, policy: { widths: [320], formats: ['webp'] } }),
+      (error) => {
+        assert.equal(error.name, 'ArtifactCompilationError');
+        assert.equal(error.phase, 'commit');
+        assert.equal(error.errorCode, 'E301');
+      },
+    );
+    assert.deepEqual(await fsp.readdir(outputDir), []);
+  });
+
+  for (const fixture of [{ shared: false, split: false }, { shared: true, split: true }]) {
+    await withTempParent(async (parent) => {
+      const inputPath = path.join(parent, 'icc-input.jpg');
+      await writeIccFixture(inputPath, fixture);
+      const manifest = await compileImage({
+        inputPath,
+        outputDir: path.join(parent, 'icc-output'),
+        policy: { widths: [320], formats: ['jpeg'], placeholder: false },
+      });
+      assert.equal(manifest.artifacts[0].iccOutcome, 'preserved');
+    });
+  }
+
+  await withTempParent(async (parent) => {
+    await assertRejected(
+      () => compileImage({
+        inputPath: INPUT,
+        outputDir: path.join(parent, 'invalid-policy'),
+        policy: { unknown: true },
+      }),
+      (error) => {
+        assert.equal(error.name, 'ArtifactCompilationError');
+        assert.equal(error.phase, 'planning');
+        assert.equal(error.errorCode, 'E400');
+        assert.equal(error.category, 0);
+      },
+    );
+  });
+
+  await withTempParent(async (parent) => {
+    const outputDir = path.join(parent, 'budget-failure');
+    await assertRejected(
+      () => compileImage({
+        inputPath: INPUT,
+        outputDir,
+        policy: {
+          widths: [320],
+          formats: ['webp'],
+          budgets: [{ width: 320, format: 'webp', maxBytes: 1 }],
+          placeholder: false,
+        },
+      }),
+      (error) => {
+        assert.equal(error.name, 'ArtifactCompilationError');
+        assert.equal(error.phase, 'processing');
+        assert.equal(error.artifactId, '320/webp');
+        assert.equal(error.errorCode, 'E300');
+      },
+    );
+    assert.equal(await fsp.stat(outputDir).catch(() => null), null);
+  });
+
+  await withTempParent(async (parent) => {
+    const outputDir = path.join(parent, 'aborted');
+    const controller = new AbortController();
+    controller.abort();
+    await assertRejected(
+      () => compileImage({ inputPath: INPUT, outputDir, policy: { widths: [320], formats: ['webp'] }, signal: controller.signal }),
+      (error) => {
+        assert.equal(error.name, 'AbortError');
+        assert.equal(error.phase, 'preflight');
+      },
+    );
+    assert.equal(await fsp.stat(outputDir).catch(() => null), null);
+  });
+
+  for (const format of ['png', 'webp']) {
+    await withTempParent(async (parent) => {
+      const inputPath = path.join(parent, `unknown-orientation.${format}`);
+      await writeUnknownOrientationFixture(format, inputPath);
+      await assertRejected(
+        () => compileImage({
+          inputPath,
+          outputDir: path.join(parent, 'orientation-output'),
+          policy: { widths: [16], formats: ['webp'], placeholder: false },
+        }),
+        (error) => {
+          assert.equal(error.name, 'ArtifactCompilationError');
+          assert.equal(error.phase, 'preflight');
+          assert.equal(error.errorCode, 'E130');
+        },
+      );
+    });
+  }
+
+  await withTempParent(async (parent) => {
+    const inputPath = path.join(parent, 'mutable-input.jpg');
+    const original = await fsp.readFile(INPUT);
+    const mutated = Buffer.from(original);
+    mutated[mutated.length - 1] ^= 1;
+    await fsp.writeFile(inputPath, original);
+    const originalToFileWithMetrics = ImageEngine.prototype.toFileWithMetrics;
+    let changed = false;
+    ImageEngine.prototype.toFileWithMetrics = async function patchedToFileWithMetrics(...args) {
+      const result = await originalToFileWithMetrics.apply(this, args);
+      if (!changed) {
+        changed = true;
+        await fsp.writeFile(inputPath, mutated);
+      }
+      return result;
+    };
+    try {
+      await assertRejected(
+        () => compileImage({
+          inputPath,
+          outputDir: path.join(parent, 'mutable-output'),
+          policy: { widths: [320, 640], formats: ['webp'], placeholder: false },
+        }),
+        (error) => {
+          assert.equal(error.name, 'ArtifactCompilationError');
+          assert.equal(error.errorCode, 'E101');
+        },
+      );
+    } finally {
+      ImageEngine.prototype.toFileWithMetrics = originalToFileWithMetrics;
+    }
+    assert.equal(await fsp.stat(path.join(parent, 'mutable-output')).catch(() => null), null);
+  });
+
+  await withTempParent(async (parent) => {
+    const originalToFileWithMetrics = ImageEngine.prototype.toFileWithMetrics;
+    let injected = false;
+    ImageEngine.prototype.toFileWithMetrics = async function patchedAvifMetadata(...args) {
+      const result = await originalToFileWithMetrics.apply(this, args);
+      if (!injected && args[1] === 'avif') {
+        injected = true;
+        const uuid = Buffer.alloc(12);
+        uuid.writeUInt32BE(uuid.length, 0);
+        uuid.write('uuid', 4, 'ascii');
+        await fsp.appendFile(args[0], uuid);
+        return {
+          ...result,
+          bytesWritten: result.bytesWritten + uuid.length,
+          metrics: { ...result.metrics, bytesOut: result.metrics.bytesOut + uuid.length },
+        };
+      }
+      return result;
+    };
+    try {
+      await assertRejected(
+        () => compileImage({
+          inputPath: INPUT,
+          outputDir: path.join(parent, 'avif-metadata-output'),
+          policy: { widths: [320], formats: ['avif'], placeholder: false },
+        }),
+        (error) => {
+          assert.equal(error.name, 'ArtifactCompilationError');
+          assert.equal(error.phase, 'verification');
+          assert.equal(error.errorCode, 'E900');
+        },
+      );
+    } finally {
+      ImageEngine.prototype.toFileWithMetrics = originalToFileWithMetrics;
+    }
+    assert.equal(await fsp.stat(path.join(parent, 'avif-metadata-output')).catch(() => null), null);
+  });
+
+  await withTempParent(async (parent) => {
+    const originalToFileWithMetrics = ImageEngine.prototype.toFileWithMetrics;
+    let injected = false;
+    ImageEngine.prototype.toFileWithMetrics = async function patchedAvifUnknownBox(...args) {
+      const result = await originalToFileWithMetrics.apply(this, args);
+      if (!injected && args[1] === 'avif') {
+        injected = true;
+        const junk = Buffer.alloc(12);
+        junk.writeUInt32BE(junk.length, 0);
+        junk.write('junk', 4, 'ascii');
+        await fsp.appendFile(args[0], junk);
+        return {
+          ...result,
+          bytesWritten: result.bytesWritten + junk.length,
+          metrics: { ...result.metrics, bytesOut: result.metrics.bytesOut + junk.length },
+        };
+      }
+      return result;
+    };
+    try {
+      await assertRejected(
+        () => compileImage({
+          inputPath: INPUT,
+          outputDir: path.join(parent, 'avif-unknown-box-output'),
+          policy: { widths: [320], formats: ['avif'], placeholder: false },
+        }),
+        (error) => {
+          assert.equal(error.name, 'ArtifactCompilationError');
+          assert.equal(error.phase, 'verification');
+          assert.equal(error.errorCode, 'E900');
+        },
+      );
+    } finally {
+      ImageEngine.prototype.toFileWithMetrics = originalToFileWithMetrics;
+    }
+    assert.equal(await fsp.stat(path.join(parent, 'avif-unknown-box-output')).catch(() => null), null);
+  });
+
+  await withTempParent(async (parent) => {
+    const originalToFileWithMetrics = ImageEngine.prototype.toFileWithMetrics;
+    let injected = false;
+    ImageEngine.prototype.toFileWithMetrics = async function patchedJpegMetadataAfterScan(...args) {
+      const result = await originalToFileWithMetrics.apply(this, args);
+      if (!injected && args[1] === 'jpeg') {
+        injected = true;
+        const data = await fsp.readFile(args[0]);
+        const eoi = data.lastIndexOf(Buffer.from([0xff, 0xd9]));
+        assert.ok(eoi > 0);
+        const exif = Buffer.from([0xff, 0xe1, 0x00, 0x08, 0x45, 0x78, 0x69, 0x66, 0x00, 0x00]);
+        await fsp.writeFile(args[0], Buffer.concat([data.subarray(0, eoi), exif, data.subarray(eoi)]));
+        return {
+          ...result,
+          bytesWritten: result.bytesWritten + exif.length,
+          metrics: { ...result.metrics, bytesOut: result.metrics.bytesOut + exif.length },
+        };
+      }
+      return result;
+    };
+    try {
+      await assertRejected(
+        () => compileImage({
+          inputPath: INPUT,
+          outputDir: path.join(parent, 'jpeg-post-scan-output'),
+          policy: { widths: [320], formats: ['jpeg'], placeholder: false },
+        }),
+        (error) => {
+          assert.equal(error.name, 'ArtifactCompilationError');
+          assert.equal(error.phase, 'verification');
+          assert.equal(error.errorCode, 'E900');
+        },
+      );
+    } finally {
+      ImageEngine.prototype.toFileWithMetrics = originalToFileWithMetrics;
+    }
+    assert.equal(await fsp.stat(path.join(parent, 'jpeg-post-scan-output')).catch(() => null), null);
+  });
+
+  await withTempParent(async (parent) => {
+    const originalToFileWithMetrics = ImageEngine.prototype.toFileWithMetrics;
+    let injected = false;
+    ImageEngine.prototype.toFileWithMetrics = async function patchedJpegTrailingData(...args) {
+      const result = await originalToFileWithMetrics.apply(this, args);
+      if (!injected && args[1] === 'jpeg') {
+        injected = true;
+        await fsp.appendFile(args[0], Buffer.from([0x00]));
+        return {
+          ...result,
+          bytesWritten: result.bytesWritten + 1,
+          metrics: { ...result.metrics, bytesOut: result.metrics.bytesOut + 1 },
+        };
+      }
+      return result;
+    };
+    try {
+      await assertRejected(
+        () => compileImage({
+          inputPath: INPUT,
+          outputDir: path.join(parent, 'jpeg-trailing-output'),
+          policy: { widths: [320], formats: ['jpeg'], placeholder: false },
+        }),
+        (error) => {
+          assert.equal(error.name, 'ArtifactCompilationError');
+          assert.equal(error.phase, 'verification');
+          assert.equal(error.errorCode, 'E900');
+        },
+      );
+    } finally {
+      ImageEngine.prototype.toFileWithMetrics = originalToFileWithMetrics;
+    }
+    assert.equal(await fsp.stat(path.join(parent, 'jpeg-trailing-output')).catch(() => null), null);
+  });
+
+  for (const format of ['jpeg', 'webp', 'avif']) {
+    await withTempParent(async (parent) => {
+      const originalToFileWithMetrics = ImageEngine.prototype.toFileWithMetrics;
+      let injected = false;
+      ImageEngine.prototype.toFileWithMetrics = async function patchedMalformedIcc(...args) {
+        const result = await originalToFileWithMetrics.apply(this, args);
+        if (!injected && args[1] === format) {
+          injected = true;
+          const data = await fsp.readFile(args[0]);
+          let mutated;
+          if (format === 'jpeg') {
+            const eoi = data.lastIndexOf(Buffer.from([0xff, 0xd9]));
+            const payload = Buffer.concat([Buffer.from('ICC_PROFILE\0', 'ascii'), Buffer.from([1, 1]), Buffer.from([0, 0, 0, 4])]);
+            const segment = Buffer.concat([Buffer.from([0xff, 0xe2]), Buffer.alloc(2), payload]);
+            segment.writeUInt16BE(segment.length - 2, 2);
+            mutated = Buffer.concat([data.subarray(0, eoi), segment, data.subarray(eoi)]);
+          } else if (format === 'webp') {
+            const payload = Buffer.from([0, 1, 2, 3]);
+            const chunk = Buffer.alloc(8 + payload.length + (payload.length % 2));
+            chunk.write('ICCP', 0, 'ascii');
+            chunk.writeUInt32LE(payload.length, 4);
+            payload.copy(chunk, 8);
+            const riff = Buffer.from(data);
+            mutated = Buffer.concat([riff, chunk]);
+            mutated.writeUInt32LE(mutated.length - 8, 4);
+          } else {
+            const avif = Buffer.from(data);
+            const colr = avif.indexOf(Buffer.from('colr', 'ascii'));
+            assert.ok(colr > 4);
+            avif.write('prof', colr + 4, 'ascii');
+            avif.fill(0, colr + 12, colr + 19);
+            mutated = avif;
+          }
+          await fsp.writeFile(args[0], mutated);
+          return {
+            ...result,
+            bytesWritten: mutated.length,
+            metrics: { ...result.metrics, bytesOut: mutated.length },
+          };
+        }
+        return result;
+      };
+      try {
+        await assertRejected(
+          () => compileImage({
+            inputPath: INPUT,
+            outputDir: path.join(parent, `${format}-malformed-icc-output`),
+            policy: { widths: [320], formats: [format], placeholder: false },
+          }),
+          (error) => {
+            assert.equal(error.name, 'ArtifactCompilationError');
+            assert.equal(error.phase, 'verification');
+            assert.equal(error.errorCode, 'E900');
+          },
+        );
+      } finally {
+        ImageEngine.prototype.toFileWithMetrics = originalToFileWithMetrics;
+      }
+      assert.equal(await fsp.stat(path.join(parent, `${format}-malformed-icc-output`)).catch(() => null), null);
+    });
+  }
+
+  for (const mutation of [
+    { format: 'jpeg', name: 'jfif-payload', needle: Buffer.from('JFIF\0'), mutate(data, offset) {
+      const marker = data.indexOf(Buffer.from([0xff, 0xe0]), 2);
+      assert.ok(marker > 0);
+      const length = data.readUInt16BE(marker + 2);
+      const payload = Buffer.concat([data.subarray(marker + 4, marker + 2 + length), Buffer.from('PRIVATE')]);
+      const segment = Buffer.alloc(4 + payload.length);
+      segment[0] = 0xff;
+      segment[1] = 0xe0;
+      segment.writeUInt16BE(payload.length + 2, 2);
+      payload.copy(segment, 4);
+      return Buffer.concat([data.subarray(0, marker), segment, data.subarray(marker + 2 + length)]);
+    } },
+    { format: 'jpeg', name: 'jfxx-segment', needle: Buffer.from('JFIF\0'), mutate(data, offset) {
+      const mutated = Buffer.from(data);
+      mutated.write('JFXX', offset, 'ascii');
+      return mutated;
+    } },
+    { format: 'avif', name: 'ftyp-minor', needle: Buffer.from('ftyp'), mutate(data, offset) {
+      const mutated = Buffer.from(data);
+      mutated[offset + 8] = 1;
+      return mutated;
+    } },
+    { format: 'avif', name: 'ftyp-brand', needle: Buffer.from('ftyp'), mutate(data, offset) {
+      const mutated = Buffer.from(data);
+      mutated.write('evil', offset + 12, 'ascii');
+      return mutated;
+    } },
+    { format: 'avif', name: 'hdlr-payload', needle: Buffer.from('libavif\0'), mutate(data, offset) {
+      const mutated = Buffer.from(data);
+      mutated[offset] = 'x'.charCodeAt(0);
+      return mutated;
+    } },
+    { format: 'avif', name: 'infe-payload', needle: Buffer.from('Color\0'), mutate(data, offset) {
+      const mutated = Buffer.from(data);
+      mutated[offset] = 'S'.charCodeAt(0);
+      return mutated;
+    } },
+  ]) {
+    await withTempParent(async (parent) => {
+      const originalToFileWithMetrics = ImageEngine.prototype.toFileWithMetrics;
+      let injected = false;
+      ImageEngine.prototype.toFileWithMetrics = async function patchedPrivatePayload(...args) {
+        const result = await originalToFileWithMetrics.apply(this, args);
+        if (!injected && args[1] === mutation.format) {
+          injected = true;
+          const data = await fsp.readFile(args[0]);
+          const offset = data.indexOf(mutation.needle);
+          assert.ok(offset >= 0, `${mutation.name} fixture should contain its canonical payload`);
+          const mutated = mutation.mutate(data, offset);
+          await fsp.writeFile(args[0], mutated);
+          return {
+            ...result,
+            bytesWritten: mutated.length,
+            metrics: { ...result.metrics, bytesOut: mutated.length },
+          };
+        }
+        return result;
+      };
+      try {
+        await assertRejected(
+          () => compileImage({
+            inputPath: INPUT,
+            outputDir: path.join(parent, `${mutation.name}-output`),
+            policy: { widths: [320], formats: [mutation.format], placeholder: false },
+          }),
+          (error) => {
+            assert.equal(error.name, 'ArtifactCompilationError');
+            assert.equal(error.phase, 'verification');
+            assert.equal(error.errorCode, 'E900');
+          },
+        );
+      } finally {
+        ImageEngine.prototype.toFileWithMetrics = originalToFileWithMetrics;
+      }
+      assert.equal(await fsp.stat(path.join(parent, `${mutation.name}-output`)).catch(() => null), null);
+    });
+  }
+}
+
+main().then(
+  () => console.log('artifact compiler contract passed'),
+  (error) => {
+    console.error(error);
+    process.exitCode = 1;
+  },
+);

--- a/test/type-safety/typescript-typecheck.test.ts
+++ b/test/type-safety/typescript-typecheck.test.ts
@@ -6,9 +6,13 @@ import * as path from 'path';
 import {
     ArtifactPlan,
     ArtifactSourceFacts,
+    ArtifactCompilationError,
     BatchProgressEvent,
+    CompileImageOptions,
     compileArtifactPlan,
+    compileImage,
     ImageEngine,
+    ImageArtifactManifest,
     ImageMetadata,
     OutputFormat,
     PublicUploadPolicy,
@@ -46,6 +50,15 @@ async function testTypeSafety() {
         'b'.repeat(64),
     );
     console.log(`Artifact policy: ${artifactSource.format} ${publicUploadPolicy.widths?.length} ${artifactPlan} ${compiledArtifactPlan.cacheKey}`);
+
+    const compileOptions: CompileImageOptions = {
+        inputPath: imagePath,
+        outputDir: path.resolve(__dirname, '../../.tmp/type-safety-artifacts'),
+        policy: publicUploadPolicy,
+    };
+    const compiledManifest: Promise<ImageArtifactManifest> = compileImage(compileOptions);
+    const compilationError: ArtifactCompilationError | null = null;
+    console.log(`Transactional compiler: ${compiledManifest} ${compilationError}`);
     
     // Type-safe OutputFormat usage
     const validFormats: OutputFormat[] = ['jpeg', 'jpg', 'png', 'webp', 'avif'];

--- a/test/unit/target-bytes-search.test.js
+++ b/test/unit/target-bytes-search.test.js
@@ -138,3 +138,22 @@ test('target-bytes options reject values above the native u32 contract', async (
     /u32 limit \(4294967295\)/,
   )
 })
+
+test('target-bytes strict rejects malformed values before native output', async () => {
+  let called = false
+  const engine = {
+    toBufferTargetBytesNative: async () => { called = true },
+    toFileTargetBytesNative: async () => { called = true },
+  }
+  for (const strict of [null, 'true', 1]) {
+    await assert.rejects(
+      runTargetBytesSearch(engine, 'jpeg', { targetBytes: 1000, strict }),
+      (error) => error.errorCode === 'E400' && error.category === 0,
+    )
+    await assert.rejects(
+      runTargetBytesFileSearch(engine, '/tmp/output.jpg', 'jpeg', { targetBytes: 1000, strict }),
+      (error) => error.errorCode === 'E400' && error.category === 0,
+    )
+  }
+  assert.equal(called, false)
+})


### PR DESCRIPTION
## Summary

Closes #816. Adds the transactional native `compileImage()` API for turning one untrusted local image into a verified public-upload artifact set.

## Changes

- Reuses `compileArtifactPlan()` and executes plan outputs sequentially through native file-to-file APIs.
- Snapshots and hashes the source, rejects caller-controlled filenames/staging, and refuses an existing output directory.
- Uses private sibling staging, strict target-byte handling, bounded placeholder data URL generation, streaming artifact verification, deterministic `manifest.json`, and one atomic directory publish.
- Preserves native E400/E300/E301 semantics and exposes phase/artifact context through `ArtifactCompilationError`; abort/failure cleans unpublished staging.
- Adds compiler/build identity fingerprints, CJS/ESM/TypeScript exports, documentation, and contract/security regression tests.

## Validation

- `rustc --test build.rs -o /tmp/lazy-image-build-test && /tmp/lazy-image-build-test` (4 passed)
- `npm run build`
- `node test/integration/artifact-compiler.test.js`
- `npm test` (JS, Rust, and Wasm package suites passed)
- Security specialist review: ALLOW
- TypeScript/API review: ALLOW

## Remaining constraint

The output parent must be trusted and protected from concurrent replacement during compilation; the library does not provide a cross-platform directory no-replace primitive. This PR does not merge the branch.