### PR TITLE
test: fix Windows alpha artifact cleanup EBUSY

### DIFF
--- a/test/integration/artifact-compiler-alpha.test.js
+++ b/test/integration/artifact-compiler-alpha.test.js
@@ -21,7 +21,9 @@ async function main() {
         policy: { widths: [32], formats: ['webp', 'avif'], placeholder: false } });
       assert.equal(manifest.artifacts.length, 2);
       for (const artifact of manifest.artifacts) {
-        const { data, info } = await sharp(path.join(outputDir, artifact.path)).raw().toBuffer({ resolveWithObject: true })
+        // Buffer input prevents libvips from retaining file handles that block Windows cleanup.
+        const encoded = await fs.readFile(path.join(outputDir, artifact.path));
+        const { data, info } = await sharp(encoded).raw().toBuffer({ resolveWithObject: true })
           .catch((error) => { throw new Error(`${format}/${alpha}/${icc}/${artifact.format}: ${error.message}`); });
         assert.equal(info.channels, alpha === 255 ? 3 : 4);
         assert.equal(artifact.iccOutcome, icc ? 'preserved' : 'absent');


### PR DESCRIPTION
## 背景
main CI 34310979347 のWindows Node 22/24が、alpha契約テストの終了時に output-png-0-false/image-32.webp の削除でEBUSYとなりました。直前mainの34310373752でも同じ失敗があり、PR #840による新規回帰ではありません。

## 変更と判断理由
Sharpにファイルパスを直接渡さず、fs.readFileで読み込んだBufferを渡します。libvipsが一時ファイルのハンドルを保持する経路をなくします。既存のデコード、透明度、ICC outcome、AVIF破損拒否のassertionとcleanup失敗時のエラーは維持します。retry、エラー無視、グローバルキャッシュ設定変更は追加しません。変更はテスト1ファイルのみで本体コード・依存・workflowは不変です。

## 検証
- node test/integration/artifact-compiler-alpha.test.js: 成功（macOS）
- git diff --check: 成功
- 読み取りStop Review Gate（gpt-5.6-luna medium）: ALLOW

## 残る確認
Windows Node 22/24での修正後実行はまだ未確認です。PRのUbuntuチェックだけではWindows固有の解消証拠にならないため、既存CI workflowをこのブランチで実行して確認します。

失敗run: https://github.com/albert-einshutoin/lazy-image/actions/runs/34310979347