### PR TITLE
feat(js): add responsive output helpers

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -102,6 +102,7 @@ const meta = inspectFile('input.jpg');
 - JPEG/PNG/WebP/AVIF エンコード
 - ICC / EXIF / GPS オフロード
 - フォーマット別最適化・メトリクス
+- レスポンシブ画像セット / srcset 生成ヘルパー
 - Image Firewall / Rust メモリ安全
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ await .toFile(path, format, quality?)
 await .toBuffer(format, quality?)
 await .encode({ format, quality?, preset?, metrics? })
 await .toResponsiveSet({ widths, format, quality? })
-await .toFilesResponsive('path-{width}.webp', { widths, format, quality? })
+await .toFilesResponsive('path-{width}.webp', { widths, format, quality? }, srcsetPattern?)
 ```
 
 Operations are queued and evaluated once when an output method runs. Use

--- a/README.md
+++ b/README.md
@@ -109,12 +109,14 @@ await ImageEngine.fromPathAsync(path)
 await .toFile(path, format, quality?)
 await .toBuffer(format, quality?)
 await .encode({ format, quality?, preset?, metrics? })
+await .toResponsiveSet({ widths, format, quality? })
+await .toFilesResponsive('path-{width}.webp', { widths, format, quality? })
 ```
 
 Operations are queued and evaluated once when an output method runs. Use
 `clone()` when producing multiple variants from one source. See the
 [full API reference](./docs/API.md) for batch processing, presets, metrics,
-streaming, metadata controls, and error codes.
+streaming, metadata controls, responsive output helpers, and error codes.
 
 ## When to use it
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -93,7 +93,10 @@ console.log(output.srcset);
 
 `widths` must contain positive integers; duplicate values are removed while
 preserving input order. `toFilesResponsive()` requires a `{width}` placeholder
-and returns the generated paths plus a ready-to-use `srcset` string. Each
+and returns the generated paths plus a ready-to-use `srcset` string. When the
+output pattern is an absolute filesystem path, pass a third `srcsetPattern`
+argument (for example, `/images/hero-{width}.webp`) so private filesystem
+paths are never exposed to browsers. Each
 variant is decoded and encoded independently, so CPU and memory scale with the
 number of requested widths. For a privacy-safe artifact set with deterministic
 library-owned names, use `compileImage()` instead.

--- a/docs/API.md
+++ b/docs/API.md
@@ -70,6 +70,34 @@ const bytes = await ImageEngine.fromPath('photo.jpg').toFileWithPreset('thumb.we
 | `processBatchChunked(inputs, outDir, { format, quality?, fastMode?, concurrency?, chunkSize?, onProgress?, signal? })` | Top-level batch helper that splits inputs into native `processBatch()` chunks. Reports progress after each chunk and checks `AbortSignal` before starting the next chunk. |
 | `.clone()` | Clone the engine for multi-output (e.g. same pipeline to JPEG + WebP + AVIF). |
 
+### Responsive output helpers
+
+Use the responsive helpers when a caller needs a small set of variants without
+writing its own `clone()` loop. The input engine is not consumed, and any
+queued operations (for example `grayscale()` or `crop()`) are inherited by
+every variant.
+
+```javascript
+const variants = await ImageEngine.fromPath('hero.jpg').toResponsiveSet({
+  widths: [320, 768, 1280],
+  format: 'webp',
+  quality: 80,
+});
+
+const output = await ImageEngine.fromPath('hero.jpg').toFilesResponsive(
+  'dist/hero-{width}.webp',
+  { widths: [320, 768, 1280], format: 'webp' },
+);
+console.log(output.srcset);
+```
+
+`widths` must contain positive integers; duplicate values are removed while
+preserving input order. `toFilesResponsive()` requires a `{width}` placeholder
+and returns the generated paths plus a ready-to-use `srcset` string. Each
+variant is decoded and encoded independently, so CPU and memory scale with the
+number of requested widths. For a privacy-safe artifact set with deterministic
+library-owned names, use `compileImage()` instead.
+
 ### Transactional public-upload compilation
 
 `compileImage()` is the high-level native Node.js entrypoint for one untrusted

--- a/docs/API.md
+++ b/docs/API.md
@@ -98,8 +98,10 @@ output pattern is an absolute filesystem path, pass a third `srcsetPattern`
 argument (for example, `/images/hero-{width}.webp`) so private filesystem
 paths are never exposed to browsers. Each
 variant is decoded and encoded independently, so CPU and memory scale with the
-number of requested widths. For a privacy-safe artifact set with deterministic
-library-owned names, use `compileImage()` instead.
+number of requested widths. Widths larger than the source image are enlarged;
+there is no `withoutEnlargement` option in this initial helper. For a
+privacy-safe artifact set with deterministic library-owned names, use
+`compileImage()` instead.
 
 ### Transactional public-upload compilation
 

--- a/examples/basic.mjs
+++ b/examples/basic.mjs
@@ -56,6 +56,13 @@ async function runSelfTest() {
     assert(jpegBytes > 0);
     assert(webpBytes > 0);
 
+    const responsive = await ImageEngine.fromPath(inputJpeg).toFilesResponsive(
+      path.join(tmp, 'responsive-{width}.webp'),
+      { widths: [320, 160], format: 'webp' },
+    );
+    assert.deepEqual(responsive.files.map(({ width }) => width), [320, 160]);
+    assert.equal(responsive.files.length, 2);
+
     const meta = inspectFile(inputJpeg);
     assert(meta.width > 0);
     assert(meta.height > 0);
@@ -107,17 +114,24 @@ async function runDemo() {
 
   console.log(`JPEG: ${jpegBytes} bytes, AVIF: ${avifBytes} bytes`);
 
-  // 4. Inspect metadata without decoding
+  // 4. Responsive variants and srcset
+  const responsive = await ImageEngine.fromPath('hero.jpg').toFilesResponsive(
+    'dist/hero-{width}.webp',
+    { widths: [320, 768, 1280], format: 'webp' },
+  );
+  console.log(`srcset: ${responsive.srcset}`);
+
+  // 5. Inspect metadata without decoding
   const meta = inspectFile('input.jpg');
   console.log(`${meta.width}x${meta.height} ${meta.format}`);
 
-  // 5. Presets for common use cases
+  // 6. Presets for common use cases
   const thumbnail = await ImageEngine.fromPath('photo.jpg')
     .toBufferWithPreset('thumbnail');
 
   console.log(`Thumbnail: ${thumbnail.length} bytes`);
 
-  // 6. Crop, rotate, and grayscale
+  // 7. Crop, rotate, and grayscale
   const processed = await ImageEngine.fromPath('photo.jpg')
     .crop(100, 100, 400, 400)
     .rotate(90)
@@ -126,7 +140,7 @@ async function runDemo() {
 
   console.log(`Processed: ${processed.length} bytes`);
 
-  // 7. Encode with metrics
+  // 8. Encode with metrics
   const { data, metrics } = await ImageEngine.fromPath('photo.jpg')
     .resize(600)
     .toBufferWithMetrics('webp', 80);

--- a/examples/basic.mjs
+++ b/examples/basic.mjs
@@ -59,6 +59,7 @@ async function runSelfTest() {
     const responsive = await ImageEngine.fromPath(inputJpeg).toFilesResponsive(
       path.join(tmp, 'responsive-{width}.webp'),
       { widths: [320, 160], format: 'webp' },
+      '/images/responsive-{width}.webp',
     );
     assert.deepEqual(responsive.files.map(({ width }) => width), [320, 160]);
     assert.equal(responsive.files.length, 2);

--- a/index.d.ts
+++ b/index.d.ts
@@ -748,6 +748,30 @@ export interface ArtifactCompilationError extends Error {
 
 export declare function compileImage(options: CompileImageOptions): Promise<ImageArtifactManifest>
 
+export interface ResponsiveVariant {
+  readonly width: number
+  readonly data: Buffer
+  readonly bytes: number
+}
+
+export interface ResponsiveSetOptions {
+  widths: number[]
+  format: OutputFormat
+  quality?: number
+  fastMode?: boolean
+}
+
+export interface ResponsiveFileResult {
+  readonly width: number
+  readonly path: string
+  readonly bytesWritten: number
+}
+
+export interface ResponsiveFilesOutput {
+  files: ResponsiveFileResult[]
+  srcset: string
+}
+
 export interface ResolvedEncodeProfile {
   format: CanonicalOutputFormat
   quality?: number
@@ -760,6 +784,8 @@ export interface ImageEngine {
   toFileProfile(path: string, format: OutputFormat, profile?: EncodeProfile, quality?: number | undefined | null): Promise<number>
   toBufferTargetBytes(format: TargetBytesFormat, options: TargetBytesOptions): Promise<BufferTargetBytesResult>
   toFileTargetBytes(path: string, format: TargetBytesFormat, options: TargetBytesOptions): Promise<FileTargetBytesResult>
+  toResponsiveSet(options: ResponsiveSetOptions): Promise<ResponsiveVariant[]>
+  toFilesResponsive(pattern: string, options: ResponsiveSetOptions): Promise<ResponsiveFilesOutput>
   // Note: encode() / encodeToFile() are declared on the ImageEngine class
   // (see patchIndexDts patches that retype them to EncodeOptionsInput) and
   // are deliberately NOT re-declared here to avoid duplicate signatures.

--- a/index.d.ts
+++ b/index.d.ts
@@ -785,7 +785,7 @@ export interface ImageEngine {
   toBufferTargetBytes(format: TargetBytesFormat, options: TargetBytesOptions): Promise<BufferTargetBytesResult>
   toFileTargetBytes(path: string, format: TargetBytesFormat, options: TargetBytesOptions): Promise<FileTargetBytesResult>
   toResponsiveSet(options: ResponsiveSetOptions): Promise<ResponsiveVariant[]>
-  toFilesResponsive(pattern: string, options: ResponsiveSetOptions): Promise<ResponsiveFilesOutput>
+  toFilesResponsive(pattern: string, options: ResponsiveSetOptions, srcsetPattern?: string): Promise<ResponsiveFilesOutput>
   // Note: encode() / encodeToFile() are declared on the ImageEngine class
   // (see patchIndexDts patches that retype them to EncodeOptionsInput) and
   // are deliberately NOT re-declared here to avoid duplicate signatures.

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -206,6 +206,37 @@ function resolveEncodeProfile(format, profile = 'balanced', quality) {
   };
 }
 
+/** Validate and normalize options shared by responsive output helpers. */
+function normalizeResponsiveOptions(options = {}) {
+  if (options === null || typeof options !== 'object' || Array.isArray(options)) {
+    throw new TypeError('responsive options must be an object');
+  }
+
+  const rawWidths = options.widths;
+  if (!Array.isArray(rawWidths) || rawWidths.length === 0) {
+    throw new Error('widths must be a non-empty array of positive integers');
+  }
+
+  const widths = [...new Set(rawWidths.map((width) => {
+    const normalized = Number(width);
+    if (!Number.isInteger(normalized) || normalized <= 0) {
+      throw new Error('widths must be a non-empty array of positive integers');
+    }
+    return normalized;
+  }))];
+
+  if (options.format == null) {
+    throw new Error('format is required for responsive output');
+  }
+
+  return {
+    widths,
+    format: String(options.format).toLowerCase(),
+    quality: options.quality,
+    fastMode: Boolean(options.fastMode),
+  };
+}
+
 // ---------------------------------------------------------------------------
 // getErrorCategory — needs ErrorCategory / ErrorCode from the native binding.
 // Accepts them as an argument so this module stays decoupled from index.js.
@@ -427,6 +458,29 @@ function attachPrototypeMethods(ImageEngine) {
   p.toFileTargetBytes = async function toFileTargetBytes(path, format, options) {
     return runTargetBytesFileSearch(this, path, format, options);
   };
+
+  p.toResponsiveSet = function toResponsiveSet(options) {
+    const { widths, format, quality, fastMode } = normalizeResponsiveOptions(options);
+    return Promise.all(widths.map(async (width) => {
+      const data = await this.clone().resize(width).toBuffer(format, quality, fastMode);
+      return { width, data, bytes: data.length };
+    }));
+  };
+
+  p.toFilesResponsive = function toFilesResponsive(pattern, options) {
+    if (typeof pattern !== 'string' || !pattern.includes('{width}')) {
+      throw new Error("pattern must contain a {width} placeholder, e.g. 'out-{width}.webp'");
+    }
+    const { widths, format, quality, fastMode } = normalizeResponsiveOptions(options);
+    return Promise.all(widths.map(async (width) => {
+      const filePath = pattern.replaceAll('{width}', String(width));
+      const bytesWritten = await this.clone().resize(width).toFile(filePath, format, quality, fastMode);
+      return { width, path: filePath, bytesWritten };
+    })).then((files) => ({
+      files,
+      srcset: files.map((file) => `${file.path} ${file.width}w`).join(', '),
+    }));
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -443,6 +497,7 @@ module.exports = {
   runTargetBytesSearch,
   runTargetBytesFileSearch,
   resolveEncodeProfile,
+  normalizeResponsiveOptions,
   createGetErrorCategory,
   createProcessBatchChunked,
   attachPrototypeMethods,

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('node:fs');
+const path = require('node:path');
 
 // ---------------------------------------------------------------------------
 // Helper functions extracted from the postbuild-appended JS block.
@@ -467,9 +468,19 @@ function attachPrototypeMethods(ImageEngine) {
     }));
   };
 
-  p.toFilesResponsive = function toFilesResponsive(pattern, options) {
+  p.toFilesResponsive = function toFilesResponsive(pattern, options, srcsetPattern) {
     if (typeof pattern !== 'string' || !pattern.includes('{width}')) {
       throw new Error("pattern must contain a {width} placeholder, e.g. 'out-{width}.webp'");
+    }
+    const isAbsoluteFilesystemPath = path.isAbsolute(pattern) || /^[A-Za-z]:[\\/]/.test(pattern) || pattern.startsWith('\\\\');
+    if (srcsetPattern == null) {
+      if (isAbsoluteFilesystemPath) {
+        throw new Error('srcsetPattern is required when pattern is an absolute filesystem path');
+      }
+      srcsetPattern = pattern;
+    }
+    if (typeof srcsetPattern !== 'string' || !srcsetPattern.includes('{width}')) {
+      throw new Error("srcsetPattern must contain a {width} placeholder, e.g. '/images/out-{width}.webp'");
     }
     const { widths, format, quality, fastMode } = normalizeResponsiveOptions(options);
     return Promise.all(widths.map(async (width) => {
@@ -478,7 +489,7 @@ function attachPrototypeMethods(ImageEngine) {
       return { width, path: filePath, bytesWritten };
     })).then((files) => ({
       files,
-      srcset: files.map((file) => `${file.path} ${file.width}w`).join(', '),
+      srcset: files.map((file) => `${srcsetPattern.replaceAll('{width}', String(file.width))} ${file.width}w`).join(', '),
     }));
   };
 }

--- a/scripts/postbuild-fixup.js
+++ b/scripts/postbuild-fixup.js
@@ -235,7 +235,7 @@ export interface ImageEngine {
   toBufferTargetBytes(format: TargetBytesFormat, options: TargetBytesOptions): Promise<BufferTargetBytesResult>
   toFileTargetBytes(path: string, format: TargetBytesFormat, options: TargetBytesOptions): Promise<FileTargetBytesResult>
   toResponsiveSet(options: ResponsiveSetOptions): Promise<ResponsiveVariant[]>
-  toFilesResponsive(pattern: string, options: ResponsiveSetOptions): Promise<ResponsiveFilesOutput>
+  toFilesResponsive(pattern: string, options: ResponsiveSetOptions, srcsetPattern?: string): Promise<ResponsiveFilesOutput>
   // Note: encode() / encodeToFile() are declared on the ImageEngine class
   // (see patchIndexDts patches that retype them to EncodeOptionsInput) and
   // are deliberately NOT re-declared here to avoid duplicate signatures.

--- a/scripts/postbuild-fixup.js
+++ b/scripts/postbuild-fixup.js
@@ -198,6 +198,30 @@ export interface ArtifactCompilationError extends Error {
 
 export declare function compileImage(options: CompileImageOptions): Promise<ImageArtifactManifest>
 
+export interface ResponsiveVariant {
+  readonly width: number
+  readonly data: Buffer
+  readonly bytes: number
+}
+
+export interface ResponsiveSetOptions {
+  widths: number[]
+  format: OutputFormat
+  quality?: number
+  fastMode?: boolean
+}
+
+export interface ResponsiveFileResult {
+  readonly width: number
+  readonly path: string
+  readonly bytesWritten: number
+}
+
+export interface ResponsiveFilesOutput {
+  files: ResponsiveFileResult[]
+  srcset: string
+}
+
 export interface ResolvedEncodeProfile {
   format: CanonicalOutputFormat
   quality?: number
@@ -210,6 +234,8 @@ export interface ImageEngine {
   toFileProfile(path: string, format: OutputFormat, profile?: EncodeProfile, quality?: number | undefined | null): Promise<number>
   toBufferTargetBytes(format: TargetBytesFormat, options: TargetBytesOptions): Promise<BufferTargetBytesResult>
   toFileTargetBytes(path: string, format: TargetBytesFormat, options: TargetBytesOptions): Promise<FileTargetBytesResult>
+  toResponsiveSet(options: ResponsiveSetOptions): Promise<ResponsiveVariant[]>
+  toFilesResponsive(pattern: string, options: ResponsiveSetOptions): Promise<ResponsiveFilesOutput>
   // Note: encode() / encodeToFile() are declared on the ImageEngine class
   // (see patchIndexDts patches that retype them to EncodeOptionsInput) and
   // are deliberately NOT re-declared here to avoid duplicate signatures.

--- a/test/integration/responsive.test.js
+++ b/test/integration/responsive.test.js
@@ -46,12 +46,12 @@ async function main() {
     const output = await ImageEngine.fromPath(INPUT).toFilesResponsive(pattern, {
       widths: [64, 32],
       format: 'webp',
-    });
+    }, '/images/image-{width}.webp');
 
     assert.deepEqual(output.files.map(({ width }) => width), [64, 32]);
     assert.equal(
       output.srcset,
-      `${path.join(directory, 'image-64.webp')} 64w, ${path.join(directory, 'image-32.webp')} 32w`,
+      '/images/image-64.webp 64w, /images/image-32.webp 32w',
     );
     for (const file of output.files) {
       assert.equal(file.bytesWritten, (await fs.stat(file.path)).size);
@@ -79,6 +79,10 @@ async function main() {
     () => ImageEngine.fromPath(INPUT).toFilesResponsive('image.webp', { widths: [100], format: 'webp' }),
     /pattern must contain a \{width\} placeholder/,
   );
+  assert.throws(
+    () => ImageEngine.fromPath(INPUT).toFilesResponsive('/tmp/image-{width}.webp', { widths: [100], format: 'webp' }),
+    /srcsetPattern is required when pattern is an absolute filesystem path/,
+  );
 
   const transformed = await ImageEngine.fromPath(INPUT)
     .grayscale()
@@ -96,4 +100,3 @@ main().catch((error) => {
   console.error(error);
   process.exitCode = 1;
 });
-

--- a/test/integration/responsive.test.js
+++ b/test/integration/responsive.test.js
@@ -1,0 +1,99 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+
+const { ImageEngine, inspect } = require('../../index');
+const { resolveFixture } = require('../helpers/paths');
+
+const INPUT = resolveFixture('test_100KB_1057x1057.jpg');
+
+async function withTempDir(run) {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'lazy-image-responsive-'));
+  try {
+    return await run(directory);
+  } finally {
+    await fs.rm(directory, { recursive: true, force: true });
+  }
+}
+
+async function main() {
+  const engine = ImageEngine.fromPath(INPUT);
+  const variants = await engine.toResponsiveSet({
+    widths: [100, 50],
+    format: 'webp',
+  });
+
+  assert.deepEqual(variants.map(({ width }) => width), [100, 50]);
+  for (const variant of variants) {
+    assert.ok(Buffer.isBuffer(variant.data));
+    assert.equal(variant.bytes, variant.data.length);
+    assert.equal(inspect(variant.data).format, 'webp');
+    assert.equal(inspect(variant.data).width, variant.width);
+    assert.equal(inspect(variant.data).height, variant.width);
+  }
+
+  const deduped = await ImageEngine.fromPath(INPUT).toResponsiveSet({
+    widths: [100, 100, 50],
+    format: 'webp',
+  });
+  assert.deepEqual(deduped.map(({ width }) => width), [100, 50]);
+
+  await withTempDir(async (directory) => {
+    const pattern = path.join(directory, 'image-{width}.webp');
+    const output = await ImageEngine.fromPath(INPUT).toFilesResponsive(pattern, {
+      widths: [64, 32],
+      format: 'webp',
+    });
+
+    assert.deepEqual(output.files.map(({ width }) => width), [64, 32]);
+    assert.equal(
+      output.srcset,
+      `${path.join(directory, 'image-64.webp')} 64w, ${path.join(directory, 'image-32.webp')} 32w`,
+    );
+    for (const file of output.files) {
+      assert.equal(file.bytesWritten, (await fs.stat(file.path)).size);
+      assert.equal(inspect(await fs.readFile(file.path)).width, file.width);
+    }
+  });
+
+  assert.throws(
+    () => ImageEngine.fromPath(INPUT).toResponsiveSet({ widths: [], format: 'webp' }),
+    /widths must be a non-empty array of positive integers/,
+  );
+  assert.throws(
+    () => ImageEngine.fromPath(INPUT).toResponsiveSet({ widths: [0], format: 'webp' }),
+    /widths must be a non-empty array of positive integers/,
+  );
+  assert.throws(
+    () => ImageEngine.fromPath(INPUT).toResponsiveSet({ widths: ['a'], format: 'webp' }),
+    /widths must be a non-empty array of positive integers/,
+  );
+  assert.throws(
+    () => ImageEngine.fromPath(INPUT).toResponsiveSet({ widths: [100] }),
+    /format is required for responsive output/,
+  );
+  assert.throws(
+    () => ImageEngine.fromPath(INPUT).toFilesResponsive('image.webp', { widths: [100], format: 'webp' }),
+    /pattern must contain a \{width\} placeholder/,
+  );
+
+  const transformed = await ImageEngine.fromPath(INPUT)
+    .grayscale()
+    .toResponsiveSet({ widths: [80], format: 'jpeg', quality: 80 });
+  assert.equal(inspect(transformed[0].data).width, 80);
+
+  const reusable = ImageEngine.fromPath(INPUT);
+  await reusable.toResponsiveSet({ widths: [80], format: 'webp' });
+  assert.equal(inspect(await reusable.toBuffer('jpeg', 80)).width, 1057);
+
+  console.log('Responsive helper integration tests passed');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});
+

--- a/test/type-safety/typescript-typecheck.test.ts
+++ b/test/type-safety/typescript-typecheck.test.ts
@@ -18,6 +18,9 @@ import {
     PublicUploadPolicy,
     PresetName,
     PresetResult,
+    ResponsiveFilesOutput,
+    ResponsiveSetOptions,
+    ResponsiveVariant,
     ResizeFit,
     processBatchChunked,
 } from '../../index';
@@ -81,6 +84,17 @@ async function testTypeSafety() {
     const coverFit: ResizeFit = 'cover';
     await ImageEngine.fromPath(imagePath).resize(300, 300, coverFit).toBuffer('jpeg', 75);
     await ImageEngine.fromPath(imagePath).resize({ width: 320, fit: coverFit }).toBuffer('jpeg', 75);
+
+    const responsiveOptions: ResponsiveSetOptions = {
+        widths: [320, 640],
+        format: 'webp',
+        quality: 80,
+    };
+    const responsiveVariants: ResponsiveVariant[] = await ImageEngine.fromPath(imagePath)
+        .toResponsiveSet(responsiveOptions);
+    const responsiveFiles: ResponsiveFilesOutput = await ImageEngine.fromPath(imagePath)
+        .toFilesResponsive(path.resolve(__dirname, '../../.tmp/image-{width}.webp'), responsiveOptions);
+    console.log(`Responsive outputs: ${responsiveVariants.length} ${responsiveFiles.files.length}`);
 
     // Uppercase format is also accepted
     await ImageEngine.fromPath(imagePath).toBuffer('JPEG', 80);

--- a/test/type-safety/typescript-typecheck.test.ts
+++ b/test/type-safety/typescript-typecheck.test.ts
@@ -93,7 +93,7 @@ async function testTypeSafety() {
     const responsiveVariants: ResponsiveVariant[] = await ImageEngine.fromPath(imagePath)
         .toResponsiveSet(responsiveOptions);
     const responsiveFiles: ResponsiveFilesOutput = await ImageEngine.fromPath(imagePath)
-        .toFilesResponsive(path.resolve(__dirname, '../../.tmp/image-{width}.webp'), responsiveOptions);
+        .toFilesResponsive(path.resolve(__dirname, '../../.tmp/image-{width}.webp'), responsiveOptions, '/images/image-{width}.webp');
     console.log(`Responsive outputs: ${responsiveVariants.length} ${responsiveFiles.files.length}`);
 
     // Uppercase format is also accepted


### PR DESCRIPTION
## 背景
#697のresponsive出力を、既存のlazy pipelineとclone()から利用できる公開APIとして追加します。

## 変更内容
- `toResponsiveSet({ widths, format, quality?, fastMode? })`を追加
- `toFilesResponsive(pattern, options)`を追加し、ファイル結果とsrcsetを返却
- widthの空配列・不正値・重複、pattern placeholderを同期検証
-各variantをclone()から生成し、元engineと前段操作を保持
- TypeScript型、APIドキュメント、README英日、basic exampleを更新
- responsive統合テストと型テストを追加

## 意思決定
- ネイティブ変更・新規依存は追加せず、既存のresize/toBuffer/toFile/native validationを再利用
- standalone helperは入力順を保持し、format/qualityの詳細検証は既存native経路へ委譲
- privacy-safeで決定的なmanifestが必要な場合は既存のcompileImage()を使用する契約を明記

## 検証
- `npm run build`
- `node test/integration/responsive.test.js`
- `npm run test:types`
- `npm run test:examples`
- `npm test`（JS/Rust/Wasm）

Closes #697

## 残る制約
各variantは独立にdecode/encodeするため、CPUとメモリはwidth数に比例します。native側の共有decode最適化は別Issueです。