### PR TITLE
fix: keep corpus license checksum stable on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+LICENSE text eol=lf


### PR DESCRIPTION
## Summary

- Pin the tracked benchmark corpus license to LF checkout line endings.
- Keep the byte-level MIT license checksum stable on Windows runners.

The post-merge `main` CI exposed that Windows line-ending conversion changed the bytes read by the corpus manifest verifier. No runtime or benchmark logic changes are included.

## Validation

- `git check-attr text eol -- LICENSE`
- `node test/integration/benchmark-corpus-manifest.test.js` (5 passed)
- `npm run test:bench:compile-image` (3/3 accepted)

Follow-up to #841 / Issue #769.
