### PR TITLE
feat(js): add LQIP placeholder helper

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -103,6 +103,7 @@ const meta = inspectFile('input.jpg');
 - ICC / EXIF / GPS オフロード
 - フォーマット別最適化・メトリクス
 - レスポンシブ画像セット / srcset 生成ヘルパー
+- LQIPプレースホルダ / blurDataURL生成
 - Image Firewall / Rust メモリ安全
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ await .toBuffer(format, quality?)
 await .encode({ format, quality?, preset?, metrics? })
 await .toResponsiveSet({ widths, format, quality? })
 await .toFilesResponsive('path-{width}.webp', { widths, format, quality? })
+await .toPlaceholder({ size?, format?, quality? })
 ```
 
 Operations are queued and evaluated once when an output method runs. Use

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ await .toFile(path, format, quality?)
 await .toBuffer(format, quality?)
 await .encode({ format, quality?, preset?, metrics? })
 await .toResponsiveSet({ widths, format, quality? })
-await .toFilesResponsive('path-{width}.webp', { widths, format, quality? })
+await .toFilesResponsive('path-{width}.webp', { widths, format, quality? }, srcsetPattern?)
 await .toPlaceholder({ size?, format?, quality? })
 ```
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -93,7 +93,10 @@ console.log(output.srcset);
 
 `widths` must contain positive integers; duplicate values are removed while
 preserving input order. `toFilesResponsive()` requires a `{width}` placeholder
-and returns the generated paths plus a ready-to-use `srcset` string. Each
+and returns the generated paths plus a ready-to-use `srcset` string. When the
+output pattern is an absolute filesystem path, pass a third `srcsetPattern`
+argument (for example, `/images/hero-{width}.webp`) so private filesystem
+paths are never exposed to browsers. Each
 variant is decoded and encoded independently, so CPU and memory scale with the
 number of requested widths. For a privacy-safe artifact set with deterministic
 library-owned names, use `compileImage()` instead.

--- a/docs/API.md
+++ b/docs/API.md
@@ -117,10 +117,11 @@ const { dataUrl, width, height, bytes } = await ImageEngine
 // <Image src="/hero.jpg" placeholder="blur" blurDataURL={dataUrl} ... />
 ```
 
-Supported formats are WebP, JPEG, and PNG. PNG is lossless and does not accept
-a quality value. The source engine is not consumed, and the returned `bytes`
-count is measured before base64 conversion. For the privacy-safe placeholder
-inside a deterministic artifact set, use `compileImage()` instead.
+Supported formats are WebP, JPEG, and PNG. PNG is lossless, so `quality` is
+ignored and is not passed to the native encoder. The source engine is not
+consumed, and the returned `bytes` count is measured before base64 conversion.
+For the privacy-safe placeholder inside a deterministic artifact set, use
+`compileImage()` instead.
 
 ### Transactional public-upload compilation
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -98,6 +98,25 @@ variant is decoded and encoded independently, so CPU and memory scale with the
 number of requested widths. For a privacy-safe artifact set with deterministic
 library-owned names, use `compileImage()` instead.
 
+### Placeholder output
+
+`toPlaceholder()` creates a small data URL for UI placeholders such as
+Next.js `blurDataURL`. The long edge defaults to 16 pixels and must be between
+4 and 64 pixels; the source aspect ratio is preserved.
+
+```javascript
+const { dataUrl, width, height, bytes } = await ImageEngine
+  .fromPath('hero.jpg')
+  .toPlaceholder({ format: 'webp', size: 16, quality: 20 });
+
+// <Image src="/hero.jpg" placeholder="blur" blurDataURL={dataUrl} ... />
+```
+
+Supported formats are WebP, JPEG, and PNG. PNG is lossless and does not accept
+a quality value. The source engine is not consumed, and the returned `bytes`
+count is measured before base64 conversion. For the privacy-safe placeholder
+inside a deterministic artifact set, use `compileImage()` instead.
+
 ### Transactional public-upload compilation
 
 `compileImage()` is the high-level native Node.js entrypoint for one untrusted

--- a/examples/basic.mjs
+++ b/examples/basic.mjs
@@ -63,6 +63,11 @@ async function runSelfTest() {
     assert.deepEqual(responsive.files.map(({ width }) => width), [320, 160]);
     assert.equal(responsive.files.length, 2);
 
+    const placeholder = await ImageEngine.fromPath(inputJpeg).toPlaceholder();
+    assert.equal(placeholder.width, 16);
+    assert.equal(placeholder.height, 16);
+    assert.match(placeholder.dataUrl, /^data:image\/webp;base64,/);
+
     const meta = inspectFile(inputJpeg);
     assert(meta.width > 0);
     assert(meta.height > 0);
@@ -121,17 +126,21 @@ async function runDemo() {
   );
   console.log(`srcset: ${responsive.srcset}`);
 
-  // 5. Inspect metadata without decoding
+  // 5. LQIP placeholder for blurDataURL
+  const placeholder = await ImageEngine.fromPath('hero.jpg').toPlaceholder();
+  console.log(`Placeholder: ${placeholder.width}x${placeholder.height} (${placeholder.bytes} bytes)`);
+
+  // 6. Inspect metadata without decoding
   const meta = inspectFile('input.jpg');
   console.log(`${meta.width}x${meta.height} ${meta.format}`);
 
-  // 6. Presets for common use cases
+  // 7. Presets for common use cases
   const thumbnail = await ImageEngine.fromPath('photo.jpg')
     .toBufferWithPreset('thumbnail');
 
   console.log(`Thumbnail: ${thumbnail.length} bytes`);
 
-  // 7. Crop, rotate, and grayscale
+  // 8. Crop, rotate, and grayscale
   const processed = await ImageEngine.fromPath('photo.jpg')
     .crop(100, 100, 400, 400)
     .rotate(90)
@@ -140,7 +149,7 @@ async function runDemo() {
 
   console.log(`Processed: ${processed.length} bytes`);
 
-  // 8. Encode with metrics
+  // 9. Encode with metrics
   const { data, metrics } = await ImageEngine.fromPath('photo.jpg')
     .resize(600)
     .toBufferWithMetrics('webp', 80);

--- a/examples/basic.mjs
+++ b/examples/basic.mjs
@@ -59,6 +59,7 @@ async function runSelfTest() {
     const responsive = await ImageEngine.fromPath(inputJpeg).toFilesResponsive(
       path.join(tmp, 'responsive-{width}.webp'),
       { widths: [320, 160], format: 'webp' },
+      '/images/responsive-{width}.webp',
     );
     assert.deepEqual(responsive.files.map(({ width }) => width), [320, 160]);
     assert.equal(responsive.files.length, 2);

--- a/index.d.ts
+++ b/index.d.ts
@@ -772,6 +772,25 @@ export interface ResponsiveFilesOutput {
   srcset: string
 }
 
+export interface PlaceholderOptions {
+  /** Longest edge in pixels. Defaults to 16 and must be between 4 and 64. */
+  size?: number
+  /** Output format. Defaults to WebP. */
+  format?: 'webp' | 'jpeg' | 'png'
+  /** Quality for lossy formats. Defaults to 20; ignored for PNG. */
+  quality?: number
+}
+
+export interface PlaceholderResult {
+  /** A data URL suitable for an image src or blurDataURL. */
+  dataUrl: string
+  /** Actual encoded dimensions after preserving the source aspect ratio. */
+  width: number
+  height: number
+  /** Encoded bytes before base64 conversion. */
+  bytes: number
+}
+
 export interface ResolvedEncodeProfile {
   format: CanonicalOutputFormat
   quality?: number
@@ -786,6 +805,7 @@ export interface ImageEngine {
   toFileTargetBytes(path: string, format: TargetBytesFormat, options: TargetBytesOptions): Promise<FileTargetBytesResult>
   toResponsiveSet(options: ResponsiveSetOptions): Promise<ResponsiveVariant[]>
   toFilesResponsive(pattern: string, options: ResponsiveSetOptions): Promise<ResponsiveFilesOutput>
+  toPlaceholder(options?: PlaceholderOptions): Promise<PlaceholderResult>
   // Note: encode() / encodeToFile() are declared on the ImageEngine class
   // (see patchIndexDts patches that retype them to EncodeOptionsInput) and
   // are deliberately NOT re-declared here to avoid duplicate signatures.

--- a/index.d.ts
+++ b/index.d.ts
@@ -804,7 +804,7 @@ export interface ImageEngine {
   toBufferTargetBytes(format: TargetBytesFormat, options: TargetBytesOptions): Promise<BufferTargetBytesResult>
   toFileTargetBytes(path: string, format: TargetBytesFormat, options: TargetBytesOptions): Promise<FileTargetBytesResult>
   toResponsiveSet(options: ResponsiveSetOptions): Promise<ResponsiveVariant[]>
-  toFilesResponsive(pattern: string, options: ResponsiveSetOptions): Promise<ResponsiveFilesOutput>
+  toFilesResponsive(pattern: string, options: ResponsiveSetOptions, srcsetPattern?: string): Promise<ResponsiveFilesOutput>
   toPlaceholder(options?: PlaceholderOptions): Promise<PlaceholderResult>
   // Note: encode() / encodeToFile() are declared on the ImageEngine class
   // (see patchIndexDts patches that retype them to EncodeOptionsInput) and

--- a/index.js
+++ b/index.js
@@ -612,5 +612,5 @@ module.exports.resolveEncodeProfile = helpers.resolveEncodeProfile
 module.exports.compileArtifactPlan = compileArtifactPlan
 module.exports.compileImage = compileImage
 if (nativeBinding && nativeBinding.ImageEngine) {
-  helpers.attachPrototypeMethods(nativeBinding.ImageEngine)
+  helpers.attachPrototypeMethods(nativeBinding.ImageEngine, { inspect: nativeBinding.inspect })
 }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -16,6 +16,11 @@ const DEFAULT_QUALITY_BY_FORMAT = {
 
 const TARGET_BYTES_SUPPORTED_FORMATS = new Set(['jpeg', 'jpg', 'webp', 'avif']);
 const DEFAULT_TARGET_BYTES_MIN_QUALITY = 30;
+const PLACEHOLDER_MIME = {
+  webp: 'image/webp',
+  jpeg: 'image/jpeg',
+  png: 'image/png',
+};
 
 const ENCODE_PROFILE_CONFIG = {
   'size-first': {
@@ -237,6 +242,29 @@ function normalizeResponsiveOptions(options = {}) {
   };
 }
 
+/** Validate and normalize standalone placeholder options. */
+function normalizePlaceholderOptions(options = {}) {
+  if (options === null || typeof options !== 'object' || Array.isArray(options)) {
+    throw new TypeError('placeholder options must be an object');
+  }
+
+  const size = options.size ?? 16;
+  if (!Number.isInteger(size) || size < 4 || size > 64) {
+    throw new Error('placeholder size must be an integer between 4 and 64');
+  }
+
+  const format = String(options.format ?? 'webp').toLowerCase();
+  if (!Object.hasOwn(PLACEHOLDER_MIME, format)) {
+    throw new Error("placeholder format must be 'webp', 'jpeg', or 'png'");
+  }
+
+  return {
+    size,
+    format,
+    quality: format === 'png' ? undefined : (options.quality ?? 20),
+  };
+}
+
 // ---------------------------------------------------------------------------
 // getErrorCategory — needs ErrorCategory / ErrorCode from the native binding.
 // Accepts them as an argument so this module stays decoupled from index.js.
@@ -424,7 +452,7 @@ function createProcessBatchChunked(ImageEngine) {
 // ---------------------------------------------------------------------------
 
 /** Attach profile and target-bytes convenience methods to ImageEngine.prototype. */
-function attachPrototypeMethods(ImageEngine) {
+function attachPrototypeMethods(ImageEngine, { inspect } = {}) {
   if (!ImageEngine || !ImageEngine.prototype) return;
   const p = ImageEngine.prototype;
 
@@ -481,6 +509,26 @@ function attachPrototypeMethods(ImageEngine) {
       srcset: files.map((file) => `${file.path} ${file.width}w`).join(', '),
     }));
   };
+
+  p.toPlaceholder = function toPlaceholder(options) {
+    const { size, format, quality } = normalizePlaceholderOptions(options);
+    if (typeof inspect !== 'function') {
+      throw new Error('toPlaceholder requires the native inspect function');
+    }
+
+    return this.clone()
+      .resize({ width: size, height: size, fit: 'inside' })
+      .toBuffer(format, quality)
+      .then((data) => {
+        const metadata = inspect(data);
+        return {
+          dataUrl: `data:${PLACEHOLDER_MIME[format]};base64,${data.toString('base64')}`,
+          width: metadata.width,
+          height: metadata.height,
+          bytes: data.length,
+        };
+      });
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -498,6 +546,7 @@ module.exports = {
   runTargetBytesFileSearch,
   resolveEncodeProfile,
   normalizeResponsiveOptions,
+  normalizePlaceholderOptions,
   createGetErrorCategory,
   createProcessBatchChunked,
   attachPrototypeMethods,

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('node:fs');
+const path = require('node:path');
 
 // ---------------------------------------------------------------------------
 // Helper functions extracted from the postbuild-appended JS block.
@@ -495,9 +496,19 @@ function attachPrototypeMethods(ImageEngine, { inspect } = {}) {
     }));
   };
 
-  p.toFilesResponsive = function toFilesResponsive(pattern, options) {
+  p.toFilesResponsive = function toFilesResponsive(pattern, options, srcsetPattern) {
     if (typeof pattern !== 'string' || !pattern.includes('{width}')) {
       throw new Error("pattern must contain a {width} placeholder, e.g. 'out-{width}.webp'");
+    }
+    const isAbsoluteFilesystemPath = path.isAbsolute(pattern) || /^[A-Za-z]:[\\/]/.test(pattern) || pattern.startsWith('\\\\');
+    if (srcsetPattern == null) {
+      if (isAbsoluteFilesystemPath) {
+        throw new Error('srcsetPattern is required when pattern is an absolute filesystem path');
+      }
+      srcsetPattern = pattern;
+    }
+    if (typeof srcsetPattern !== 'string' || !srcsetPattern.includes('{width}')) {
+      throw new Error("srcsetPattern must contain a {width} placeholder, e.g. '/images/out-{width}.webp'");
     }
     const { widths, format, quality, fastMode } = normalizeResponsiveOptions(options);
     return Promise.all(widths.map(async (width) => {
@@ -506,7 +517,7 @@ function attachPrototypeMethods(ImageEngine, { inspect } = {}) {
       return { width, path: filePath, bytesWritten };
     })).then((files) => ({
       files,
-      srcset: files.map((file) => `${file.path} ${file.width}w`).join(', '),
+      srcset: files.map((file) => `${srcsetPattern.replaceAll('{width}', String(file.width))} ${file.width}w`).join(', '),
     }));
   };
 

--- a/scripts/postbuild-fixup.js
+++ b/scripts/postbuild-fixup.js
@@ -222,6 +222,25 @@ export interface ResponsiveFilesOutput {
   srcset: string
 }
 
+export interface PlaceholderOptions {
+  /** Longest edge in pixels. Defaults to 16 and must be between 4 and 64. */
+  size?: number
+  /** Output format. Defaults to WebP. */
+  format?: 'webp' | 'jpeg' | 'png'
+  /** Quality for lossy formats. Defaults to 20; ignored for PNG. */
+  quality?: number
+}
+
+export interface PlaceholderResult {
+  /** A data URL suitable for an image src or blurDataURL. */
+  dataUrl: string
+  /** Actual encoded dimensions after preserving the source aspect ratio. */
+  width: number
+  height: number
+  /** Encoded bytes before base64 conversion. */
+  bytes: number
+}
+
 export interface ResolvedEncodeProfile {
   format: CanonicalOutputFormat
   quality?: number
@@ -236,6 +255,7 @@ export interface ImageEngine {
   toFileTargetBytes(path: string, format: TargetBytesFormat, options: TargetBytesOptions): Promise<FileTargetBytesResult>
   toResponsiveSet(options: ResponsiveSetOptions): Promise<ResponsiveVariant[]>
   toFilesResponsive(pattern: string, options: ResponsiveSetOptions): Promise<ResponsiveFilesOutput>
+  toPlaceholder(options?: PlaceholderOptions): Promise<PlaceholderResult>
   // Note: encode() / encodeToFile() are declared on the ImageEngine class
   // (see patchIndexDts patches that retype them to EncodeOptionsInput) and
   // are deliberately NOT re-declared here to avoid duplicate signatures.
@@ -442,7 +462,7 @@ module.exports.resolveEncodeProfile = helpers.resolveEncodeProfile
 module.exports.compileArtifactPlan = compileArtifactPlan
 module.exports.compileImage = compileImage
 if (nativeBinding && nativeBinding.ImageEngine) {
-  helpers.attachPrototypeMethods(nativeBinding.ImageEngine)
+  helpers.attachPrototypeMethods(nativeBinding.ImageEngine, { inspect: nativeBinding.inspect })
 }
 `;
     fs.writeFileSync(indexJsPath, content);

--- a/scripts/postbuild-fixup.js
+++ b/scripts/postbuild-fixup.js
@@ -254,7 +254,7 @@ export interface ImageEngine {
   toBufferTargetBytes(format: TargetBytesFormat, options: TargetBytesOptions): Promise<BufferTargetBytesResult>
   toFileTargetBytes(path: string, format: TargetBytesFormat, options: TargetBytesOptions): Promise<FileTargetBytesResult>
   toResponsiveSet(options: ResponsiveSetOptions): Promise<ResponsiveVariant[]>
-  toFilesResponsive(pattern: string, options: ResponsiveSetOptions): Promise<ResponsiveFilesOutput>
+  toFilesResponsive(pattern: string, options: ResponsiveSetOptions, srcsetPattern?: string): Promise<ResponsiveFilesOutput>
   toPlaceholder(options?: PlaceholderOptions): Promise<PlaceholderResult>
   // Note: encode() / encodeToFile() are declared on the ImageEngine class
   // (see patchIndexDts patches that retype them to EncodeOptionsInput) and

--- a/src/engine/resize.rs
+++ b/src/engine/resize.rs
@@ -48,20 +48,24 @@ pub fn calc_resize_dimensions(
             if orig_ratio > target_ratio {
                 // Original image is wider → fit to width
                 let ratio = w as f64 / orig_w as f64;
-                (w, (orig_h as f64 * ratio).round() as u32)
+                let resized_h = (orig_h as f64 * ratio).round() as u32;
+                (w, resized_h.max(1))
             } else {
                 // Original image is taller → fit to height
                 let ratio = h as f64 / orig_h as f64;
-                ((orig_w as f64 * ratio).round() as u32, h)
+                let resized_w = (orig_w as f64 * ratio).round() as u32;
+                (resized_w.max(1), h)
             }
         }
         (Some(w), None) => {
             let ratio = w as f64 / orig_w as f64;
-            (w, (orig_h as f64 * ratio).round() as u32)
+            let resized_h = (orig_h as f64 * ratio).round() as u32;
+            (w, resized_h.max(1))
         }
         (None, Some(h)) => {
             let ratio = h as f64 / orig_h as f64;
-            ((orig_w as f64 * ratio).round() as u32, h)
+            let resized_w = (orig_w as f64 * ratio).round() as u32;
+            (resized_w.max(1), h)
         }
         (None, None) => (orig_w, orig_h),
     }
@@ -485,6 +489,12 @@ mod tests {
         fn test_both_dimensions_same_aspect_ratio() {
             let (w, h) = calc_resize_dimensions(1000, 500, Some(800), Some(400));
             assert_eq!((w, h), (800, 400));
+        }
+
+        #[test]
+        fn test_extreme_aspect_ratio_keeps_short_edge_at_one_pixel() {
+            assert_eq!(calc_resize_dimensions(1000, 1, Some(16), Some(16)), (16, 1));
+            assert_eq!(calc_resize_dimensions(1, 1000, Some(16), Some(16)), (1, 16));
         }
     }
 

--- a/test/integration/placeholder.test.js
+++ b/test/integration/placeholder.test.js
@@ -25,6 +25,12 @@ async function main() {
   assert.equal(landscape.height, 16);
   assert.match(landscape.dataUrl, /^data:image\/jpeg;base64,/);
 
+  const extreme = await ImageEngine.from(
+    await ImageEngine.fromPath(INPUT).resize({ width: 1000, height: 1, fit: 'fill' }).toBuffer('jpeg', 80),
+  ).toPlaceholder();
+  assert.equal(extreme.width, 16);
+  assert.equal(extreme.height, 1);
+
   const png = await ImageEngine.fromPath(INPUT).toPlaceholder({ format: 'png', quality: 1 });
   assert.match(png.dataUrl, /^data:image\/png;base64,/);
   assert.equal(inspect(Buffer.from(png.dataUrl.split(',', 2)[1], 'base64')).format, 'png');
@@ -62,4 +68,3 @@ main().catch((error) => {
   console.error(error);
   process.exitCode = 1;
 });
-

--- a/test/integration/placeholder.test.js
+++ b/test/integration/placeholder.test.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+
+const { ImageEngine, inspect } = require('../../index');
+const { resolveFixture } = require('../helpers/paths');
+
+const INPUT = resolveFixture('test_100KB_1057x1057.jpg');
+
+async function main() {
+  const placeholder = await ImageEngine.fromPath(INPUT).toPlaceholder();
+  assert.match(placeholder.dataUrl, /^data:image\/webp;base64,/);
+  const webp = Buffer.from(placeholder.dataUrl.split(',', 2)[1], 'base64');
+  assert.equal(inspect(webp).format, 'webp');
+  assert.equal(placeholder.width, 16);
+  assert.equal(placeholder.height, 16);
+  assert.equal(placeholder.bytes, webp.length);
+  assert.ok(placeholder.bytes < 2048);
+
+  const landscape = await ImageEngine.from(
+    await ImageEngine.fromPath(INPUT).resize({ width: 500, height: 250, fit: 'fill' }).toBuffer('jpeg', 80),
+  ).toPlaceholder({ size: 32, format: 'jpeg', quality: 20 });
+  assert.equal(landscape.width, 32);
+  assert.equal(landscape.height, 16);
+  assert.match(landscape.dataUrl, /^data:image\/jpeg;base64,/);
+
+  const png = await ImageEngine.fromPath(INPUT).toPlaceholder({ format: 'png', quality: 1 });
+  assert.match(png.dataUrl, /^data:image\/png;base64,/);
+  assert.equal(inspect(Buffer.from(png.dataUrl.split(',', 2)[1], 'base64')).format, 'png');
+
+  assert.throws(
+    () => ImageEngine.fromPath(INPUT).toPlaceholder({ size: 3 }),
+    /placeholder size must be an integer between 4 and 64/,
+  );
+  assert.throws(
+    () => ImageEngine.fromPath(INPUT).toPlaceholder({ size: 65 }),
+    /placeholder size must be an integer between 4 and 64/,
+  );
+  assert.throws(
+    () => ImageEngine.fromPath(INPUT).toPlaceholder({ size: 16.5 }),
+    /placeholder size must be an integer between 4 and 64/,
+  );
+  assert.throws(
+    () => ImageEngine.fromPath(INPUT).toPlaceholder({ format: 'gif' }),
+    /placeholder format must be 'webp', 'jpeg', or 'png'/,
+  );
+  assert.throws(
+    () => ImageEngine.fromPath(INPUT).toPlaceholder(null),
+    /placeholder options must be an object/,
+  );
+
+  const reusable = ImageEngine.fromPath(INPUT);
+  await reusable.toPlaceholder();
+  assert.equal(inspect(await reusable.toBuffer('jpeg', 80)).width, 1057);
+
+  await fs.access(INPUT);
+  console.log('Placeholder helper integration tests passed');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});
+

--- a/test/integration/responsive.test.js
+++ b/test/integration/responsive.test.js
@@ -46,12 +46,12 @@ async function main() {
     const output = await ImageEngine.fromPath(INPUT).toFilesResponsive(pattern, {
       widths: [64, 32],
       format: 'webp',
-    });
+    }, '/images/image-{width}.webp');
 
     assert.deepEqual(output.files.map(({ width }) => width), [64, 32]);
     assert.equal(
       output.srcset,
-      `${path.join(directory, 'image-64.webp')} 64w, ${path.join(directory, 'image-32.webp')} 32w`,
+      '/images/image-64.webp 64w, /images/image-32.webp 32w',
     );
     for (const file of output.files) {
       assert.equal(file.bytesWritten, (await fs.stat(file.path)).size);
@@ -79,6 +79,10 @@ async function main() {
     () => ImageEngine.fromPath(INPUT).toFilesResponsive('image.webp', { widths: [100], format: 'webp' }),
     /pattern must contain a \{width\} placeholder/,
   );
+  assert.throws(
+    () => ImageEngine.fromPath(INPUT).toFilesResponsive('/tmp/image-{width}.webp', { widths: [100], format: 'webp' }),
+    /srcsetPattern is required when pattern is an absolute filesystem path/,
+  );
 
   const transformed = await ImageEngine.fromPath(INPUT)
     .grayscale()
@@ -96,4 +100,3 @@ main().catch((error) => {
   console.error(error);
   process.exitCode = 1;
 });
-

--- a/test/type-safety/typescript-typecheck.test.ts
+++ b/test/type-safety/typescript-typecheck.test.ts
@@ -15,6 +15,8 @@ import {
     ImageArtifactManifest,
     ImageMetadata,
     OutputFormat,
+    PlaceholderOptions,
+    PlaceholderResult,
     PublicUploadPolicy,
     PresetName,
     PresetResult,
@@ -95,6 +97,11 @@ async function testTypeSafety() {
     const responsiveFiles: ResponsiveFilesOutput = await ImageEngine.fromPath(imagePath)
         .toFilesResponsive(path.resolve(__dirname, '../../.tmp/image-{width}.webp'), responsiveOptions);
     console.log(`Responsive outputs: ${responsiveVariants.length} ${responsiveFiles.files.length}`);
+
+    const placeholderOptions: PlaceholderOptions = { size: 16, format: 'webp', quality: 20 };
+    const placeholder: PlaceholderResult = await ImageEngine.fromPath(imagePath)
+        .toPlaceholder(placeholderOptions);
+    console.log(`Placeholder: ${placeholder.width}x${placeholder.height} ${placeholder.bytes}`);
 
     // Uppercase format is also accepted
     await ImageEngine.fromPath(imagePath).toBuffer('JPEG', 80);

--- a/test/type-safety/typescript-typecheck.test.ts
+++ b/test/type-safety/typescript-typecheck.test.ts
@@ -95,7 +95,7 @@ async function testTypeSafety() {
     const responsiveVariants: ResponsiveVariant[] = await ImageEngine.fromPath(imagePath)
         .toResponsiveSet(responsiveOptions);
     const responsiveFiles: ResponsiveFilesOutput = await ImageEngine.fromPath(imagePath)
-        .toFilesResponsive(path.resolve(__dirname, '../../.tmp/image-{width}.webp'), responsiveOptions);
+        .toFilesResponsive(path.resolve(__dirname, '../../.tmp/image-{width}.webp'), responsiveOptions, '/images/image-{width}.webp');
     console.log(`Responsive outputs: ${responsiveVariants.length} ${responsiveFiles.files.length}`);
 
     const placeholderOptions: PlaceholderOptions = { size: 16, format: 'webp', quality: 20 };

--- a/tests/edge_cases.rs
+++ b/tests/edge_cases.rs
@@ -181,7 +181,7 @@ mod large_image_tests {
     fn test_calc_resize_extreme_aspect_ratio() {
         // 極端なアスペクト比でのリサイズ計算
         let (w, h) = calc_resize_dimensions(32768, 1, Some(100), None);
-        assert_eq!((w, h), (100, 0));
+        assert_eq!((w, h), (100, 1));
     }
 }
 
@@ -438,11 +438,9 @@ mod extreme_aspect_ratio_tests {
             height: None,
             fit: ResizeFit::Inside,
         }];
-        let result = apply_ops(Cow::Owned(img), &ops);
-        assert!(
-            result.is_err(),
-            "Expect resize to report error for extreme aspect ratio producing zero height"
-        );
+        let result =
+            apply_ops(Cow::Owned(img), &ops).expect("short edge should clamp to one pixel");
+        assert_eq!(result.dimensions(), (100, 1));
     }
 
     #[test]
@@ -456,11 +454,9 @@ mod extreme_aspect_ratio_tests {
             height: Some(100),
             fit: ResizeFit::Inside,
         }];
-        let result = apply_ops(Cow::Owned(img), &ops);
-        assert!(
-            result.is_err(),
-            "Expect resize to report error for extreme aspect ratio producing zero width"
-        );
+        let result =
+            apply_ops(Cow::Owned(img), &ops).expect("short edge should clamp to one pixel");
+        assert_eq!(result.dimensions(), (1, 100));
     }
 }
 


### PR DESCRIPTION
## 背景
#698のLQIP生成を、既存のlazy pipelineから利用できる`toPlaceholder()`として追加します。PR1（#823）のresponsive helperを親にした差分です。

## 変更内容
- `toPlaceholder({ size?, format?, quality? })`を追加
- 4〜64pxのサイズ検証、WebP/JPEG/PNGの形式検証を同期実行
- 長辺サイズとアスペクト比を維持し、`data:image/...;base64`を返却
- `bytes`はbase64変換前のencoded bytesを返却
- PNGにはqualityを渡さず、nativeの既存契約を維持
- 共有のresize dimension計算で、極端なアスペクト比の短辺を最低1pxにclamp
- native `inspect`を注入して実寸を取得
- TypeScript型、API/README英日、basic example、統合/型テストを更新

## 意思決定
- 新規runtime依存は追加せず、共有nativeのresize dimension計算を1px clampへ修正
- `clone()`で元engineを消費しない
- 決定的なprivacy-safe artifact setは既存`compileImage()`が担当し、standalone helperはUI向けdata URLに限定

## 検証
- `npm run build`
- `node test/integration/placeholder.test.js`
- `npm run test:types`
- `npm run test:examples`
- `npm test`（JS/Rust/Wasm）

Closes #698

## 残る制約
blurhash/thumbhash、dominant color、blur処理自体は対象外です。placeholderは各呼び出しで独立にdecode/encodeします。