### PR TITLE
docs: finalize v1.2.0 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.2.0]
+## [1.2.0] - 2026-09-05
 
 ### Added
 - Added `toResponsiveSet()` and `toFilesResponsive()` for generating

--- a/docs/VERSIONING_PLAN.md
+++ b/docs/VERSIONING_PLAN.md
@@ -1,6 +1,6 @@
 # 📋 Versioning Plan & Priorities
 
-> **Current package version**: v1.2.0 (release preparation)
+> **Current package version**: v1.2.0
 > **Working baseline**: `main`
 
 このドキュメントは、古い issue 番号ベースの固定計画ではなく、`main` の現状に合った優先順位を簡潔に示します。


### PR DESCRIPTION
## 背景

v1.2.0のタグ作成前に、リリース日とバージョン計画の準備中表記を確定します。

## 変更前後

- CHANGELOGのv1.2.0に実リリース日が未記載
- VERSIONING_PLANがrelease preparation表記のまま
- 変更後は2026-09-05のリリース日と正式なv1.2.0表記になります

## 意思決定

実装・公開契約は変更せず、タグ対象コミットに必要な文書メタデータだけを更新しました。

## 変更内容

- CHANGELOG.md: v1.2.0のリリース日を2026-09-05に確定
- docs/VERSIONING_PLAN.md: release preparation表記を削除

## 検証結果

- npm run release:check -- 1.2.0 v1.2.0
- npm run build
- npm test
- git diff --check
- 高リスク最終レビュー: 指摘なし

## 残る制約

npm公開はv1.2.0タグのHosted CIで実行します。NPM_TOKENの有効期限は2026-09-05です。
