### PR TITLE
chore(release): prepare 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [1.1.0] - 2026-09-02
+
 ### Added
+- Deterministic `compileArtifactPlan()` policy compilation for responsive
+  artifacts, byte budgets, placeholders, fingerprints, and cache keys.
 - Transactional native `compileImage()` for deterministic public-upload
   artifacts, optional placeholder data URLs, verified hashes, and atomic
   directory publication. Existing output directories are never overwritten.
@@ -598,7 +604,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[Unreleased]: https://github.com/albert-einshutoin/lazy-image/compare/v1.0.1...HEAD
+[Unreleased]: https://github.com/albert-einshutoin/lazy-image/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/albert-einshutoin/lazy-image/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/albert-einshutoin/lazy-image/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/albert-einshutoin/lazy-image/compare/v0.16.0...v1.0.0
 [0.16.0]: https://github.com/albert-einshutoin/lazy-image/compare/v0.15.0...v0.16.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "lazy-image"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "bitflags",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lazy-image"
-version = "1.0.1"
+version = "1.1.0"
 edition = "2021"
 description = "Web image optimization engine for Node.js with secure defaults and smaller browser-facing JPEG outputs, powered by Rust + mozjpeg"
 license = "MIT"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "lazy-image"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "bitflags",
  "fast_image_resize",

--- a/index.js
+++ b/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-android-arm64')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-android-arm64/package.json').version
-        if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-android-arm-eabi')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-win32-x64-gnu')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-win32-x64-msvc')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-win32-ia32-msvc')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-win32-arm64-msvc')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@alberteinshutoin/lazy-image-darwin-universal')
       const bindingPackageVersion = require('@alberteinshutoin/lazy-image-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-darwin-x64')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-darwin-arm64')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-freebsd-x64')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-freebsd-arm64')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-x64-musl')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-x64-gnu')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-arm64-musl')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-arm64-gnu')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-arm-musleabihf')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-loong64-musl')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-loong64-gnu')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-riscv64-musl')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@alberteinshutoin/lazy-image-linux-riscv64-gnu')
           const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-linux-ppc64-gnu')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-linux-s390x-gnu')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-openharmony-arm64')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-openharmony-x64')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@alberteinshutoin/lazy-image-openharmony-arm')
         const bindingPackageVersion = require('@alberteinshutoin/lazy-image-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '1.0.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.0.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.1.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.1.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alberteinshutoin/lazy-image",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@alberteinshutoin/lazy-image",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "MIT",
       "workspaces": [
         "packages/lazy-image-wasm"
@@ -22,32 +22,32 @@
         "node": ">= 22"
       },
       "optionalDependencies": {
-        "@alberteinshutoin/lazy-image-darwin-arm64": "1.0.1",
-        "@alberteinshutoin/lazy-image-darwin-x64": "1.0.1",
-        "@alberteinshutoin/lazy-image-linux-arm64-gnu": "1.0.1",
-        "@alberteinshutoin/lazy-image-linux-x64-gnu": "1.0.1",
-        "@alberteinshutoin/lazy-image-linux-x64-musl": "1.0.1",
-        "@alberteinshutoin/lazy-image-win32-x64-msvc": "1.0.1"
+        "@alberteinshutoin/lazy-image-darwin-arm64": "1.1.0",
+        "@alberteinshutoin/lazy-image-darwin-x64": "1.1.0",
+        "@alberteinshutoin/lazy-image-linux-arm64-gnu": "1.1.0",
+        "@alberteinshutoin/lazy-image-linux-x64-gnu": "1.1.0",
+        "@alberteinshutoin/lazy-image-linux-x64-musl": "1.1.0",
+        "@alberteinshutoin/lazy-image-win32-x64-msvc": "1.1.0"
       }
     },
     "node_modules/@alberteinshutoin/lazy-image-darwin-arm64": {
-      "version": "1.0.1",
+      "version": "1.1.0",
       "optional": true
     },
     "node_modules/@alberteinshutoin/lazy-image-darwin-x64": {
-      "version": "1.0.1",
+      "version": "1.1.0",
       "optional": true
     },
     "node_modules/@alberteinshutoin/lazy-image-linux-arm64-gnu": {
-      "version": "1.0.1",
+      "version": "1.1.0",
       "optional": true
     },
     "node_modules/@alberteinshutoin/lazy-image-linux-x64-gnu": {
-      "version": "1.0.1",
+      "version": "1.1.0",
       "optional": true
     },
     "node_modules/@alberteinshutoin/lazy-image-linux-x64-musl": {
-      "version": "1.0.1",
+      "version": "1.1.0",
       "optional": true
     },
     "node_modules/@alberteinshutoin/lazy-image-wasm": {
@@ -55,7 +55,7 @@
       "link": true
     },
     "node_modules/@alberteinshutoin/lazy-image-win32-x64-msvc": {
-      "version": "1.0.1",
+      "version": "1.1.0",
       "optional": true
     },
     "node_modules/@emnapi/core": {
@@ -2573,7 +2573,7 @@
     },
     "packages/lazy-image-wasm": {
       "name": "@alberteinshutoin/lazy-image-wasm",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@jsquash/jpeg": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alberteinshutoin/lazy-image",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Web image optimization engine for Node.js with Image Firewall-backed secure upload defaults and smaller JPEG outputs in canonical PNG → JPEG benchmarks, powered by Rust + mozjpeg",
   "main": "index.js",
   "exports": {
@@ -112,12 +112,12 @@
     ]
   },
   "optionalDependencies": {
-    "@alberteinshutoin/lazy-image-darwin-arm64": "1.0.1",
-    "@alberteinshutoin/lazy-image-darwin-x64": "1.0.1",
-    "@alberteinshutoin/lazy-image-linux-x64-gnu": "1.0.1",
-    "@alberteinshutoin/lazy-image-linux-x64-musl": "1.0.1",
-    "@alberteinshutoin/lazy-image-linux-arm64-gnu": "1.0.1",
-    "@alberteinshutoin/lazy-image-win32-x64-msvc": "1.0.1"
+    "@alberteinshutoin/lazy-image-darwin-arm64": "1.1.0",
+    "@alberteinshutoin/lazy-image-darwin-x64": "1.1.0",
+    "@alberteinshutoin/lazy-image-linux-x64-gnu": "1.1.0",
+    "@alberteinshutoin/lazy-image-linux-x64-musl": "1.1.0",
+    "@alberteinshutoin/lazy-image-linux-arm64-gnu": "1.1.0",
+    "@alberteinshutoin/lazy-image-win32-x64-msvc": "1.1.0"
   },
   "engines": {
     "node": ">= 22"

--- a/packages/lazy-image-wasm/package.json
+++ b/packages/lazy-image-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alberteinshutoin/lazy-image-wasm",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Browser and Edge upload-preflight optimizer for lazy-image policy APIs",
   "type": "module",
   "sideEffects": false,

--- a/packages/lazy-image-wasm/shared.js
+++ b/packages/lazy-image-wasm/shared.js
@@ -1,4 +1,4 @@
-export const VERSION = '1.0.1';
+export const VERSION = '1.1.0';
 
 export const ERROR_CATEGORIES = Object.freeze({
   UserError: 'UserError',


### PR DESCRIPTION
## 背景

v1.0.1以降に、決定的なpublic-upload policy compilerとtransactional `compileImage()` executorが`main`へ入りました。既存APIを壊さないadditive APIとしてv1.1.0を準備します。

## 変更前後

- 変更前: root、platform package、Wasm、Cargo、生成loaderは1.0.1
- 変更後: 公開・生成・lockfile上のrelease versionを1.1.0へ同期
- CHANGELOG: `compileArtifactPlan()`と`compileImage()`をv1.1.0のAddedとして確定

## 意思決定

- SemVer上は後方互換の機能追加なのでMINOR release
- `npm run version`を正本としてroot/platform/Cargoを同期
- script対象外のWasm versionと`fuzz/Cargo.lock`だけを明示的に同期
- 新しいrelease automationや依存は追加しない

## 変更内容

- `package.json`と6 platform optional dependenciesを1.1.0へ更新
- root/Wasm `package-lock.json` metadataを1.1.0へ更新
- `Cargo.toml`、root/fuzz `Cargo.lock`を1.1.0へ更新
- Wasm packageと公開`VERSION`定数を1.1.0へ更新
- generated native loaderのversion checkを1.1.0へ更新
- CHANGELOG 1.1.0節とcompare linkを追加

## 検証結果

- `npm ci --ignore-scripts`
- `npm run release:check`
- `node scripts/check-release-policy.js 1.1.0 v1.1.0`
- `cargo metadata --locked --format-version 1`
- `cargo metadata --manifest-path fuzz/Cargo.toml --locked --format-version 1`
- `npm run build`
- `npm test`
- `npm run check:generated-artifacts`（commit後）
- `git diff --check`
- Codex Companion Stop Review Gate: 指摘なし

## 残る制約

`v1.1.0` tag、npm publish、GitHub Release作成はこのPRに含めません。期限切れのnpm tokenが交換され、明示的に公開を進めるまで停止します。
