### PR TITLE
docs: align JPEG performance claims with canonical baseline (#830)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -25,7 +25,7 @@ console.log(`Wrote ${bytesWritten} bytes`);
 
 **差分が出る主要点**
 
-- JPEG サイズは同じ encoder quality 設定の canonical な PNG→JPEG 2ケースで 17-20% 小さい。resize ケースは source-reference 品質下限を通過しますが、完全な知覚品質一致を意味しません
+- JPEG サイズは、[過去baseline](./docs/TRUE_BENCHMARKS.md)（2026-07-17、macOS 26.3 / Apple M4 (arm64)、Node.js v24.2.0、lazy-image v0.16.0、sharp v0.34.5）のcanonicalなPNG→JPEG 2ケースで、同じencoder quality設定では17-20%小さい。resizeケースはsource-reference品質下限を通過しますが、完全な知覚品質一致を意味しません
 - 256MB を超える大きな入力は Rust 側バッファへ全量読み込まず、メモリ安全な mmap 経路で処理します。`fromPath()` を使う際は、同時に対象ファイルの変更・切り詰め・削除を避け、破損や `SIGBUS` / `SIGSEGV` を防いでください。
 - `fromPath()` は256MB以下のsourceを呼び出しthreadで同期readします。HTTP/serverless経路では `await ImageEngine.fromPathAsync(path)` を使い、source setupをNode.js event loop外へ移してください。
 - メタデータは既定で安全寄り（GPS は既定で除去、`keepMetadata()` で制御）

--- a/docs/BENCHMARK_CLAIMS.md
+++ b/docs/BENCHMARK_CLAIMS.md
@@ -6,6 +6,10 @@ This document maps every public performance claim to its canonical source, class
 
 **[TRUE_BENCHMARKS.md](./TRUE_BENCHMARKS.md)** is the single source of truth for all public performance claims.
 
+The cited values are a historical baseline recorded on 2026-07-17 with
+lazy-image v0.16.0, Node.js v24.2.0, sharp v0.34.5, and macOS 26.3 on an
+Apple M4 (arm64); they are not current v1.2.0 measurements.
+
 All numbers in README.md, PERFORMANCE.md, MIGRATION_FROM_SHARP.md, and ROI_CALCULATOR.md must be traceable to a specific scenario in TRUE_BENCHMARKS.md.
 
 **Why a single source?** Multiple docs quoting independently-measured numbers inevitably diverge. By requiring every public claim to trace back to TRUE_BENCHMARKS.md, updates flow in one direction and inconsistencies surface as missing cross-references rather than contradictory numbers.
@@ -30,8 +34,8 @@ These **must always include the codec, input format, and scenario** when quoted:
 |-------|----------|----------------|----------------------|
 | "17.0% smaller JPEG output" | PERFORMANCE.md, TRUE_BENCHMARKS.md | PNG -> JPEG (no resize, 5000×5000) | Must cite format + input size |
 | "20.0% smaller JPEG output" | PERFORMANCE.md, TRUE_BENCHMARKS.md | PNG -> JPEG (resize 800px, 5000×5000 input) | Must cite format + resize context |
-| "AVIF is slower and larger in current canonical PNG -> AVIF benchmarks" | PERFORMANCE.md, TRUE_BENCHMARKS.md | PNG -> AVIF no-resize and resize 800px | Must cite exact scenario; do not turn into a universal AVIF claim |
-| "WebP is slower and similar/larger in current canonical PNG -> WebP benchmarks" | PERFORMANCE.md, TRUE_BENCHMARKS.md | PNG -> WebP no-resize and resize 800px | Must cite exact scenario; do not turn into a universal WebP claim |
+| "AVIF is slower and larger in recorded canonical PNG -> AVIF benchmarks" | PERFORMANCE.md, TRUE_BENCHMARKS.md | PNG -> AVIF no-resize and resize 800px | Must cite exact scenario; do not turn into a universal AVIF claim |
+| "WebP is slower and similar/larger in recorded canonical PNG -> WebP benchmarks" | PERFORMANCE.md, TRUE_BENCHMARKS.md | PNG -> WebP no-resize and resize 800px | Must cite exact scenario; do not turn into a universal WebP claim |
 
 **Rule of thumb:** If removing the scenario context would mislead a reader into thinking the claim is universal, it is workload-specific.
 
@@ -39,7 +43,7 @@ These **must always include the codec, input format, and scenario** when quoted:
 
 1. **Always qualify codec and workload.** Never say "lazy-image is faster than sharp" without specifying the format and scenario.
 2. **"17-20% smaller JPEG" is a qualified summary claim.** It applies only at the same encoder quality setting in the two canonical PNG -> JPEG scenarios. The resize result must retain its source-reference SSIM/PSNR context; it is not an exact perceptual-quality-match claim.
-3. **Speed claims are workload-specific.** Current JPEG resize was faster, JPEG no-resize was slightly slower, and AVIF/WebP favored sharp in the measured scenarios. Always cite the specific scenario.
+3. **Speed claims are workload-specific.** In the recorded baseline, JPEG no-resize was slightly faster for lazy-image (712ms vs 765ms), while JPEG resize 800px was faster for sharp (114ms vs 78ms); AVIF/WebP favored sharp in their listed scenarios. Do not turn these timings into codec-wide or general speed claims.
 4. **Do not mix resize and no-resize numbers.** Results differ significantly when resize is involved.
 5. **Cite the test environment.** TRUE_BENCHMARKS.md specifies the machine, Node version, and library versions used.
 
@@ -116,4 +120,4 @@ When TRUE_BENCHMARKS.md is updated, also check:
 
 The `*Last updated:*` footer at the bottom of TRUE_BENCHMARKS.md records the lazy-image and sharp versions used. When either dependency updates significantly, re-run benchmarks and update all downstream claims.
 
-Current: lazy-image v0.16.0, Node.js v24.2.0, sharp v0.34.5 (benchmarked 2026-07-17)
+Historical baseline: lazy-image v0.16.0, Node.js v24.2.0, sharp v0.34.5, macOS 26.3 / Apple M4 (arm64) (benchmarked 2026-07-17; not current v1.2.0)

--- a/docs/MIGRATION_FROM_SHARP.md
+++ b/docs/MIGRATION_FROM_SHARP.md
@@ -57,9 +57,9 @@ const output = await ImageEngine.from(input)
 ```
 
 ## Performance Comparison (when to switch)
-- JPEG: in the canonical `PNG -> JPEG` benchmarks, lazy-image produces **17.0% smaller** output for no-resize conversion and **20.0% smaller** output for resize-to-800px. Encoding speed depends on workload and settings.
-- AVIF: in the current canonical `PNG -> AVIF` benchmarks, sharp is faster and produces smaller output. Use lazy-image AVIF when you need its output path, metadata behavior, and safety defaults; benchmark before switching for size/speed.
-- WebP: use if you want the safer defaults and metadata stripping, but expect sharp to remain faster in many throughput-sensitive workloads.
+- JPEG: in the historical canonical `PNG -> JPEG` baseline recorded in [TRUE_BENCHMARKS.md](./TRUE_BENCHMARKS.md), lazy-image produced **17.0% smaller** output for no-resize conversion and **20.0% smaller** output for resize-to-800px at the same encoder quality setting. This is not a current v1.2.0 measurement or an exact perceptual-quality-match claim; encoding speed depends on workload and settings.
+- AVIF: in the recorded canonical `PNG -> AVIF` baseline, sharp was faster and produced smaller output. Use lazy-image AVIF when you need its output path, metadata behavior, and safety defaults; benchmark before switching for size/speed.
+- WebP: in the recorded canonical scenarios, sharp was faster; benchmark the target workload rather than assuming a universal speed advantage.
 - Latency-sensitive or filter-heavy workloads still favor sharp; build-time optimization and batch processing favor lazy-image.
 
 ## FAQ

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -6,6 +6,11 @@ lazy-image is optimized for **JPEG output size and memory safety** rather than r
 
 The canonical benchmark dataset for public performance claims is [TRUE_BENCHMARKS.md](./TRUE_BENCHMARKS.md).
 
+> **Historical baseline, not a current v1.2.0 measurement:** The values below
+> were recorded on 2026-07-17 with lazy-image v0.16.0, Node.js v24.2.0,
+> sharp v0.34.5, and macOS 26.3 on an Apple M4 (arm64). Timings are specific
+> to these scenarios and should be remeasured for the target workload.
+
 All summary claims in README and migration docs should be derived from that document's exact scenarios rather than mixing numbers from different workloads.
 
 For the full inventory of public claims and quoting rules, see [BENCHMARK_CLAIMS.md](./BENCHMARK_CLAIMS.md).
@@ -15,14 +20,15 @@ For the full inventory of public claims and quoting rules, see [BENCHMARK_CLAIMS
 | Scenario | Metric | lazy-image | sharp | Interpretation |
 |---------|--------|------------|-------|----------------|
 | PNG → JPEG (no resize, 5000×5000) | Output size | **1,224,894 bytes** | 1,475,223 bytes | lazy-image output is **17.0% smaller** |
+| PNG → JPEG (no resize, 5000×5000) | Encode time | **712ms** | 765ms | lazy-image was **1.07x faster** in this run |
 | PNG → JPEG (resize 800px, 5000×5000 input) | Output size | **31,518 bytes** | 39,416 bytes | lazy-image output is **20.0% smaller** |
 | PNG → JPEG (resize 800px, 5000×5000 input) | Encode time | 114ms | **78ms** | sharp was faster in this run |
 | PNG → AVIF (no resize, 5000×5000) | Encode time | 13,440ms | **5,849ms** | sharp is faster for this workload |
 | PNG → AVIF (no resize, 5000×5000) | Output size | 1,718,430 bytes | **1,290,501 bytes** | sharp output is smaller for this workload |
 | PNG → WebP (no resize, 5000×5000) | Encode time | 4,379ms | **964ms** | sharp is much faster for this workload |
+| JPEG/WebP real-time resize workloads | Latency | scenario-dependent | scenario-dependent | no general speed winner; benchmark the target codec and image mix |
 
 The JPEG size comparison uses the same encoder quality setting. In the resize case, lazy-image measured SSIM 0.9942 / PSNR 37.07 dB against the resized source reference versus sharp at 0.9955 / 37.65 dB; this is not an exact perceptual-quality-match claim.
-| JPEG/WebP real-time resize workloads | Latency | varies by codec and settings | often faster | use sharp if sub-100ms latency is the main priority |
 
 Full data: [TRUE_BENCHMARKS.md](./TRUE_BENCHMARKS.md).
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -46,7 +46,7 @@ Full data: [TRUE_BENCHMARKS.md](./TRUE_BENCHMARKS.md).
 
 - **Heavy persistent servers** — Plenty of RAM and CPU.
 - **Throughput-critical** — Thousands of JPEG/WebP resizes per second.
-- **AVIF/WebP speed or size is decisive** — Current canonical AVIF/WebP benchmarks favor sharp for speed, and often for output size.
+- **AVIF/WebP speed or size is decisive** — The recorded historical canonical AVIF/WebP baseline favored sharp for speed, and often for output size.
 
 ## Philosophy
 

--- a/docs/TRUE_BENCHMARKS.md
+++ b/docs/TRUE_BENCHMARKS.md
@@ -2,6 +2,11 @@
 
 This document is the **canonical benchmark source** for public performance claims in lazy-image documentation.
 
+The values below are a historical baseline recorded on 2026-07-17 with
+lazy-image v0.16.0, Node.js v24.2.0, sharp v0.34.5, and macOS 26.3 on an
+Apple M4 (arm64). They remain the canonical reference for these documented
+claims, but are not current v1.2.0 measurements.
+
 Use this file when citing benchmark numbers in:
 
 - `README.md`
@@ -13,7 +18,7 @@ Do not mix numbers from different workloads without clearly labeling the scenari
 This document provides comprehensive benchmark documentation showing the actual performance characteristics of lazy-image, with a focus on:
 
 - **JPEG file size advantages** in benchmarked web-delivery scenarios
-- **AVIF/WebP trade-offs** where current sharp results are often faster or smaller
+- **AVIF/WebP trade-offs** where sharp was often faster or smaller in the recorded baseline
 - **Copy and memory semantics** that distinguish V8-heap avoidance from codec working buffers
 
 ## Test Environment
@@ -47,9 +52,11 @@ npm run test:bench:extended
 
 ---
 
-## AVIF Current Trade-offs
+## AVIF Trade-offs in the Historical Baseline
 
-In the current benchmarked PNG → AVIF scenarios below, sharp is faster and produces smaller AVIF output. Do not quote AVIF as a blanket speed or size win for lazy-image.
+In the recorded PNG → AVIF scenarios below, sharp was faster and produced
+smaller AVIF output. Do not quote AVIF as a blanket speed or size win for
+lazy-image.
 
 ### Performance Results
 
@@ -103,7 +110,8 @@ const avifBuffer = await ImageEngine.fromPath('test/fixtures/test_4.5MB_5000x500
 
 ## JPEG File Size Advantages (mozjpeg Optimization)
 
-lazy-image produces significantly smaller JPEG files than sharp, thanks to mozjpeg's advanced optimization techniques.
+In this historical baseline, lazy-image produced significantly smaller JPEG
+files than sharp, thanks to mozjpeg's advanced optimization techniques.
 
 ### Performance Results
 
@@ -193,7 +201,7 @@ const jpegBuffer = await ImageEngine.fromPath('test/fixtures/test_4.5MB_5000x500
   .resize(800, null)
   .toBuffer('jpeg', 80); // Quality 80, mozjpeg optimization
 
-// Result in simple canonical JPEG benchmarks: 17-20% smaller than sharp at the same quality setting
+// Result in the historical canonical JPEG baseline: 17-20% smaller than sharp at the same quality setting
 ```
 
 ---
@@ -202,7 +210,9 @@ const jpegBuffer = await ImageEngine.fromPath('test/fixtures/test_4.5MB_5000x500
 
 ### Format Conversion Efficiency (No Resize)
 
-When converting formats without resizing, current results are codec-specific. CoW avoids unnecessary pipeline materialization, but encoders still allocate codec working buffers.
+When converting formats without resizing, the recorded results are
+codec-specific. CoW avoids unnecessary pipeline materialization, but encoders
+still allocate codec working buffers.
 
 | Conversion | lazy-image | sharp | Speed | File Size |
 |------------|------------|-------|-------|-----------|
@@ -242,12 +252,15 @@ See [ZERO_COPY.md](./ZERO_COPY.md) for the precise scope and validation method.
 
 ```
 JPEG: 17-20% smaller files in simple PNG -> JPEG no-resize and resize-800px scenarios
-AVIF: current PNG -> AVIF benchmarks are slower and larger than sharp
-WebP: current PNG -> WebP benchmarks are slower and similar/larger than sharp
+AVIF: recorded PNG -> AVIF benchmarks were slower and larger than sharp
+WebP: recorded PNG -> WebP benchmarks were slower and similar/larger than sharp
 Memory: fromPath avoids V8-heap input copies; codec working buffers still exist
 ```
 
-**Summary**: lazy-image's current public size advantage is strongest for **JPEG compression efficiency** in the benchmarked delivery-oriented scenarios. AVIF and WebP must be treated as workload-specific trade-offs, not blanket wins over sharp.
+**Summary**: The documented baseline's size advantage is strongest for **JPEG
+compression efficiency** in the benchmarked delivery-oriented scenarios.
+AVIF and WebP must be treated as workload-specific trade-offs, not blanket
+wins over sharp.
 
 ---
 
@@ -299,8 +312,8 @@ For ongoing CI/threshold operation rules, see [docs/BENCHMARK_OPERATIONS.md](./B
 
 ### Performance Trade-offs
 
-- **JPEG encoding speed**: lazy-image prioritizes compression ratio and produced 17-20% smaller JPEG outputs in the two simple current benchmarked PNG -> JPEG scenarios. Speed was comparable in these runs and should be remeasured on target hardware.
-- **AVIF/WebP encoding speed and size**: current PNG -> AVIF and PNG -> WebP benchmarks favor sharp for speed, and often for output size.
+- **JPEG encoding speed**: lazy-image prioritizes compression ratio and produced 17-20% smaller JPEG outputs in the two simple historical baseline PNG -> JPEG scenarios. The no-resize run was slightly faster for lazy-image (712ms vs 765ms); the resize-800px run was faster for sharp (114ms vs 78ms). These are workload-specific baseline timings, not a general speed claim.
+- **AVIF/WebP encoding speed and size**: the recorded PNG -> AVIF and PNG -> WebP benchmarks favored sharp for speed, and often for output size.
 - **Real-time processing**: For strict latency requirements (<100ms), benchmark the target codec and image mix before choosing lazy-image.
 
 ### Test Environment Variations
@@ -320,7 +333,7 @@ These benchmarks are for reference only and should be validated in your specific
 
 lazy-image provides significant advantages in:
 
-1. **JPEG file size**: 17-20% smaller files through mozjpeg optimization in the two simple canonical PNG -> JPEG scenarios
+1. **JPEG file size**: 17-20% smaller files through mozjpeg optimization in the two simple historical baseline PNG -> JPEG scenarios
 2. **Memory efficiency**: `fromPath()` avoids V8-heap input copies and keeps decoded pixels in Rust memory
 3. **Operational safety**: metadata stripping, Image Firewall, structured errors, and panic guards
 4. **Build-time optimization**: Ideal for static site generation and CI/CD pipelines
@@ -334,9 +347,9 @@ Choose lazy-image when:
 Choose sharp when:
 - Real-time processing with strict latency requirements (<100ms)
 - Maximum throughput is needed (high-volume processing)
-- AVIF/WebP speed or size is the primary decision criterion in the current benchmarked scenarios
+- AVIF/WebP speed or size is the primary decision criterion in the recorded benchmark scenarios
 - Complex operations are needed (advanced filters, color space conversions)
 
 ---
 
-*Last updated: 2026-07-17, based on lazy-image v0.16.0, Node.js v24.2.0, and sharp v0.34.5. Re-run `npm run test:bench`, `node --expose-gc test/benchmarks/convert-only.bench.js`, and `npm run test:bench:extended` when encoder dependencies or public claims change.*
+*Historical baseline recorded 2026-07-17 on macOS 26.3 / Apple M4 (arm64), based on lazy-image v0.16.0, Node.js v24.2.0, and sharp v0.34.5. Re-run the benchmarks when encoder dependencies or public claims change.*


### PR DESCRIPTION
Closes #830

## Summary
- Correct JPEG speed wording to match the canonical baseline: no-resize lazy-image 712ms vs sharp 765ms; resize 800px lazy-image 114ms vs sharp 78ms.
- Mark the cited values as the historical lazy-image v0.16.0 / Node.js v24.2.0 / sharp 0.34.5 baseline on macOS 26.3 Apple M4 (arm64), not current v1.2.0 measurements.
- Keep the same-quality, source-reference, scenario-specific, and non-universal-speed constraints explicit across public explanations.

## Validation
- `git diff --check`
- Benchmark and test suites were not run per request; no new measurements were taken.