### PR TITLE
docs: sync v1.3.0 release scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+> Target: v1.3.0. The release baseline includes #827, #828, and #829; #830
+> and #769 remain release gates. The #696 CLI is deferred until the evidence
+> gate is complete. See [VERSIONING_PLAN.md](docs/VERSIONING_PLAN.md).
+
+### Fixed
+- Hardened `compileImage()` verification for transparent AVIF artifacts.
+- Distinguished absent EXIF Orientation from unparseable or over-budget input
+  during upload preflight while retaining fail-closed behavior.
+
+### Performance
+- Replaced byte-at-a-time JPEG container verification I/O with bounded-buffer
+  reads while preserving complete scan validation and cleanup guarantees.
+
 ---
 
 ## [1.2.0] - 2026-09-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-> Target: v1.3.0. The release baseline includes #827, #828, and #829; #830
-> and #769 remain release gates. The #696 CLI is deferred until the evidence
-> gate is complete. See [VERSIONING_PLAN.md](docs/VERSIONING_PLAN.md).
+> Target: v1.3.0. The release baseline includes #827, #828, #829, and the
+> already-aligned benchmark claims in #830; #769 remains the release gate. The
+> #696 CLI is deferred until the evidence gate is complete. See
+> [VERSIONING_PLAN.md](docs/VERSIONING_PLAN.md).
 
 ### Fixed
 - Hardened `compileImage()` verification for transparent AVIF artifacts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-> Target: v1.3.0. The release baseline includes #827, #828, #829, and the
-> already-aligned benchmark claims in #830; #769 remains the release gate. The
+> Target: v1.3.0. The release baseline includes #827, #828, and #829;
+> #830 and #769 remain release gates. The
 > #696 CLI is deferred until the evidence gate is complete. See
 > [VERSIONING_PLAN.md](docs/VERSIONING_PLAN.md).
 

--- a/docs/VERSIONING_PLAN.md
+++ b/docs/VERSIONING_PLAN.md
@@ -18,6 +18,32 @@ The responsive and placeholder helpers are additive Node.js APIs. They reuse
 the existing lazy pipeline and do not change the native ABI or the
 privacy-safe `compileImage()` contract.
 
+### v1.3.0 planned scope (#703)
+
+v1.3.0 is a backward-compatible release focused on closing the remaining
+artifact-compiler evidence gap. The following compiler hardening is already on
+`main` and is part of the release baseline:
+
+- #827: transparent AVIF artifact verification
+- #828: bounded-buffer JPEG container verification
+- #829: distinction between absent and unparseable EXIF Orientation
+
+The remaining release gates are:
+
+- #830: align the benchmark explanation with the canonical historical numbers
+- #769: record real-image, perceptual-quality, budget, memory, and E2E compiler
+  evidence, including the #827/#828/#829 regression cases
+
+#696 (the thin `compileImage()` CLI) stays outside v1.3.0 until #769 is
+complete. It adds a public filesystem entrypoint and needs its own API,
+packaging, and security review; bundling it now would make the release scope
+larger without closing the evidence gate.
+
+v1.3.0 is release-ready only after #830 and #769 are resolved, the resulting
+claims are synchronized, and the published native/Wasm package smoke evidence
+is recorded. Merged implementation and published-package evidence remain
+separate release claims.
+
 ### P1
 
 - 長時間稼働と NAPI 境界を含むリーク検知の強化
@@ -49,10 +75,9 @@ privacy-safe `compileImage()` contract.
 - `toBufferWithMetrics()` などの既存 output convenience API は v1.x では
   維持し、削除は v2.0.0 でのみ検討する。v1 より前に削除済みの metrics
   aliases は v1.x の公開契約に含めない。
-- #703（artifact compiler）はv1.2.0で#697/#698の完了を追跡する。#696（CLI）と
-  #769（実画像 benchmark evidence）は後続リリースで扱い、v1.2.0のblockerには
-  しない。
+- #703（artifact compiler）はv1.3.0で#827/#828/#829の完了を含め、#830と#769を
+  release gateとして追跡する。#696（CLI）は#769後の後続リリースで扱う。
 - #645（Wasm runtime expansion）と#88（Web Streams）はv2.0以降の計画であり、
-  v1.2.0には含めない。
+  v1.3.0にも含めない。
 
 詳細な中長期方針は [ROADMAP.md](./ROADMAP.md) を参照してください。

--- a/docs/VERSIONING_PLAN.md
+++ b/docs/VERSIONING_PLAN.md
@@ -27,11 +27,11 @@ artifact-compiler evidence gap. The following compiler hardening is already on
 - #827: transparent AVIF artifact verification
 - #828: bounded-buffer JPEG container verification
 - #829: distinction between absent and unparseable EXIF Orientation
-- #830: benchmark claims are already aligned with the canonical historical
-  numbers and measurement context; the tracker is reconciled as complete
 
-The remaining release gate is:
+The remaining release gates are:
 
+- #830: align benchmark explanations with the canonical historical numbers
+  and measurement context
 - #769: record real-image, perceptual-quality, budget, memory, and E2E compiler
   evidence, including the #827/#828/#829 regression cases
 
@@ -40,10 +40,11 @@ complete. It adds a public filesystem entrypoint and needs its own API,
 packaging, and security review; bundling it now would make the release scope
 larger without closing the evidence gate.
 
-v1.3.0 is release-ready only after #769 is resolved, the resulting claims are
-synchronized, and the published native/Wasm package smoke evidence is
-recorded. Merged implementation and published-package evidence remain
-separate release claims.
+v1.3.0 is release-ready after #830 and #769 are resolved, the resulting claims
+are synchronized, and pre-publication pack/install smoke checks pass for the
+release artifacts. After publication, verify the published native/platform and
+Wasm packages and record their smoke evidence as post-release verification
+according to [RELEASE.md](./RELEASE.md).
 
 ### P1
 
@@ -76,7 +77,7 @@ separate release claims.
 - `toBufferWithMetrics()` などの既存 output convenience API は v1.x では
   維持し、削除は v2.0.0 でのみ検討する。v1 より前に削除済みの metrics
   aliases は v1.x の公開契約に含めない。
-- #703（artifact compiler）はv1.3.0で#827/#828/#829/#830の完了を含め、#769を
+- #703（artifact compiler）はv1.3.0で#827/#828/#829の完了を含め、#830と#769を
   release gateとして追跡する。#696（CLI）は#769後の後続リリースで扱う。
 - #645（Wasm runtime expansion）と#88（Web Streams）はv2.0以降の計画であり、
   v1.3.0にも含めない。

--- a/docs/VERSIONING_PLAN.md
+++ b/docs/VERSIONING_PLAN.md
@@ -27,10 +27,11 @@ artifact-compiler evidence gap. The following compiler hardening is already on
 - #827: transparent AVIF artifact verification
 - #828: bounded-buffer JPEG container verification
 - #829: distinction between absent and unparseable EXIF Orientation
+- #830: benchmark claims are already aligned with the canonical historical
+  numbers and measurement context; the tracker is reconciled as complete
 
-The remaining release gates are:
+The remaining release gate is:
 
-- #830: align the benchmark explanation with the canonical historical numbers
 - #769: record real-image, perceptual-quality, budget, memory, and E2E compiler
   evidence, including the #827/#828/#829 regression cases
 
@@ -39,9 +40,9 @@ complete. It adds a public filesystem entrypoint and needs its own API,
 packaging, and security review; bundling it now would make the release scope
 larger without closing the evidence gate.
 
-v1.3.0 is release-ready only after #830 and #769 are resolved, the resulting
-claims are synchronized, and the published native/Wasm package smoke evidence
-is recorded. Merged implementation and published-package evidence remain
+v1.3.0 is release-ready only after #769 is resolved, the resulting claims are
+synchronized, and the published native/Wasm package smoke evidence is
+recorded. Merged implementation and published-package evidence remain
 separate release claims.
 
 ### P1
@@ -75,7 +76,7 @@ separate release claims.
 - `toBufferWithMetrics()` などの既存 output convenience API は v1.x では
   維持し、削除は v2.0.0 でのみ検討する。v1 より前に削除済みの metrics
   aliases は v1.x の公開契約に含めない。
-- #703（artifact compiler）はv1.3.0で#827/#828/#829の完了を含め、#830と#769を
+- #703（artifact compiler）はv1.3.0で#827/#828/#829/#830の完了を含め、#769を
   release gateとして追跡する。#696（CLI）は#769後の後続リリースで扱う。
 - #645（Wasm runtime expansion）と#88（Web Streams）はv2.0以降の計画であり、
   v1.3.0にも含めない。


### PR DESCRIPTION
## 変更内容

#703に残っていた完了状態と次期リリース範囲を同期します。マージ済みの#827/#828/#829をCHANGELOGへ記録し、未完了の#830と#769をv1.3.0のゲート、#696 CLIを後続に位置付けます。

公開前はrelease artifactsのpack/install smoke、公開後は公開native/platform・Wasm packageのsmokeを確認する順序に修正しました。#830の誤った完了判定を撤回し、Issueを再オープンします。

## 検証

- git diff --check
- node scripts/check-release-policy.js 1.3.0
- npm run test:release-policy

文書のみ。build・全test・benchmark・公開package smokeは未実行。

Related: #703
