### PR TITLE
fix: compileImage() の透明AVIF成果物を安全に検証する

### DIFF
--- a/lib/artifact-compiler.js
+++ b/lib/artifact-compiler.js
@@ -868,16 +868,19 @@ async function parseWebpContainer(reader, rejectPrivacy) {
 
 const AVIF_ALLOWED = {
   top: new Set(['ftyp', 'meta', 'mdat']),
-  meta: new Set(['hdlr', 'pitm', 'iloc', 'iinf', 'iprp']),
+  meta: new Set(['hdlr', 'pitm', 'iloc', 'iinf', 'iref', 'iprp']),
   iinf: new Set(['infe']),
   iprp: new Set(['ipco', 'ipma']),
-  ipco: new Set(['ispe', 'pixi', 'av1C', 'colr']),
+  ipco: new Set(['ispe', 'pixi', 'av1C', 'colr', 'auxC']),
 };
 const AVIF_FORBIDDEN = new Set(['Exif', 'xml ', 'XMP ', 'mime', 'uuid']);
 const AVIF_ITEM_FORBIDDEN = [Buffer.from('Exif'), Buffer.from('mime'), Buffer.from('xml '), Buffer.from('XMP ')];
 const AVIF_FTYP_PAYLOAD = Buffer.from('6176696600000000617669666d6966316d6961664d413142', 'hex');
 const AVIF_HANDLER = Buffer.from('0000000000000000706963740000000000000000000000006c69626176696600', 'hex');
 const AVIF_ITEM = Buffer.from('020000000001000061763031436f6c6f7200', 'hex');
+const AVIF_ALPHA_ITEM = Buffer.from('020000000002000061763031416c70686100', 'hex');
+const AVIF_ALPHA_REFERENCE = Buffer.from('000000000000000e6175786c000200010001', 'hex');
+const AVIF_ALPHA_PROPERTY = Buffer.concat([Buffer.alloc(4), Buffer.from('urn:mpeg:mpegB:cicp:systems:auxiliary:alpha\0')]);
 const AVIF_IPMA_BASE_ASSOCIATIONS = Buffer.from([1, 2, 0x83, 4]);
 
 async function readAvifBox(reader, fileSize) {
@@ -902,12 +905,15 @@ async function readAvifBox(reader, fileSize) {
 
 async function parseAvifBoxesStream(reader, fileSize, end, state, rejectPrivacy, context = 'top', depth = 0) {
   if (depth > 12) return false;
+  const types = [];
   while (reader.position < end) {
     const box = await readAvifBox(reader, fileSize);
     if (!box || box.end > end) return false;
     if (!AVIF_ALLOWED[context] || !AVIF_ALLOWED[context].has(box.type) || AVIF_FORBIDDEN.has(box.type)) {
       throw privacyFailure();
     }
+    types.push(box.type);
+    if (types.length > 8) throw privacyFailure();
     if (box.type === 'ftyp') {
       if (box.payload !== AVIF_FTYP_PAYLOAD.length) throw privacyFailure();
       const data = await reader.read(box.payload);
@@ -921,11 +927,22 @@ async function parseAvifBoxesStream(reader, fileSize, end, state, rejectPrivacy,
       if (data.length !== 6 || data.readUInt32BE(0) !== 0 || data.readUInt16BE(4) !== 1) throw privacyFailure();
     } else if (box.type === 'iloc') {
       const data = await reader.read(box.payload);
-      if (data.length !== 22 || data.readUInt32BE(0) !== 0 || data[4] !== 0x44 || data[5] !== 0
-        || data.readUInt16BE(6) !== 1 || data.readUInt16BE(8) !== 1 || data.readUInt16BE(10) !== 0
-        || data.readUInt16BE(12) !== 1) throw privacyFailure();
-      state.extent = { offset: data.readUInt32BE(14), length: data.readUInt32BE(18) };
-      if (state.extent.offset < 1 || state.extent.length < 1) throw privacyFailure();
+      if (data.length < 8 || data.readUInt32BE(0) !== 0 || data[4] !== 0x44 || data[5] !== 0) throw privacyFailure();
+      state.itemCount = data.readUInt16BE(6);
+      if (![1, 2].includes(state.itemCount) || data.length !== 8 + 14 * state.itemCount) throw privacyFailure();
+      state.extents = [];
+      for (let i = 0; i < state.itemCount; i += 1) {
+        const start = 8 + 14 * i;
+        if (data.readUInt16BE(start) !== i + 1 || data.readUInt16BE(start + 2) !== 0
+          || data.readUInt16BE(start + 4) !== 1) throw privacyFailure();
+        const extent = { offset: data.readUInt32BE(start + 6), length: data.readUInt32BE(start + 10) };
+        if (extent.offset < 1 || extent.length < 1) throw privacyFailure();
+        state.extents.push(extent);
+      }
+    } else if (box.type === 'iref') {
+      if (state.itemCount !== 2 || !(await reader.read(box.payload)).equals(AVIF_ALPHA_REFERENCE)) throw privacyFailure();
+    } else if (box.type === 'auxC') {
+      if (state.itemCount !== 2 || !(await reader.read(box.payload)).equals(AVIF_ALPHA_PROPERTY)) throw privacyFailure();
     } else if (box.type === 'ispe') {
       if (box.payload !== 12) return false;
       const data = await reader.read(12);
@@ -934,14 +951,18 @@ async function parseAvifBoxesStream(reader, fileSize, end, state, rejectPrivacy,
       state.height = data.readUInt32BE(8);
     } else if (box.type === 'pixi') {
       const data = await reader.read(box.payload);
-      if (data.length !== 8 || data.readUInt32BE(0) !== 0 || data[4] !== 3 || data[5] !== 8
-        || data[6] !== 8 || data[7] !== 8) throw privacyFailure();
+      const alpha = types.filter((type) => type === 'pixi').length === 2;
+      const expected = alpha ? [0, 0, 0, 0, 1, 8] : [0, 0, 0, 0, 3, 8, 8, 8];
+      if (!data.equals(Buffer.from(expected))) throw privacyFailure();
     } else if (box.type === 'av1C') {
       const data = await reader.read(box.payload);
-      if (!data.equals(Buffer.from([0x81, 0x1f, 0x0c, 0x00]))) throw privacyFailure();
+      const alpha = types.filter((type) => type === 'av1C').length === 2;
+      if (!data.equals(Buffer.from([0x81, 0x1f, alpha ? 0x1c : 0x0c, 0x00]))) throw privacyFailure();
     } else if (box.type === 'colr') {
       if (box.payload < 4) return false;
       const colourType = (await reader.read(4)).toString('ascii');
+      if (state.colourTypes.has(colourType)) throw privacyFailure();
+      state.colourTypes.add(colourType);
       if (colourType === 'prof') {
         if (box.payload - 4 > MAX_ICC_BYTES) throw privacyFailure();
         recordIccProfile(state, await reader.read(box.payload - 4), rejectPrivacy);
@@ -953,15 +974,18 @@ async function parseAvifBoxesStream(reader, fileSize, end, state, rejectPrivacy,
       }
     } else if (box.type === 'infe') {
       const data = await reader.read(box.payload);
-      if (!data.equals(AVIF_ITEM) || AVIF_ITEM_FORBIDDEN.some((marker) => data.includes(marker))) throw privacyFailure();
+      if (!data.equals(types.length === 1 ? AVIF_ITEM : AVIF_ALPHA_ITEM) || AVIF_ITEM_FORBIDDEN.some((marker) => data.includes(marker))) throw privacyFailure();
     } else if (box.type === 'ipma') {
       const data = await reader.read(box.payload);
       const associations = state.iccOutcome === 'preserved'
         ? Buffer.concat([AVIF_IPMA_BASE_ASSOCIATIONS, Buffer.from([5])])
         : AVIF_IPMA_BASE_ASSOCIATIONS;
-      if (data.length !== 11 + associations.length || data.readUInt32BE(0) !== 0 || data.readUInt32BE(4) !== 1
-        || data.readUInt16BE(8) !== 1 || data[10] !== associations.length
-        || !data.subarray(11).equals(associations)) throw privacyFailure();
+      const colorEntry = Buffer.concat([Buffer.from([0, 1, associations.length]), associations]);
+      const alphaEntry = state.itemCount === 2
+        ? Buffer.from([0, 2, 4, 1, associations.length + 1, 0x80 | (associations.length + 2), associations.length + 3])
+        : Buffer.alloc(0);
+      const expected = Buffer.concat([Buffer.from([0, 0, 0, 0, 0, 0, 0, state.itemCount]), colorEntry, alphaEntry]);
+      if (!data.equals(expected)) throw privacyFailure();
     } else if (box.type === 'mdat') {
       if (state.mdat) throw privacyFailure();
       state.mdat = { offset: reader.position, length: box.payload };
@@ -973,23 +997,40 @@ async function parseAvifBoxesStream(reader, fileSize, end, state, rejectPrivacy,
       } else if (box.type === 'iinf') {
         if (box.payload < 6) return false;
         const fullbox = await reader.read(4);
-        if (fullbox.readUInt32BE(0) !== 0 || (await reader.u16be()) !== 1) return false;
+        if (fullbox.readUInt32BE(0) !== 0 || (await reader.u16be()) !== state.itemCount) return false;
       }
       const childContext = box.type;
       if (!await parseAvifBoxesStream(reader, fileSize, box.end, state, rejectPrivacy, childContext, depth + 1)) return false;
     }
     if (reader.position !== box.end) return false;
   }
+  // Accept only the native encoder's color/optional-alpha graph. Extra boxes,
+  // duplicate properties and unreferenced items must not bypass privacy checks.
+  const expectedTypes = {
+    top: ['ftyp', 'meta', 'mdat'],
+    meta: ['hdlr', 'pitm', 'iloc', 'iinf', ...(state.itemCount === 2 ? ['iref'] : []), 'iprp'],
+    iinf: Array(state.itemCount).fill('infe'),
+    iprp: ['ipco', 'ipma'],
+    ipco: ['ispe', 'pixi', 'av1C', 'colr', ...(state.iccOutcome === 'preserved' ? ['colr'] : []),
+      ...(state.itemCount === 2 ? ['pixi', 'av1C', 'auxC'] : [])],
+  };
+  if (types.join(',') !== expectedTypes[context].join(',')) throw privacyFailure();
   return reader.position === end;
 }
 
 async function parseAvifContainer(reader, rejectPrivacy) {
-  const state = { iccOutcome: 'absent' };
+  const state = { iccOutcome: 'absent', colourTypes: new Set() };
   const complete = await parseAvifBoxesStream(reader, reader.size, reader.size, state, rejectPrivacy);
-  const extentMatchesData = state.extent && state.mdat
-    && state.extent.offset === state.mdat.offset
-    && state.extent.length === state.mdat.length;
-  return { complete: complete && Boolean(state.ftyp && extentMatchesData), ...state, isAnimated: false };
+  // Alpha is written before color. Extents must cover mdat exactly, without
+  // gaps, overlap or unused bytes that could conceal unverified metadata.
+  const extents = state.extents ? [...state.extents].reverse() : [];
+  let nextOffset = state.mdat && state.mdat.offset;
+  const extentMatchesData = extents.length > 0 && state.mdat && extents.every((extent) => {
+    if (extent.offset !== nextOffset) return false;
+    nextOffset += extent.length;
+    return true;
+  }) && nextOffset === state.mdat.offset + state.mdat.length;
+  return { complete: complete && Boolean(state.ftyp && extentMatchesData && state.colourTypes.has('nclx')), ...state, isAnimated: false };
 }
 
 async function inspectAvifFile(filePath, signal) {

--- a/test/integration/artifact-compiler-alpha.test.js
+++ b/test/integration/artifact-compiler-alpha.test.js
@@ -1,0 +1,94 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+const sharp = require('sharp');
+const { ImageEngine, compileImage } = require('../../index');
+const { createRgbaPng } = require('../helpers/png-helpers');
+
+async function main() {
+  const parent = await fs.mkdtemp(path.join(os.tmpdir(), 'lazy-image-alpha-'));
+  try {
+    for (const [format, alpha, icc] of [['png', 128, false], ['webp', 128, false], ['png', 0, false], ['png', 255, false], ['png', 128, true]]) {
+      const inputPath = path.join(parent, `input-${alpha}-${icc}.${format}`);
+      let png = createRgbaPng(32, 24, [255, 0, 0, alpha]);
+      if (icc) {
+        png = await sharp(png).withIccProfile('srgb').png().toBuffer();
+      }
+      await fs.writeFile(inputPath, format === 'png' ? png : await ImageEngine.from(png).toBuffer('webp', 80, false));
+      const outputDir = path.join(parent, `output-${format}-${alpha}-${icc}`);
+      const manifest = await compileImage({ inputPath, outputDir,
+        policy: { widths: [32], formats: icc ? ['avif'] : ['webp', 'avif'], placeholder: false } });
+      assert.equal(manifest.artifacts.length, icc ? 1 : 2);
+      for (const artifact of manifest.artifacts) {
+        const { data, info } = await sharp(path.join(outputDir, artifact.path)).raw().toBuffer({ resolveWithObject: true })
+          .catch((error) => { throw new Error(`${format}/${alpha}/${icc}/${artifact.format}: ${error.message}`); });
+        assert.equal(info.channels, alpha === 255 ? 3 : 4);
+        assert.equal(artifact.iccOutcome, icc ? 'preserved' : 'absent');
+        assert.equal(info.width, 32);
+        assert.equal(info.height, 24);
+        if (alpha !== 255) for (let i = 3; i < data.length; i += 4) assert.ok(Math.abs(data[i] - alpha) <= 1);
+      }
+    }
+
+    const inputPath = path.join(parent, 'input-128-false.png');
+    const mutations = [
+      ['alpha-item-id', 'infe', 1, (b, o) => b.writeUInt16BE(3, o + 8)],
+      ['alpha-item-type', 'infe', 1, (b, o) => b.write('Exif', o + 12)],
+      ['alpha-name', 'infe', 1, (b, o) => b.write('GPS!!', o + 16)],
+      ['aux-target', 'auxl', 0, (b, o) => b.writeUInt16BE(2, o + 8)],
+      ['aux-source', 'auxl', 0, (b, o) => b.writeUInt16BE(1, o + 4)],
+      ['aux-property', 'auxC', 0, (b, o) => { b[o + 10] ^= 1; }],
+      ['alpha-channels', 'pixi', 1, (b, o) => { b[o + 8] = 3; }],
+      ['alpha-config', 'av1C', 1, (b, o) => { b[o + 6] = 0x0c; }],
+      ['alpha-association', 'ipma', 0, (b, o) => { b[o + 24] = 0x83; }],
+      ['extent-swap', 'iloc', 0, (b, o) => {
+        const color = Buffer.from(b.subarray(o + 18, o + 26));
+        b.copy(b, o + 18, o + 32, o + 40);
+        color.copy(b, o + 32);
+      }],
+      ['extent-overlap', 'iloc', 0, (b, o) => b.writeUInt32BE(b.readUInt32BE(o + 18), o + 32)],
+      ['extent-gap', 'iloc', 0, (b, o) => b.writeUInt32BE(b.readUInt32BE(o + 32) + 1, o + 32)],
+      ['extent-oob', 'iloc', 0, (b, o) => b.writeUInt32BE(0xffffffff, o + 32)],
+      ['extent-length', 'iloc', 0, (b, o) => b.writeUInt32BE(0xffffffff, o + 36)],
+      ['item-count', 'iinf', 0, (b, o) => b.writeUInt16BE(1, o + 8)],
+      ['unknown-box', 'auxC', 0, (b, o) => b.write('junk', o)],
+      ['truncated-box', 'auxC', 0, (b, o) => b.writeUInt32BE(7, o - 4)],
+      ['missing-reference', 'iref', 0, (b, o) => b.write('iprp', o)],
+    ];
+    for (const [name, type, occurrence, mutate] of mutations) {
+      const outputDir = path.join(parent, name);
+      const original = ImageEngine.prototype.toFileWithMetrics;
+      let injected = false;
+      ImageEngine.prototype.toFileWithMetrics = async function (...args) {
+        const result = await original.apply(this, args);
+        if (args[1] === 'avif') {
+          const data = await fs.readFile(args[0]);
+          let offset = -1;
+          for (let i = 0; i <= occurrence; i += 1) offset = data.indexOf(Buffer.from(type), offset + 1);
+          assert.ok(offset >= 0, name);
+          mutate(data, offset);
+          await fs.writeFile(args[0], data);
+          injected = true;
+        }
+        return result;
+      };
+      try {
+        await assert.rejects(() => compileImage({ inputPath, outputDir,
+          policy: { widths: [32], formats: ['webp', 'avif'], placeholder: false } }),
+        (error) => error.phase === 'verification' && error.errorCode === 'E900', name);
+        assert.ok(injected, name);
+        assert.equal(await fs.stat(outputDir).catch(() => null), null, name);
+        assert.deepEqual((await fs.readdir(parent)).filter((entry) => entry.includes('staging')), [], name);
+      } finally {
+        ImageEngine.prototype.toFileWithMetrics = original;
+      }
+    }
+  } finally {
+    await fs.rm(parent, { recursive: true, force: true });
+  }
+}
+main().then(() => console.log('artifact compiler alpha contract passed'), (error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Description

透明PNG/WebPを `compileImage()` でAVIFに変換すると、nativeのencodeは成功しても、単一itemを前提にした成果物検証がE900で失敗していました。nativeが生成するcolorと任意のalpha itemを検証し、透明AVIFを公開できるようにします。

## Related Issue

Fixes #827

## Type of Change

- [x] 🐛 Bug fix
- [x] 🧪 Tests

## Changes Made

- alpha itemの宣言、補助参照、propertyとassociationを既存のAVIF検証経路で確認します。ICC有無によるproperty indexの変化も扱います。
- itemごとのextentがnativeのalpha→color順でmdat全体を覆うことを要求し、入れ替え・重複・隙間・範囲外を拒否します。
- box構成を限定し、未知の構造・禁止metadataを引き続きfail-closedで拒否します。
- 半透明・完全透明・不透明・ICC付きAVIFと複数format出力を独立decoderで確認し、不正構造18ケースで失敗時の非公開・staging cleanupを検証します。

## Testing

以下はローカルで成功しています。

```bash
node test/integration/artifact-compiler-alpha.test.js
node test/integration/artifact-compiler.test.js
npm run build
npm test
```

`npm test` はJS統合34ファイル、型、pack、規約、サンプル、Rust、Wasmを含みます。共有npmキャッシュの権限とsandboxのloopback待受制限で停止した試行は、書き込み可能なキャッシュとローカル待受権限を使って再実行し、最終exit 0を確認しました。テストの無効化・抑制はしていません。

専門レビューで指摘されたextent入れ替えの検証漏れを修正し、最終レビューは承認済み。Companion Stop GateもALLOWです。Hosted CIはPR上で確認します。

## Checklist

- [x] Self-reviewおよび専門レビューを実施
- [x] 非自明な検証制約をコメントで説明
- [x] 修正を確認する回帰テストを追加
- [x] 新規・既存テストがローカルで成功
- [x] runtime依存・公開API・生成物の変更なし

## Performance Impact

AVIFの限定された1〜2 itemを検証します。性能改善を主張する変更ではなく、別Issue #828のJPEG I/O修正は含めません。

## Additional Notes

検証対象は現在のnative encoderが生成するAVIF構造です。任意のAVIF入力対応や汎用parserへの拡張ではありません。

別の未修正事項として、native v1.2.0のpublic-upload経路で透明＋ICC付きWebPを生成するとsharpがcorrupt headerを報告する症状を確認しています。変更したAVIF parserを介さず再現します。本PRのICC付きケースはAVIFを、複数formatケースはICCなしの透明入力を検証します。
