### PR TITLE
fix: distinguish absent and unknown EXIF orientation (#829)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -416,7 +416,10 @@ export interface ImageMetadata {
   hasAlpha: boolean
   /** Whether the container declares animation frames. */
   isAnimated: boolean
-  /** EXIF Orientation 1-8, or undefined when absent. */
+  /**
+   * EXIF Orientation 1-8, or undefined when absent or inspection is unknown.
+   * Check `orientationKnown` before using the value.
+   */
   orientation?: number
   /** Whether EXIF inspection confirmed the Orientation value is present or absent. */
   orientationKnown: boolean

--- a/index.d.ts
+++ b/index.d.ts
@@ -416,8 +416,10 @@ export interface ImageMetadata {
   hasAlpha: boolean
   /** Whether the container declares animation frames. */
   isAnimated: boolean
-  /** EXIF Orientation 1-8, or undefined when absent or invalid. */
+  /** EXIF Orientation 1-8, or undefined when absent. */
   orientation?: number
+  /** Whether EXIF inspection confirmed the Orientation value is present or absent. */
+  orientationKnown: boolean
 }
 
 /**

--- a/lib/artifact-compiler.js
+++ b/lib/artifact-compiler.js
@@ -748,6 +748,8 @@ async function parseJpegContainer(reader, rejectPrivacy) {
   const soi = await reader.read(2);
   if (soi[0] !== 0xff || soi[1] !== 0xd8) return { complete: false };
   let hasExif = false;
+  let hasUnparsedExif = false;
+  let sawScan = false;
   const state = { iccParts: [], iccCount: null, iccOutcome: 'absent' };
   let pendingMarker;
   while (reader.position < reader.size || pendingMarker !== undefined) {
@@ -756,9 +758,15 @@ async function parseJpegContainer(reader, rejectPrivacy) {
     if (marker === null) return { complete: false };
     if (marker === 0xd9) {
       if (reader.position !== reader.size) return { complete: false };
-      return { complete: true, hasExif, iccOutcome: finalizeJpegIcc(state, rejectPrivacy) };
+      return {
+        complete: true,
+        hasExif,
+        hasUnparsedExif,
+        iccOutcome: finalizeJpegIcc(state, rejectPrivacy),
+      };
     }
     if (marker === 0xda) {
+      sawScan = true;
       if (reader.position + 2 > reader.size) return { complete: false };
       const scanLength = await reader.u16be();
       if (scanLength < 2 || scanLength - 2 > reader.size - reader.position) return { complete: false };
@@ -779,7 +787,10 @@ async function parseJpegContainer(reader, rejectPrivacy) {
       const isExif = marker === 0xe1 && payload.subarray(0, EXIF_PREFIX.length).equals(EXIF_PREFIX);
       const isIcc = marker === 0xe2 && payload.subarray(0, JPEG_ICC_PREFIX.length).equals(JPEG_ICC_PREFIX);
       const isJfif = marker === 0xe0 && canonicalJfifPayload(payload);
-      hasExif ||= isExif;
+      if (isExif) {
+        hasExif = true;
+        hasUnparsedExif ||= sawScan;
+      }
       if (isIcc) {
         if (payload.length < 14) {
           if (rejectPrivacy) throw privacyFailure();
@@ -1260,7 +1271,15 @@ async function compileImage(options) {
     }
     facts = sourceFacts(factsMetadata, digest);
     if (!sourceVerification) {
-      await verifySourceContainer(sourceSnapshot.path, metadata, signal);
+      sourceVerification = await verifySourceContainer(sourceSnapshot.path, metadata, signal);
+    }
+    if (sourceVerification.hasUnparsedExif === true) {
+      throw structuredError(
+        'Input contains EXIF metadata after the JPEG scan and it could not be safely parsed',
+        'E130',
+        ERROR_CATEGORY.CodecError,
+        'Remove or normalize EXIF orientation before compiling the upload.',
+      );
     }
     const nativeVersion = api.version();
     if (typeof nativeVersion !== 'string' || nativeVersion.length === 0) {

--- a/lib/artifact-compiler.js
+++ b/lib/artifact-compiler.js
@@ -631,6 +631,7 @@ async function readContainer(filePath, signal, phase, parser) {
 }
 
 const JPEG_ICC_PREFIX = Buffer.from('ICC_PROFILE\0');
+const EXIF_PREFIX = Buffer.from('Exif\0\0');
 const JFIF_CANONICAL = Buffer.from('4a46494600010100000100010000', 'hex');
 
 function canonicalJfifPayload(payload) {
@@ -746,6 +747,7 @@ async function consumeJpegScan(reader) {
 async function parseJpegContainer(reader, rejectPrivacy) {
   const soi = await reader.read(2);
   if (soi[0] !== 0xff || soi[1] !== 0xd8) return { complete: false };
+  let hasExif = false;
   const state = { iccParts: [], iccCount: null, iccOutcome: 'absent' };
   let pendingMarker;
   while (reader.position < reader.size || pendingMarker !== undefined) {
@@ -754,7 +756,7 @@ async function parseJpegContainer(reader, rejectPrivacy) {
     if (marker === null) return { complete: false };
     if (marker === 0xd9) {
       if (reader.position !== reader.size) return { complete: false };
-      return { complete: true, iccOutcome: finalizeJpegIcc(state, rejectPrivacy) };
+      return { complete: true, hasExif, iccOutcome: finalizeJpegIcc(state, rejectPrivacy) };
     }
     if (marker === 0xda) {
       if (reader.position + 2 > reader.size) return { complete: false };
@@ -774,8 +776,10 @@ async function parseJpegContainer(reader, rejectPrivacy) {
     const payloadLength = length - 2;
     if (marker === 0xfe || (marker >= 0xe0 && marker <= 0xef)) {
       const payload = await reader.read(payloadLength);
+      const isExif = marker === 0xe1 && payload.subarray(0, EXIF_PREFIX.length).equals(EXIF_PREFIX);
       const isIcc = marker === 0xe2 && payload.subarray(0, JPEG_ICC_PREFIX.length).equals(JPEG_ICC_PREFIX);
       const isJfif = marker === 0xe0 && canonicalJfifPayload(payload);
+      hasExif ||= isExif;
       if (isIcc) {
         if (payload.length < 14) {
           if (rejectPrivacy) throw privacyFailure();
@@ -812,11 +816,13 @@ const PNG_ALLOWED = new Set(['IHDR', 'PLTE', 'IDAT', 'IEND', 'iCCP', 'sRGB', 'gA
 
 async function parsePngContainer(reader, rejectPrivacy) {
   if (!(await reader.read(8)).equals(PNG_SIGNATURE)) return { complete: false };
+  let hasExif = false;
   const state = { iccOutcome: 'absent' };
   while (reader.position < reader.size) {
     const length = await reader.u32be();
     const type = (await reader.read(4)).toString('ascii');
     if (length > reader.size - reader.position - 4) return { complete: false };
+    hasExif ||= type === 'eXIf';
     if (rejectPrivacy && !PNG_ALLOWED.has(type)) throw privacyFailure();
     if (type === 'iCCP') {
       if (length > MAX_ICC_BYTES + MAX_METADATA_BUFFER) throw privacyFailure();
@@ -840,7 +846,7 @@ async function parsePngContainer(reader, rejectPrivacy) {
     await reader.skip(4);
     if (type === 'IEND') {
       if (length !== 0) return { complete: false };
-      return { complete: reader.position === reader.size, iccOutcome: state.iccOutcome };
+      return { complete: reader.position === reader.size, hasExif, iccOutcome: state.iccOutcome };
     }
   }
   return { complete: false };
@@ -851,11 +857,13 @@ async function parseWebpContainer(reader, rejectPrivacy) {
   const riffSize = await reader.u32le();
   if ((await reader.read(4)).toString('ascii') !== 'WEBP' || riffSize + 8 !== reader.size) return { complete: false };
   const allowed = new Set(['VP8 ', 'VP8L', 'VP8X', 'ALPH', 'ICCP']);
+  let hasExif = false;
   const state = { iccOutcome: 'absent' };
   while (reader.position < reader.size) {
     const type = (await reader.read(4)).toString('ascii');
     const length = await reader.u32le();
     if (length > reader.size - reader.position) return { complete: false };
+    hasExif ||= type === 'EXIF';
     if (rejectPrivacy && (!allowed.has(type) || type === 'EXIF' || type === 'XMP ')) {
       throw privacyFailure();
     }
@@ -872,7 +880,7 @@ async function parseWebpContainer(reader, rejectPrivacy) {
     }
     if ((length & 1) !== 0) await reader.skip(1);
   }
-  return { complete: reader.position === reader.size, iccOutcome: state.iccOutcome };
+  return { complete: reader.position === reader.size, hasExif, iccOutcome: state.iccOutcome };
 }
 
 const AVIF_ALLOWED = {
@@ -1022,7 +1030,7 @@ async function verifyPrivacy(filePath, format, signal) {
 
 async function verifySourceContainer(filePath, metadata, signal) {
   try {
-    await readContainer(filePath, signal, 'preflight', (reader) => {
+    return await readContainer(filePath, signal, 'preflight', (reader) => {
       if (metadata.format === 'jpeg') return parseJpegContainer(reader, false);
       if (metadata.format === 'png') return parsePngContainer(reader, false);
       if (metadata.format === 'webp') return parseWebpContainer(reader, false);
@@ -1240,8 +1248,20 @@ async function compileImage(options) {
     // Load the package lazily to avoid an index.js circular dependency during startup.
     api = require('../index');
     const metadata = api.inspectFile(sourceSnapshot.path);
-    facts = sourceFacts(metadata, digest);
-    await verifySourceContainer(sourceSnapshot.path, metadata, signal);
+    let factsMetadata = metadata;
+    let sourceVerification;
+    if (metadata.orientationKnown !== true) {
+      sourceVerification = await verifySourceContainer(sourceSnapshot.path, metadata, signal);
+      // A bounded scan may end before the image container ends; only a complete
+      // verification with no EXIF can safely resolve that state as absent.
+      if (sourceVerification.hasExif === false) {
+        factsMetadata = { ...metadata, orientationKnown: true };
+      }
+    }
+    facts = sourceFacts(factsMetadata, digest);
+    if (!sourceVerification) {
+      await verifySourceContainer(sourceSnapshot.path, metadata, signal);
+    }
     const nativeVersion = api.version();
     if (typeof nativeVersion !== 'string' || nativeVersion.length === 0) {
       throw structuredError('Native compiler version is unavailable', 'E900', ERROR_CATEGORY.InternalBug, 'Report the compiler identity failure.');

--- a/lib/artifact-compiler.js
+++ b/lib/artifact-compiler.js
@@ -357,6 +357,9 @@ function sourceFacts(metadata, digest) {
     || typeof metadata.isAnimated !== 'boolean') {
     throw structuredError('Input metadata is incomplete', 'E130', ERROR_CATEGORY.CodecError, 'Provide a decodable static image.');
   }
+  if (metadata.orientationKnown !== true) {
+    throw structuredError('Input EXIF orientation could not be determined within the safe inspection contract', 'E130', ERROR_CATEGORY.CodecError, 'Remove or normalize EXIF orientation before compiling the upload.');
+  }
   const orientation = metadata.orientation === undefined ? null : metadata.orientation;
   if (orientation !== null && (!Number.isInteger(orientation) || orientation < 1 || orientation > 8)) {
     throw structuredError('Input orientation is invalid', 'E130', ERROR_CATEGORY.CodecError, 'Provide a decodable image with valid orientation metadata.');
@@ -628,7 +631,6 @@ async function readContainer(filePath, signal, phase, parser) {
 }
 
 const JPEG_ICC_PREFIX = Buffer.from('ICC_PROFILE\0');
-const EXIF_PREFIX = Buffer.from('Exif\0\0');
 const JFIF_CANONICAL = Buffer.from('4a46494600010100000100010000', 'hex');
 
 function canonicalJfifPayload(payload) {
@@ -744,7 +746,6 @@ async function consumeJpegScan(reader) {
 async function parseJpegContainer(reader, rejectPrivacy) {
   const soi = await reader.read(2);
   if (soi[0] !== 0xff || soi[1] !== 0xd8) return { complete: false };
-  let hasExif = false;
   const state = { iccParts: [], iccCount: null, iccOutcome: 'absent' };
   let pendingMarker;
   while (reader.position < reader.size || pendingMarker !== undefined) {
@@ -753,7 +754,7 @@ async function parseJpegContainer(reader, rejectPrivacy) {
     if (marker === null) return { complete: false };
     if (marker === 0xd9) {
       if (reader.position !== reader.size) return { complete: false };
-      return { complete: true, hasExif, iccOutcome: finalizeJpegIcc(state, rejectPrivacy) };
+      return { complete: true, iccOutcome: finalizeJpegIcc(state, rejectPrivacy) };
     }
     if (marker === 0xda) {
       if (reader.position + 2 > reader.size) return { complete: false };
@@ -773,10 +774,8 @@ async function parseJpegContainer(reader, rejectPrivacy) {
     const payloadLength = length - 2;
     if (marker === 0xfe || (marker >= 0xe0 && marker <= 0xef)) {
       const payload = await reader.read(payloadLength);
-      const isExif = marker === 0xe1 && payload.subarray(0, EXIF_PREFIX.length).equals(EXIF_PREFIX);
       const isIcc = marker === 0xe2 && payload.subarray(0, JPEG_ICC_PREFIX.length).equals(JPEG_ICC_PREFIX);
       const isJfif = marker === 0xe0 && canonicalJfifPayload(payload);
-      hasExif ||= isExif;
       if (isIcc) {
         if (payload.length < 14) {
           if (rejectPrivacy) throw privacyFailure();
@@ -813,13 +812,11 @@ const PNG_ALLOWED = new Set(['IHDR', 'PLTE', 'IDAT', 'IEND', 'iCCP', 'sRGB', 'gA
 
 async function parsePngContainer(reader, rejectPrivacy) {
   if (!(await reader.read(8)).equals(PNG_SIGNATURE)) return { complete: false };
-  let hasExif = false;
   const state = { iccOutcome: 'absent' };
   while (reader.position < reader.size) {
     const length = await reader.u32be();
     const type = (await reader.read(4)).toString('ascii');
     if (length > reader.size - reader.position - 4) return { complete: false };
-    if (type === 'eXIf') hasExif = true;
     if (rejectPrivacy && !PNG_ALLOWED.has(type)) throw privacyFailure();
     if (type === 'iCCP') {
       if (length > MAX_ICC_BYTES + MAX_METADATA_BUFFER) throw privacyFailure();
@@ -843,7 +840,7 @@ async function parsePngContainer(reader, rejectPrivacy) {
     await reader.skip(4);
     if (type === 'IEND') {
       if (length !== 0) return { complete: false };
-      return { complete: reader.position === reader.size, hasExif, iccOutcome: state.iccOutcome };
+      return { complete: reader.position === reader.size, iccOutcome: state.iccOutcome };
     }
   }
   return { complete: false };
@@ -854,13 +851,11 @@ async function parseWebpContainer(reader, rejectPrivacy) {
   const riffSize = await reader.u32le();
   if ((await reader.read(4)).toString('ascii') !== 'WEBP' || riffSize + 8 !== reader.size) return { complete: false };
   const allowed = new Set(['VP8 ', 'VP8L', 'VP8X', 'ALPH', 'ICCP']);
-  let hasExif = false;
   const state = { iccOutcome: 'absent' };
   while (reader.position < reader.size) {
     const type = (await reader.read(4)).toString('ascii');
     const length = await reader.u32le();
     if (length > reader.size - reader.position) return { complete: false };
-    if (type === 'EXIF') hasExif = true;
     if (rejectPrivacy && (!allowed.has(type) || type === 'EXIF' || type === 'XMP ')) {
       throw privacyFailure();
     }
@@ -877,7 +872,7 @@ async function parseWebpContainer(reader, rejectPrivacy) {
     }
     if ((length & 1) !== 0) await reader.skip(1);
   }
-  return { complete: reader.position === reader.size, hasExif, iccOutcome: state.iccOutcome };
+  return { complete: reader.position === reader.size, iccOutcome: state.iccOutcome };
 }
 
 const AVIF_ALLOWED = {
@@ -1025,11 +1020,9 @@ async function verifyPrivacy(filePath, format, signal) {
   return result.iccOutcome || 'absent';
 }
 
-async function rejectUnknownOrientation(filePath, metadata, signal) {
-  if (metadata.orientation !== undefined) return;
-  let result;
+async function verifySourceContainer(filePath, metadata, signal) {
   try {
-    result = await readContainer(filePath, signal, 'preflight', (reader) => {
+    await readContainer(filePath, signal, 'preflight', (reader) => {
       if (metadata.format === 'jpeg') return parseJpegContainer(reader, false);
       if (metadata.format === 'png') return parsePngContainer(reader, false);
       if (metadata.format === 'webp') return parseWebpContainer(reader, false);
@@ -1037,10 +1030,7 @@ async function rejectUnknownOrientation(filePath, metadata, signal) {
     });
   } catch (error) {
     if (isAbortError(error)) throw error;
-    throw structuredError('Input orientation could not be determined', 'E130', ERROR_CATEGORY.CodecError, 'Remove or normalize EXIF orientation before compiling the upload.', error);
-  }
-  if (result.hasExif) {
-    throw structuredError('Input EXIF orientation could not be determined within the safe inspection contract', 'E130', ERROR_CATEGORY.CodecError, 'Remove or normalize EXIF orientation before compiling the upload.');
+    throw structuredError('Input container could not be completely verified', 'E130', ERROR_CATEGORY.CodecError, 'Provide a complete decodable image.', error);
   }
 }
 
@@ -1250,8 +1240,8 @@ async function compileImage(options) {
     // Load the package lazily to avoid an index.js circular dependency during startup.
     api = require('../index');
     const metadata = api.inspectFile(sourceSnapshot.path);
-    await rejectUnknownOrientation(sourceSnapshot.path, metadata, signal);
     facts = sourceFacts(metadata, digest);
+    await verifySourceContainer(sourceSnapshot.path, metadata, signal);
     const nativeVersion = api.version();
     if (typeof nativeVersion !== 'string' || nativeVersion.length === 0) {
       throw structuredError('Native compiler version is unavailable', 'E900', ERROR_CATEGORY.InternalBug, 'Report the compiler identity failure.');

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -67,7 +67,7 @@ pub use io::Source;
 #[cfg(any(feature = "napi", feature = "fuzzing", test))]
 pub(crate) use common::run_with_panic_policy;
 #[cfg(any(feature = "napi", feature = "fuzzing", test))]
-pub(crate) use decoder::detect_exif_orientation_bounded_from_reader;
+pub(crate) use decoder::{inspect_exif_orientation_bounded_from_reader, OrientationInspection};
 
 // -----------------------------------------------------------------------------
 // Internal items exposed to integration tests and fuzz targets

--- a/src/engine/decoder.rs
+++ b/src/engine/decoder.rs
@@ -585,7 +585,10 @@ fn orientation_from_jpeg_header(data: &[u8]) -> OrientationInspection {
         }
         let marker = data[position];
         position += 1;
-        if marker == 0xda || marker == 0xd9 {
+        if marker == 0xda {
+            return OrientationInspection::Unknown;
+        }
+        if marker == 0xd9 {
             return OrientationInspection::Absent;
         }
         if marker == 0x01 || (0xd0..=0xd7).contains(&marker) {
@@ -623,7 +626,22 @@ fn orientation_from_jpeg_header(data: &[u8]) -> OrientationInspection {
 pub(crate) fn inspect_exif_orientation_bounded_from_reader<R: BufRead + Seek>(
     reader: &mut R,
 ) -> OrientationInspection {
-    let mut limited = match LimitedSeekReader::new(reader, MAX_ORIENTATION_SCAN_BYTES) {
+    let start = match reader.stream_position() {
+        Ok(start) => start,
+        Err(_) => return OrientationInspection::Unknown,
+    };
+    let source_len = match reader.seek(SeekFrom::End(0)) {
+        Ok(end) => match end.checked_sub(start) {
+            Some(length) => length,
+            None => return OrientationInspection::Unknown,
+        },
+        Err(_) => return OrientationInspection::Unknown,
+    };
+    if reader.seek(SeekFrom::Start(start)).is_err() {
+        return OrientationInspection::Unknown;
+    }
+    let scan_limit = source_len.min(MAX_ORIENTATION_SCAN_BYTES);
+    let mut limited = match LimitedSeekReader::new(reader, scan_limit) {
         Ok(reader) => reader,
         Err(_) => return OrientationInspection::Unknown,
     };
@@ -632,11 +650,16 @@ pub(crate) fn inspect_exif_orientation_bounded_from_reader<R: BufRead + Seek>(
         return OrientationInspection::Unknown;
     }
     if bounded.starts_with(&[0xff, 0xd8]) {
-        return orientation_from_jpeg_header(&bounded);
+        if source_len > MAX_ORIENTATION_SCAN_BYTES {
+            return orientation_from_jpeg_header(&bounded);
+        }
     }
     let exif = match exif::Reader::new().read_from_container(&mut Cursor::new(bounded)) {
         Ok(exif) => exif,
-        Err(exif::Error::NotFound(_)) => return OrientationInspection::Absent,
+        Err(exif::Error::NotFound(_)) if source_len <= MAX_ORIENTATION_SCAN_BYTES => {
+            return OrientationInspection::Absent;
+        }
+        Err(_) if source_len > MAX_ORIENTATION_SCAN_BYTES => return OrientationInspection::Unknown,
         Err(_) => return OrientationInspection::Unknown,
     };
     orientation_from_exif(exif)
@@ -704,6 +727,25 @@ mod tests {
         invalid[orientation_value] = 9;
         let mut reader = std::io::BufReader::new(std::io::Cursor::new(invalid));
 
+        assert_eq!(
+            inspect_exif_orientation_bounded_from_reader(&mut reader),
+            OrientationInspection::Unknown
+        );
+    }
+
+    #[test]
+    fn bounded_orientation_reader_does_not_treat_budget_eof_as_absent() {
+        let mut png = b"\x89PNG\r\n\x1a\n".to_vec();
+        let padding_length = MAX_ORIENTATION_SCAN_BYTES as usize - png.len() - 12;
+        png.extend_from_slice(&(padding_length as u32).to_be_bytes());
+        png.extend_from_slice(b"tEXt");
+        png.extend(std::iter::repeat_n(0u8, padding_length));
+        png.extend_from_slice(&[0; 4]);
+        png.extend_from_slice(&[0, 0, 0, 0]);
+        png.extend_from_slice(b"eXIf");
+        png.extend_from_slice(&[0; 4]);
+
+        let mut reader = std::io::BufReader::new(std::io::Cursor::new(png));
         assert_eq!(
             inspect_exif_orientation_bounded_from_reader(&mut reader),
             OrientationInspection::Unknown

--- a/src/engine/decoder.rs
+++ b/src/engine/decoder.rs
@@ -541,7 +541,6 @@ impl<R: Seek> Seek for LimitedSeekReader<R> {
     }
 }
 
-#[cfg(any(feature = "napi", feature = "fuzzing", test))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum OrientationInspection {
     Absent,
@@ -549,7 +548,6 @@ pub(crate) enum OrientationInspection {
     Unknown,
 }
 
-#[cfg(any(feature = "napi", feature = "fuzzing", test))]
 fn orientation_from_exif(exif: exif::Exif) -> OrientationInspection {
     let Some(field) = exif.get_field(exif::Tag::Orientation, exif::In::PRIMARY) else {
         return OrientationInspection::Absent;
@@ -564,7 +562,6 @@ fn orientation_from_exif(exif: exif::Exif) -> OrientationInspection {
     }
 }
 
-#[cfg(any(feature = "napi", feature = "fuzzing", test))]
 fn orientation_from_jpeg_header(data: &[u8], source_complete: bool) -> OrientationInspection {
     const EXIF_ID: &[u8] = b"Exif\0\0";
 
@@ -575,10 +572,12 @@ fn orientation_from_jpeg_header(data: &[u8], source_complete: bool) -> Orientati
     let mut position = 2;
     let mut orientation = None;
     let mut saw_exif = false;
-    let finish = |orientation: Option<u16>, complete: bool, saw_exif: bool| {
-        if let Some(orientation) = orientation {
+    let finish = |orientation: Option<u16>, header_complete: bool, absence_confirmed: bool| {
+        if !header_complete && !source_complete {
+            OrientationInspection::Unknown
+        } else if let Some(orientation) = orientation {
             OrientationInspection::Value(orientation)
-        } else if complete || source_complete || saw_exif {
+        } else if source_complete || absence_confirmed {
             OrientationInspection::Absent
         } else {
             OrientationInspection::Unknown
@@ -597,10 +596,10 @@ fn orientation_from_jpeg_header(data: &[u8], source_complete: bool) -> Orientati
         let marker = data[position];
         position += 1;
         if marker == 0xda {
-            return finish(orientation, false, saw_exif);
+            return finish(orientation, true, saw_exif);
         }
         if marker == 0xd9 {
-            return finish(orientation, true, saw_exif);
+            return finish(orientation, true, true);
         }
         if marker == 0x01 || (0xd0..=0xd7).contains(&marker) {
             continue;
@@ -638,7 +637,7 @@ fn orientation_from_jpeg_header(data: &[u8], source_complete: bool) -> Orientati
         }
         position = payload_end;
     }
-    finish(orientation, false, saw_exif)
+    finish(orientation, false, false)
 }
 
 /// Inspect EXIF Orientation from a seekable container without decoding pixels.
@@ -677,9 +676,7 @@ pub(crate) fn inspect_exif_orientation_bounded_from_reader<R: BufRead + Seek>(
     if bounded.starts_with(&[0xff, 0xd8]) {
         let orientation =
             orientation_from_jpeg_header(&bounded, source_len <= MAX_ORIENTATION_SCAN_BYTES);
-        if source_len > MAX_ORIENTATION_SCAN_BYTES || orientation != OrientationInspection::Absent {
-            return orientation;
-        }
+        return orientation;
     }
     let exif = match exif::Reader::new().read_from_container(&mut Cursor::new(bounded)) {
         Ok(exif) => exif,
@@ -698,6 +695,12 @@ pub(crate) fn inspect_exif_orientation_bounded_from_reader<R: BufRead + Seek>(
 /// checks already run before this call, and preserving auto-orientation for
 /// valid EXIF after large APP/ICC/XMP segments is part of the existing API.
 pub fn detect_exif_orientation(bytes: &[u8]) -> Option<u16> {
+    if bytes.starts_with(&[0xff, 0xd8]) {
+        return match orientation_from_jpeg_header(bytes, true) {
+            OrientationInspection::Value(orientation) => Some(orientation),
+            OrientationInspection::Absent | OrientationInspection::Unknown => None,
+        };
+    }
     let mut cursor = Cursor::new(bytes);
     let exif = exif::Reader::new().read_from_container(&mut cursor).ok()?;
     let field = exif.get_field(exif::Tag::Orientation, exif::In::PRIMARY)?;
@@ -748,11 +751,12 @@ mod tests {
         duplicate.extend_from_slice(&jpeg[..2]);
         duplicate.extend_from_slice(&empty_segment);
         duplicate.extend_from_slice(&jpeg[2..]);
-        let mut reader = std::io::BufReader::new(std::io::Cursor::new(duplicate));
+        let mut reader = std::io::BufReader::new(std::io::Cursor::new(duplicate.as_slice()));
         assert_eq!(
             inspect_exif_orientation_bounded_from_reader(&mut reader),
             OrientationInspection::Value(6)
         );
+        assert_eq!(detect_exif_orientation(&duplicate), Some(6));
 
         let exif_offset = jpeg
             .windows(2)
@@ -770,11 +774,12 @@ mod tests {
         conflicting.extend_from_slice(&jpeg[..2]);
         conflicting.extend_from_slice(&conflicting_segment);
         conflicting.extend_from_slice(&jpeg[2..]);
-        let mut reader = std::io::BufReader::new(std::io::Cursor::new(conflicting));
+        let mut reader = std::io::BufReader::new(std::io::Cursor::new(conflicting.as_slice()));
         assert_eq!(
             inspect_exif_orientation_bounded_from_reader(&mut reader),
             OrientationInspection::Unknown
         );
+        assert_eq!(detect_exif_orientation(&conflicting), None);
     }
 
     #[test]

--- a/src/engine/decoder.rs
+++ b/src/engine/decoder.rs
@@ -565,7 +565,7 @@ fn orientation_from_exif(exif: exif::Exif) -> OrientationInspection {
 }
 
 #[cfg(any(feature = "napi", feature = "fuzzing", test))]
-fn orientation_from_jpeg_header(data: &[u8]) -> OrientationInspection {
+fn orientation_from_jpeg_header(data: &[u8], source_complete: bool) -> OrientationInspection {
     const EXIF_ID: &[u8] = b"Exif\0\0";
 
     if data.len() < 2 || data[..2] != [0xff, 0xd8] {
@@ -573,6 +573,17 @@ fn orientation_from_jpeg_header(data: &[u8]) -> OrientationInspection {
     }
 
     let mut position = 2;
+    let mut orientation = None;
+    let mut saw_exif = false;
+    let finish = |orientation: Option<u16>, complete: bool, saw_exif: bool| {
+        if let Some(orientation) = orientation {
+            OrientationInspection::Value(orientation)
+        } else if complete || source_complete || saw_exif {
+            OrientationInspection::Absent
+        } else {
+            OrientationInspection::Unknown
+        }
+    };
     while position + 1 < data.len() {
         if data[position] != 0xff {
             return OrientationInspection::Unknown;
@@ -586,10 +597,10 @@ fn orientation_from_jpeg_header(data: &[u8]) -> OrientationInspection {
         let marker = data[position];
         position += 1;
         if marker == 0xda {
-            return OrientationInspection::Unknown;
+            return finish(orientation, false, saw_exif);
         }
         if marker == 0xd9 {
-            return OrientationInspection::Absent;
+            return finish(orientation, true, saw_exif);
         }
         if marker == 0x01 || (0xd0..=0xd7).contains(&marker) {
             continue;
@@ -604,16 +615,30 @@ fn orientation_from_jpeg_header(data: &[u8]) -> OrientationInspection {
         let payload_start = position + 2;
         let payload_end = payload_start + length - 2;
         if marker == 0xe1 && data[payload_start..payload_end].starts_with(EXIF_ID) {
-            return match exif::Reader::new()
+            saw_exif = true;
+            let inspection = match exif::Reader::new()
                 .read_raw(data[payload_start + EXIF_ID.len()..payload_end].to_vec())
             {
                 Ok(exif) => orientation_from_exif(exif),
-                Err(_) => OrientationInspection::Unknown,
+                Err(_) => return OrientationInspection::Unknown,
+            };
+            match inspection {
+                OrientationInspection::Absent => {}
+                OrientationInspection::Value(value) => {
+                    if let Some(previous) = orientation {
+                        if previous != value {
+                            return OrientationInspection::Unknown;
+                        }
+                    } else {
+                        orientation = Some(value);
+                    }
+                }
+                OrientationInspection::Unknown => return OrientationInspection::Unknown,
             };
         }
         position = payload_end;
     }
-    OrientationInspection::Unknown
+    finish(orientation, false, saw_exif)
 }
 
 /// Inspect EXIF Orientation from a seekable container without decoding pixels.
@@ -650,8 +675,10 @@ pub(crate) fn inspect_exif_orientation_bounded_from_reader<R: BufRead + Seek>(
         return OrientationInspection::Unknown;
     }
     if bounded.starts_with(&[0xff, 0xd8]) {
-        if source_len > MAX_ORIENTATION_SCAN_BYTES {
-            return orientation_from_jpeg_header(&bounded);
+        let orientation =
+            orientation_from_jpeg_header(&bounded, source_len <= MAX_ORIENTATION_SCAN_BYTES);
+        if source_len > MAX_ORIENTATION_SCAN_BYTES || orientation != OrientationInspection::Absent {
+            return orientation;
         }
     }
     let exif = match exif::Reader::new().read_from_container(&mut Cursor::new(bounded)) {
@@ -702,6 +729,51 @@ mod tests {
         assert_eq!(
             inspect_exif_orientation_bounded_from_reader(&mut reader),
             OrientationInspection::Value(6)
+        );
+    }
+
+    #[test]
+    fn bounded_orientation_reader_scans_duplicate_exif_segments() {
+        let jpeg = include_bytes!("../../test/fixtures/test_with_exif.jpg");
+        let tiff_without_orientation = [
+            0x49, 0x49, 0x2a, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
+        let mut empty_segment = vec![0xff, 0xe1];
+        empty_segment
+            .extend_from_slice(&((tiff_without_orientation.len() + 8) as u16).to_be_bytes());
+        empty_segment.extend_from_slice(b"Exif\0\0");
+        empty_segment.extend_from_slice(&tiff_without_orientation);
+
+        let mut duplicate = Vec::with_capacity(jpeg.len() + empty_segment.len());
+        duplicate.extend_from_slice(&jpeg[..2]);
+        duplicate.extend_from_slice(&empty_segment);
+        duplicate.extend_from_slice(&jpeg[2..]);
+        let mut reader = std::io::BufReader::new(std::io::Cursor::new(duplicate));
+        assert_eq!(
+            inspect_exif_orientation_bounded_from_reader(&mut reader),
+            OrientationInspection::Value(6)
+        );
+
+        let exif_offset = jpeg
+            .windows(2)
+            .position(|window| window == [0xff, 0xe1])
+            .expect("fixture must contain an EXIF segment");
+        let exif_length =
+            u16::from_be_bytes([jpeg[exif_offset + 2], jpeg[exif_offset + 3]]) as usize;
+        let mut conflicting_segment = jpeg[exif_offset..exif_offset + exif_length + 2].to_vec();
+        let orientation_value = conflicting_segment
+            .windows(4)
+            .position(|window| window == [0x06, 0x00, 0x00, 0x00])
+            .expect("fixture must contain Orientation 6");
+        conflicting_segment[orientation_value] = 0x01;
+        let mut conflicting = Vec::with_capacity(jpeg.len() + conflicting_segment.len());
+        conflicting.extend_from_slice(&jpeg[..2]);
+        conflicting.extend_from_slice(&conflicting_segment);
+        conflicting.extend_from_slice(&jpeg[2..]);
+        let mut reader = std::io::BufReader::new(std::io::Cursor::new(conflicting));
+        assert_eq!(
+            inspect_exif_orientation_bounded_from_reader(&mut reader),
+            OrientationInspection::Unknown
         );
     }
 

--- a/src/engine/decoder.rs
+++ b/src/engine/decoder.rs
@@ -541,22 +541,105 @@ impl<R: Seek> Seek for LimitedSeekReader<R> {
     }
 }
 
-/// Extract EXIF Orientation from a seekable container without decoding pixels.
+#[cfg(any(feature = "napi", feature = "fuzzing", test))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OrientationInspection {
+    Absent,
+    Value(u16),
+    Unknown,
+}
+
+#[cfg(any(feature = "napi", feature = "fuzzing", test))]
+fn orientation_from_exif(exif: exif::Exif) -> OrientationInspection {
+    let Some(field) = exif.get_field(exif::Tag::Orientation, exif::In::PRIMARY) else {
+        return OrientationInspection::Absent;
+    };
+    let Some(orientation) = field.value.get_uint(0) else {
+        return OrientationInspection::Unknown;
+    };
+    if (1..=8).contains(&orientation) {
+        OrientationInspection::Value(orientation as u16)
+    } else {
+        OrientationInspection::Unknown
+    }
+}
+
+#[cfg(any(feature = "napi", feature = "fuzzing", test))]
+fn orientation_from_jpeg_header(data: &[u8]) -> OrientationInspection {
+    const EXIF_ID: &[u8] = b"Exif\0\0";
+
+    if data.len() < 2 || data[..2] != [0xff, 0xd8] {
+        return OrientationInspection::Unknown;
+    }
+
+    let mut position = 2;
+    while position + 1 < data.len() {
+        if data[position] != 0xff {
+            return OrientationInspection::Unknown;
+        }
+        while position < data.len() && data[position] == 0xff {
+            position += 1;
+        }
+        if position >= data.len() {
+            return OrientationInspection::Unknown;
+        }
+        let marker = data[position];
+        position += 1;
+        if marker == 0xda || marker == 0xd9 {
+            return OrientationInspection::Absent;
+        }
+        if marker == 0x01 || (0xd0..=0xd7).contains(&marker) {
+            continue;
+        }
+        if marker == 0xd8 || position + 2 > data.len() {
+            return OrientationInspection::Unknown;
+        }
+        let length = u16::from_be_bytes([data[position], data[position + 1]]) as usize;
+        if length < 2 || length - 2 > data.len() - position - 2 {
+            return OrientationInspection::Unknown;
+        }
+        let payload_start = position + 2;
+        let payload_end = payload_start + length - 2;
+        if marker == 0xe1 && data[payload_start..payload_end].starts_with(EXIF_ID) {
+            return match exif::Reader::new()
+                .read_raw(data[payload_start + EXIF_ID.len()..payload_end].to_vec())
+            {
+                Ok(exif) => orientation_from_exif(exif),
+                Err(_) => OrientationInspection::Unknown,
+            };
+        }
+        position = payload_end;
+    }
+    OrientationInspection::Unknown
+}
+
+/// Inspect EXIF Orientation from a seekable container without decoding pixels.
 ///
 /// This bounded reader form exists so `inspectFile()` can stream EXIF through a
 /// `BufReader<File>` instead of materializing the full file. The scan is capped
-/// at 64 KiB so missing metadata cannot consume an image payload. Invalid
-/// containers, absent tags, and values outside 1-8 all map to `None` because
-/// orientation is optional metadata, not proof that pixels are decodable.
+/// at 64 KiB, and an incomplete or invalid parse stays `Unknown` so callers do
+/// not mistake an inspection limit or malformed metadata for a missing tag.
 #[cfg(any(feature = "napi", feature = "fuzzing", test))]
-pub(crate) fn detect_exif_orientation_bounded_from_reader<R: BufRead + Seek>(
+pub(crate) fn inspect_exif_orientation_bounded_from_reader<R: BufRead + Seek>(
     reader: &mut R,
-) -> Option<u16> {
-    let mut limited = LimitedSeekReader::new(reader, MAX_ORIENTATION_SCAN_BYTES).ok()?;
-    let exif = exif::Reader::new().read_from_container(&mut limited).ok()?;
-    let field = exif.get_field(exif::Tag::Orientation, exif::In::PRIMARY)?;
-    let orientation = field.value.get_uint(0)? as u16;
-    (1..=8).contains(&orientation).then_some(orientation)
+) -> OrientationInspection {
+    let mut limited = match LimitedSeekReader::new(reader, MAX_ORIENTATION_SCAN_BYTES) {
+        Ok(reader) => reader,
+        Err(_) => return OrientationInspection::Unknown,
+    };
+    let mut bounded = Vec::new();
+    if limited.read_to_end(&mut bounded).is_err() {
+        return OrientationInspection::Unknown;
+    }
+    if bounded.starts_with(&[0xff, 0xd8]) {
+        return orientation_from_jpeg_header(&bounded);
+    }
+    let exif = match exif::Reader::new().read_from_container(&mut Cursor::new(bounded)) {
+        Ok(exif) => exif,
+        Err(exif::Error::NotFound(_)) => return OrientationInspection::Absent,
+        Err(_) => return OrientationInspection::Unknown,
+    };
+    orientation_from_exif(exif)
 }
 
 /// Extract EXIF Orientation tag (1-8). Returns None if missing or invalid.
@@ -594,8 +677,8 @@ mod tests {
 
         assert_eq!(detect_exif_orientation(jpeg), Some(6));
         assert_eq!(
-            detect_exif_orientation_bounded_from_reader(&mut reader),
-            Some(6)
+            inspect_exif_orientation_bounded_from_reader(&mut reader),
+            OrientationInspection::Value(6)
         );
     }
 
@@ -606,8 +689,8 @@ mod tests {
 
         assert_eq!(detect_exif_orientation(&jpeg), Some(6));
         assert_eq!(
-            detect_exif_orientation_bounded_from_reader(&mut preflight_reader),
-            None
+            inspect_exif_orientation_bounded_from_reader(&mut preflight_reader),
+            OrientationInspection::Unknown
         );
     }
 
@@ -622,8 +705,8 @@ mod tests {
         let mut reader = std::io::BufReader::new(std::io::Cursor::new(invalid));
 
         assert_eq!(
-            detect_exif_orientation_bounded_from_reader(&mut reader),
-            None
+            inspect_exif_orientation_bounded_from_reader(&mut reader),
+            OrientationInspection::Unknown
         );
     }
 

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -1,4 +1,6 @@
-use crate::engine::{detect_exif_orientation_bounded_from_reader, run_with_panic_policy};
+use crate::engine::{
+    inspect_exif_orientation_bounded_from_reader, run_with_panic_policy, OrientationInspection,
+};
 use crate::error::LazyImageError;
 use image::{ImageDecoder, ImageFormat, ImageReader};
 use std::fs::File;
@@ -12,6 +14,7 @@ pub struct InspectMetadata {
     pub has_alpha: bool,
     pub is_animated: bool,
     pub orientation: Option<u16>,
+    pub orientation_known: bool,
 }
 
 fn decode_failed(context: &str, error: impl std::fmt::Display) -> LazyImageError {
@@ -99,6 +102,7 @@ fn read_inspect_metadata<R: BufRead + Seek>(
         has_alpha,
         is_animated,
         orientation: None,
+        orientation_known: true,
     })
 }
 
@@ -109,7 +113,11 @@ fn inspect_header_from_reader<R: BufRead + Seek>(
     reader
         .seek(SeekFrom::Start(0))
         .map_err(|error| decode_failed("failed to rewind image for EXIF inspection", error))?;
-    metadata.orientation = detect_exif_orientation_bounded_from_reader(reader);
+    match inspect_exif_orientation_bounded_from_reader(reader) {
+        OrientationInspection::Absent => {}
+        OrientationInspection::Value(orientation) => metadata.orientation = Some(orientation),
+        OrientationInspection::Unknown => metadata.orientation_known = false,
+    }
     Ok(metadata)
 }
 
@@ -194,6 +202,7 @@ mod tests {
         assert_eq!(metadata.format.as_deref(), Some("jpeg"));
         assert!(!metadata.has_alpha);
         assert!(!metadata.is_animated);
+        assert!(metadata.orientation_known);
     }
 
     #[test]
@@ -238,6 +247,7 @@ mod tests {
         let metadata = inspect_header_from_bytes(jpeg).unwrap();
         assert_eq!((metadata.width, metadata.height), (8, 8));
         assert_eq!(metadata.orientation, Some(6));
+        assert!(metadata.orientation_known);
     }
 
     #[test]
@@ -262,10 +272,10 @@ mod tests {
             inner: BufReader::with_capacity(8 * 1024, Cursor::new(orientation_input)),
             bytes_read: Arc::clone(&orientation_bytes_read),
         };
-        let orientation = detect_exif_orientation_bounded_from_reader(&mut orientation_reader);
+        let orientation = inspect_exif_orientation_bounded_from_reader(&mut orientation_reader);
 
         assert_eq!((metadata.width, metadata.height), (32, 32));
-        assert_eq!(orientation, None);
+        assert_eq!(orientation, OrientationInspection::Absent);
         assert!(
             metadata_bytes_read.load(Ordering::Relaxed) < 64 * 1024,
             "JPEG trait inspection must stop after bounded header reads"
@@ -308,5 +318,6 @@ mod tests {
         assert_eq!((metadata.width, metadata.height), (8, 8));
         assert_eq!(metadata.format.as_deref(), Some("jpeg"));
         assert_eq!(metadata.orientation, Some(6));
+        assert!(metadata.orientation_known);
     }
 }

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -275,7 +275,7 @@ mod tests {
         let orientation = inspect_exif_orientation_bounded_from_reader(&mut orientation_reader);
 
         assert_eq!((metadata.width, metadata.height), (32, 32));
-        assert_eq!(orientation, OrientationInspection::Absent);
+        assert_eq!(orientation, OrientationInspection::Unknown);
         assert!(
             metadata_bytes_read.load(Ordering::Relaxed) < 64 * 1024,
             "JPEG trait inspection must stop after bounded header reads"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,8 +61,10 @@ pub struct ImageMetadata {
     pub has_alpha: bool,
     /// Whether the container declares animation frames.
     pub is_animated: bool,
-    /// EXIF Orientation 1-8, or undefined when absent or invalid.
+    /// EXIF Orientation 1-8, or undefined when absent.
     pub orientation: Option<u16>,
+    /// Whether EXIF inspection confirmed the Orientation value is present or absent.
+    pub orientation_known: bool,
 }
 
 #[cfg(feature = "napi")]
@@ -75,6 +77,7 @@ impl From<InspectMetadata> for ImageMetadata {
             has_alpha: value.has_alpha,
             is_animated: value.is_animated,
             orientation: value.orientation,
+            orientation_known: value.orientation_known,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,8 @@ pub struct ImageMetadata {
     pub has_alpha: bool,
     /// Whether the container declares animation frames.
     pub is_animated: bool,
-    /// EXIF Orientation 1-8, or undefined when absent.
+    /// EXIF Orientation 1-8, or undefined when absent or inspection is unknown.
+    /// Check `orientationKnown` before using the value.
     pub orientation: Option<u16>,
     /// Whether EXIF inspection confirmed the Orientation value is present or absent.
     pub orientation_known: bool,

--- a/test/integration/artifact-compiler.test.js
+++ b/test/integration/artifact-compiler.test.js
@@ -5,7 +5,7 @@ const fsp = require('node:fs/promises');
 const os = require('node:os');
 const path = require('node:path');
 
-const { ImageEngine, compileImage } = require('../../index');
+const { ImageEngine, compileImage, inspectFile } = require('../../index');
 const { compilerFingerprint } = require('../../lib/artifact-compiler');
 const { resolveFixture } = require('../helpers/paths');
 
@@ -100,6 +100,18 @@ async function writeUnknownOrientationFixture(format, outputPath) {
   data[tagOffset + 8] = 9;
   data[tagOffset + 9] = 0;
   await fsp.writeFile(outputPath, data);
+}
+
+async function writeEmptyOrientationFixture(outputPath) {
+  const jpeg = await fsp.readFile(INPUT);
+  const tiff = Buffer.from('49492a0008000000000000000000', 'hex');
+  const exif = Buffer.concat([Buffer.from('Exif\0\0'), tiff]);
+  const segment = Buffer.alloc(4 + exif.length);
+  segment[0] = 0xff;
+  segment[1] = 0xe1;
+  segment.writeUInt16BE(exif.length + 2, 2);
+  exif.copy(segment, 4);
+  await fsp.writeFile(outputPath, Buffer.concat([jpeg.subarray(0, 2), segment, jpeg.subarray(2)]));
 }
 
 function makeIccProfile(shared) {
@@ -542,6 +554,21 @@ async function main() {
       );
     });
   }
+
+  await withTempParent(async (parent) => {
+    const inputPath = path.join(parent, 'missing-orientation.jpg');
+    await writeEmptyOrientationFixture(inputPath);
+    const metadata = inspectFile(inputPath);
+    assert.equal(metadata.orientation, undefined);
+    assert.equal(metadata.orientationKnown, true);
+    const manifest = await compileImage({
+      inputPath,
+      outputDir: path.join(parent, 'orientation-absent-output'),
+      policy: { widths: [320], formats: ['webp'], placeholder: false },
+    });
+    assert.equal(manifest.source.orientation, null);
+    assert.equal(manifest.artifacts[0].width, 320);
+  });
 
   await withTempParent(async (parent) => {
     const inputPath = path.join(parent, 'mutable-input.jpg');

--- a/test/integration/artifact-compiler.test.js
+++ b/test/integration/artifact-compiler.test.js
@@ -114,6 +114,21 @@ async function writeEmptyOrientationFixture(outputPath) {
   await fsp.writeFile(outputPath, Buffer.concat([jpeg.subarray(0, 2), segment, jpeg.subarray(2)]));
 }
 
+async function writePostScanExifFixture(outputPath) {
+  const jpeg = await fsp.readFile(INPUT);
+  const oriented = await fsp.readFile(resolveFixture('test_with_exif.jpg'));
+  const markerOffset = oriented.indexOf(Buffer.from([0xff, 0xe1]));
+  assert.notEqual(markerOffset, -1, 'oriented fixture should contain an EXIF segment');
+  const segmentLength = oriented.readUInt16BE(markerOffset + 2) + 2;
+  const segment = oriented.subarray(markerOffset, markerOffset + segmentLength);
+  await fsp.writeFile(outputPath, Buffer.concat([
+    jpeg.subarray(0, jpeg.length - 2),
+    Buffer.alloc(64 * 1024),
+    segment,
+    jpeg.subarray(jpeg.length - 2),
+  ]));
+}
+
 function makeIccProfile(shared) {
   const profile = Buffer.alloc(shared ? 164 : 132);
   profile.writeUInt32BE(profile.length, 0);
@@ -568,6 +583,26 @@ async function main() {
     });
     assert.equal(manifest.source.orientation, null);
     assert.equal(manifest.artifacts[0].width, 320);
+  });
+
+  await withTempParent(async (parent) => {
+    const inputPath = path.join(parent, 'post-scan-orientation.jpg');
+    const outputDir = path.join(parent, 'post-scan-orientation-output');
+    await writePostScanExifFixture(inputPath);
+    assert.equal(inspectFile(inputPath).orientationKnown, false);
+    await assertRejected(
+      () => compileImage({
+        inputPath,
+        outputDir,
+        policy: { widths: [320], formats: ['webp'], placeholder: false },
+      }),
+      (error) => {
+        assert.equal(error.name, 'ArtifactCompilationError');
+        assert.equal(error.phase, 'preflight');
+        assert.equal(error.errorCode, 'E130');
+      },
+    );
+    assert.equal(await fsp.stat(outputDir).catch(() => null), null);
   });
 
   await withTempParent(async (parent) => {

--- a/test/integration/artifact-compiler.test.js
+++ b/test/integration/artifact-compiler.test.js
@@ -129,6 +129,16 @@ async function writePostScanExifFixture(outputPath) {
   ]));
 }
 
+async function writeLateExifFixture(outputPath) {
+  const jpeg = await fsp.readFile(resolveFixture('test_with_exif.jpg'));
+  const malformedSegment = Buffer.from('ffe1000a4578696600000000', 'hex');
+  await fsp.writeFile(outputPath, Buffer.concat([
+    jpeg.subarray(0, jpeg.length - 2),
+    malformedSegment,
+    jpeg.subarray(jpeg.length - 2),
+  ]));
+}
+
 function makeIccProfile(shared) {
   const profile = Buffer.alloc(shared ? 164 : 132);
   profile.writeUInt32BE(profile.length, 0);
@@ -590,6 +600,28 @@ async function main() {
     const outputDir = path.join(parent, 'post-scan-orientation-output');
     await writePostScanExifFixture(inputPath);
     assert.equal(inspectFile(inputPath).orientationKnown, false);
+    await assertRejected(
+      () => compileImage({
+        inputPath,
+        outputDir,
+        policy: { widths: [320], formats: ['webp'], placeholder: false },
+      }),
+      (error) => {
+        assert.equal(error.name, 'ArtifactCompilationError');
+        assert.equal(error.phase, 'preflight');
+        assert.equal(error.errorCode, 'E130');
+      },
+    );
+    assert.equal(await fsp.stat(outputDir).catch(() => null), null);
+  });
+
+  await withTempParent(async (parent) => {
+    const inputPath = path.join(parent, 'late-malformed-exif.jpg');
+    const outputDir = path.join(parent, 'late-malformed-exif-output');
+    await writeLateExifFixture(inputPath);
+    const metadata = inspectFile(inputPath);
+    assert.equal(metadata.orientationKnown, true);
+    assert.equal(metadata.orientation, 6);
     await assertRejected(
       () => compileImage({
         inputPath,

--- a/test/integration/inspect-preflight.test.js
+++ b/test/integration/inspect-preflight.test.js
@@ -27,6 +27,7 @@ assert.deepEqual(jpegMetadata, {
     format: 'jpeg',
     hasAlpha: false,
     isAnimated: false,
+    orientationKnown: true,
     orientation: 6,
 });
 assertParity(jpeg, 'inspect-preflight/oriented.jpg');


### PR DESCRIPTION
## Summary

- Distinguish valid Orientation, confirmed absence, and unparseable/over-budget EXIF during bounded native preflight.
- Expose `orientationKnown` through `inspect()` / `inspectFile()` and reject unknown orientation fail-closed in artifact compilation.
- Accept valid EXIF with an empty Orientation IFD while retaining complete-container verification for truncated inputs.

Closes #829

## Verification

- `npm run build`
- `npm test`
- `npm run test:rust`
- `node test/integration/artifact-compiler.test.js`

All passed.